### PR TITLE
fix: use visible taskbar area for vertical centering on high-DPI displays

### DIFF
--- a/src/netspeedtray/views/widget/layout.py
+++ b/src/netspeedtray/views/widget/layout.py
@@ -173,8 +173,19 @@ class WidgetLayoutManager:
                                         max_number_width + unit_gap +
                                         max_unit_width + margin)
                 
-                # Height is the full taskbar height for horizontal docking
-                calculated_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
+                # Height: use visible taskbar area (availableGeometry), not Shell_TrayWnd
+                # which can include invisible padding on high-DPI Windows 11 displays.
+                screen_obj = taskbar_info.get_screen()
+                if screen_obj:
+                    avail = screen_obj.availableGeometry()
+                    full = screen_obj.geometry()
+                    visible_height = full.height() - avail.height()
+                    if visible_height > 0:
+                        calculated_height = visible_height
+                    else:
+                        calculated_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
+                else:
+                    calculated_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
 
             else:
                 # --- VERTICAL TASKBAR (LEFT/RIGHT) ---


### PR DESCRIPTION
## Problem

On Windows 11 with fractional/high DPI scaling (e.g., 2.0x), `Shell_TrayWnd` includes invisible padding above the visible taskbar area. This causes the widget to appear vertically misaligned — shifted upward relative to the visible taskbar.

## Root Cause

The positioning code uses `Shell_TrayWnd`'s physical rect (converted to logical) for centering. On high-DPI Windows 11, this rect includes ~24px of invisible padding above the actual visible taskbar, so centering within it places the widget too high.

## Fix

Use `screen.availableGeometry()` to determine the actual visible taskbar boundaries:
- **Bottom taskbar**: visible top = `availableGeometry().bottom() + 1`, visible bottom = `geometry().bottom() + 1`
- **Top taskbar**: visible top = `geometry().top()`, visible bottom = `availableGeometry().top()`

This is applied in three places:
1. **`position_manager.py` — `_calculate_horizontal_position()`**: Y centering uses visible area
2. **`position_manager.py` — `constrain_drag_position()`**: Drag constraint uses visible area
3. **`layout.py` — widget height calculation**: Sizes widget to visible taskbar height

Falls back to the original `Shell_TrayWnd` rect if no screen is available or for vertical taskbars.

## Replaces

This replaces #109 which was against an older codebase.

## Testing

Tested on Windows 11 with 1440x900 display at 2.0x DPI scaling.