### PR TITLE
Fix window moving off-screen issue by enforcing screen bounds

### DIFF
--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -417,6 +417,8 @@ class PositionManager(QObject):
         # Timers
         self._tray_watcher_timer = QTimer(self)
         self._tray_watcher_timer.timeout.connect(self._check_for_tray_changes)
+        self._window_bounds_timer = QTimer(self)
+        self._window_bounds_timer.timeout.connect(self._enforce_window_bounds)
         
         logger.debug("Core PositionManager initialized.")
 
@@ -424,12 +426,65 @@ class PositionManager(QObject):
         """Starts the periodic tray watcher."""
         if not self._tray_watcher_timer.isActive():
             self._tray_watcher_timer.start(10000) # Check every 10s
+        if not self._window_bounds_timer.isActive():
+            # Keep the widget reachable even if external factors move it off-screen.
+            self._window_bounds_timer.start(500)
             logger.debug("PositionManager monitoring started.")
 
     def stop_monitoring(self) -> None:
         """Stops the periodic tray watcher."""
         self._tray_watcher_timer.stop()
+        self._window_bounds_timer.stop()
         logger.debug("PositionManager monitoring stopped.")
+
+    def _get_clamped_window_position(self) -> Optional[ScreenPosition]:
+        """Returns a clamped on-screen position for the current widget geometry."""
+        widget_width = self._state.widget.width()
+        widget_height = self._state.widget.height()
+        if widget_width <= 0 or widget_height <= 0:
+            return None
+
+        current_pos = self._state.widget.pos()
+        current_rect = QRect(current_pos.x(), current_pos.y(), widget_width, widget_height)
+        screen = ScreenUtils.find_screen_for_rect(current_rect)
+        if not screen:
+            screen = QApplication.primaryScreen()
+        if not screen:
+            return None
+
+        validated = ScreenUtils.validate_position(
+            current_pos.x(),
+            current_pos.y(),
+            (widget_width, widget_height),
+            screen,
+        )
+
+        # Keep the title bar reachable on Windows even if monitor coordinates are odd.
+        return ScreenPosition(validated.x, max(0, validated.y))
+
+    @pyqtSlot()
+    def _enforce_window_bounds(self) -> None:
+        """Continuously ensures the widget stays on-screen and reachable."""
+        if not self._state.widget.isVisible():
+            return
+        is_dragging = getattr(self._state.widget, "_dragging", False)
+        if isinstance(is_dragging, bool) and is_dragging:
+            return
+
+        clamped = self._get_clamped_window_position()
+        if not clamped:
+            return
+
+        current_pos = self._state.widget.pos()
+        if current_pos.x() != clamped.x or current_pos.y() != clamped.y:
+            logger.debug(
+                "Window out of bounds at (%s,%s); clamping to (%s,%s).",
+                current_pos.x(),
+                current_pos.y(),
+                clamped.x,
+                clamped.y,
+            )
+            self._apply_geometry(clamped.x, clamped.y)
 
     @pyqtSlot()
     def update_position(self, fresh_taskbar_info: Optional[TaskbarInfo] = None) -> None:

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -127,6 +127,7 @@ class TestPositionManager(unittest.TestCase):
         self.mock_widget.width.return_value = 100
         self.mock_widget.height.return_value = 40
         self.mock_widget.isVisible.return_value = True
+        self.mock_widget.pos.return_value = QPoint(0, 0)
         
         self.mock_taskbar = MagicMock(spec=TaskbarInfo)
         self.mock_taskbar.dpi_scale = 1.0
@@ -174,6 +175,39 @@ class TestPositionManager(unittest.TestCase):
         
         self.manager.update_position()
         self.mock_widget.move.assert_called_with(888, 999)
+
+    @patch('netspeedtray.core.position_manager.QApplication.primaryScreen')
+    @patch('netspeedtray.core.position_manager.QApplication.screenAt')
+    def test_enforce_window_bounds_clamps_negative_y_to_zero(self, mock_screen_at, mock_primary_screen):
+        """Title bar must remain reachable by clamping Y to 0 or greater."""
+        mock_screen = MagicMock()
+        mock_screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        mock_screen.name.return_value = "Mock Screen"
+        mock_screen_at.return_value = None
+        mock_primary_screen.return_value = mock_screen
+
+        self.mock_widget.pos.return_value = QPoint(120, -35)
+
+        self.manager._enforce_window_bounds()
+
+        self.mock_widget.move.assert_called_with(120, 0)
+
+    @patch('netspeedtray.core.position_manager.QApplication.primaryScreen')
+    @patch('netspeedtray.core.position_manager.QApplication.screenAt')
+    def test_enforce_window_bounds_skips_while_dragging(self, mock_screen_at, mock_primary_screen):
+        """Bounds enforcement must not fight user drag interactions."""
+        mock_screen = MagicMock()
+        mock_screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        mock_screen.name.return_value = "Mock Screen"
+        mock_screen_at.return_value = None
+        mock_primary_screen.return_value = mock_screen
+
+        self.mock_widget._dragging = True
+        self.mock_widget.pos.return_value = QPoint(120, -35)
+
+        self.manager._enforce_window_bounds()
+
+        self.mock_widget.move.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/netspeedtray/tests/unit/test_settings.py
+++ b/src/netspeedtray/tests/unit/test_settings.py
@@ -65,3 +65,11 @@ def test_get_settings_translates_ui_state_to_config(settings_dialog):
     assert new_settings["update_rate"] == 2.0
     assert new_settings["interface_mode"] == "selected"
     assert set(new_settings["selected_interfaces"]) == {"Wi-Fi"}
+
+
+def test_settings_dialog_clamps_top_edge(settings_dialog):
+    """Settings dialog should never keep its title bar above the top edge."""
+    settings_dialog.move(120, -200)
+    settings_dialog._clamp_dialog_to_screen()
+
+    assert settings_dialog.pos().y() >= 0

--- a/src/netspeedtray/views/settings/dialog.py
+++ b/src/netspeedtray/views/settings/dialog.py
@@ -162,6 +162,7 @@ class SettingsDialog(QDialog):
             screen_center = screen.availableGeometry().center()
             dialog_center = self.rect().center()
             self.move(screen_center - dialog_center)
+            self._clamp_dialog_to_screen()
 
         # Set a safe minimum size to prevent layout breakage on small screens or long translations
         # Increased for #104/high-DPI compatibility where OS min-track might be > 620x500
@@ -297,10 +298,8 @@ class SettingsDialog(QDialog):
             if saved_pos and isinstance(saved_pos, dict):
                  x, y = saved_pos.get("x"), saved_pos.get("y")
                  if x is not None and y is not None:
-                     # Basic validation to ensure it's on-screen is handled by OS/Qt usually, 
-                     # but we could add ScreenUtils validation here if imported.
-                     # For now, trust the save.
                      self.move(x, y)
+                     self._clamp_dialog_to_screen()
                      self.logger.debug(f"Restored Settings Dialog position to ({x}, {y})")
 
         except Exception as e:
@@ -379,6 +378,44 @@ class SettingsDialog(QDialog):
         if current_geo.height() > available_rect.height():
              self.resize(current_geo.width(), available_rect.height())
              self.move(current_geo.x(), available_rect.top())
+
+        self._clamp_dialog_to_screen()
+
+    def _clamp_dialog_to_screen(self) -> None:
+        """Clamp dialog position so it stays fully reachable on screen."""
+        screen = self.screen() or QApplication.screenAt(self.frameGeometry().center()) or QApplication.primaryScreen()
+        if not screen:
+            return
+
+        available = screen.availableGeometry()
+        frame = self.frameGeometry()
+        current_pos = self.pos()
+
+        max_x = available.right() - frame.width() + 1
+        max_y = available.bottom() - frame.height() + 1
+        min_x = available.left()
+        # Hard top clamp: never allow title bar above the top edge.
+        min_y = max(0, available.top())
+
+        # If dialog is larger than available area, pin to top-left safe origin.
+        if max_x < min_x:
+            max_x = min_x
+        if max_y < min_y:
+            max_y = min_y
+
+        clamped_x = max(min_x, min(current_pos.x(), max_x))
+        clamped_y = max(min_y, min(current_pos.y(), max_y))
+
+        if clamped_x != current_pos.x() or clamped_y != current_pos.y():
+            self.move(clamped_x, clamped_y)
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        self._clamp_dialog_to_screen()
+
+    def moveEvent(self, event) -> None:
+        super().moveEvent(event)
+        self._clamp_dialog_to_screen()
 
     def _schedule_settings_update(self) -> None:
         """Starts the throttle timer to emit settings_changed."""


### PR DESCRIPTION
## Problem
The Settings dialog could be moved off-screen, especially above the top edge, which hides the title bar and makes window controls difficult to access.

## Solution
Implemented position clamping for both the tray widget and the Settings dialog:

- Added continuous bounds enforcement for widget position monitoring
- Added dialog-level clamping on:
  - restore
  - resize/reposition
  - show
  - move events
- Enforced a hard top bound (`y >= 0`) to ensure the title bar always remains visible and accessible

## Result
- Windows remain fully visible on-screen
- Title bar controls (minimize, maximize, close) are always reachable
- Improved resilience against off-screen placement after dragging or restoring saved positions

## Testing
Added/updated unit tests for:

- Top-edge clamping behavior
- Skip-clamping while dragging

All related positioning and settings tests pass locally