### PR TITLE
fix(position): restore free_move position on secondary screens (#133)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Free-Move Widget Reverts to Primary Screen After Reboot (#133):** The saved free-move position is now validated against the screen it actually belongs to (via `QApplication.screenAt()`) instead of the primary screen's taskbar. Previously, dragging the widget to a secondary monitor and restarting would snap it back to the primary screen because the saved coordinates were rejected as "off-screen" by the primary-screen validator. If the original monitor has since been disconnected, the widget now falls back to its calculated position near the tray instead of remaining off-screen. Position-restore decisions are now logged at INFO level for easier field diagnosis.
+
+---
+
 ## [1.3.1] - April 15, 2026
 
 ### Added

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -456,7 +456,14 @@ class PositionManager(QObject):
             logger.error("Error updating position: %s", e, exc_info=True)
 
     def _apply_saved_position(self) -> bool:
-        """Applies saved position if 'free_move' is enabled."""
+        """Applies saved position if 'free_move' is enabled.
+
+        Multi-monitor aware: the saved coordinates are looked up against the
+        screen they actually belong to via QApplication.screenAt(), not the
+        primary screen's taskbar. If the saved monitor has been disconnected,
+        falls through to the calculated position so the widget appears near
+        the tray instead of off-screen. Fixes #133.
+        """
         if not self._state.config.get('free_move', False):
             return False
 
@@ -466,17 +473,38 @@ class PositionManager(QObject):
         if not isinstance(saved_x, int) or not isinstance(saved_y, int):
             return False
 
-        # Validate against current screen
-        screen = self._state.taskbar_info.get_screen() if self._state.taskbar_info else QApplication.primaryScreen()
-        if not screen:
+        widget_width = self._state.widget.width()
+        widget_height = self._state.widget.height()
+        widget_size = (widget_width, widget_height)
+
+        # Use the widget's center to identify which monitor the saved position
+        # belongs to. This handles the case where the user drags the widget to
+        # a secondary screen — the primary-screen taskbar in self._state would
+        # otherwise reject coordinates that are perfectly valid on monitor 2.
+        center = QPoint(saved_x + widget_width // 2, saved_y + widget_height // 2)
+        screen = QApplication.screenAt(center)
+
+        if screen is None:
+            logger.info(
+                "Saved free-move position (%s,%s) is on a disconnected monitor; "
+                "falling back to calculated position.",
+                saved_x, saved_y,
+            )
             return False
 
-        widget_size = (self._state.widget.width(), self._state.widget.height())
-        if ScreenUtils.is_position_valid(saved_x, saved_y, widget_size, screen):
-            self._apply_geometry(saved_x, saved_y)
-            return True
-        
-        return False
+        clamped = ScreenUtils.validate_position(saved_x, saved_y, widget_size, screen)
+        if (clamped.x, clamped.y) != (saved_x, saved_y):
+            logger.info(
+                "Clamped saved free-move position (%s,%s) onto screen '%s' -> (%s,%s).",
+                saved_x, saved_y, screen.name(), clamped.x, clamped.y,
+            )
+        else:
+            logger.info(
+                "Restored saved free-move position (%s,%s) on screen '%s'.",
+                saved_x, saved_y, screen.name(),
+            )
+        self._apply_geometry(clamped.x, clamped.y)
+        return True
 
     def _apply_calculated_position(self) -> bool:
         """Calculates and applies position based on taskbar rules."""

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -477,6 +477,19 @@ class PositionManager(QObject):
         widget_height = self._state.widget.height()
         widget_size = (widget_width, widget_height)
 
+        # Defensive: if the widget hasn't been laid out yet, its width/height
+        # report 0. A zero-size widget centered at (saved_x, saved_y) would land
+        # in screenAt() lookup at the top-left corner, which could be on a
+        # *different* screen than the actual widget will eventually occupy.
+        # Fall through to the calculated position; a follow-up update_position()
+        # after layout completes will retry with valid dimensions.
+        if widget_width <= 0 or widget_height <= 0:
+            logger.debug(
+                "Widget size not yet known (w=%s, h=%s); deferring saved-position restore.",
+                widget_width, widget_height,
+            )
+            return False
+
         # Use the widget's center to identify which monitor the saved position
         # belongs to. This handles the case where the user drags the widget to
         # a secondary screen — the primary-screen taskbar in self._state would

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -159,21 +159,86 @@ class TestPositionManager(unittest.TestCase):
             
             self.mock_widget.move.assert_called_with(100, 200)
 
+    @patch('PyQt6.QtWidgets.QApplication.screenAt')
     @patch('netspeedtray.core.position_manager.get_taskbar_info')
-    def test_update_position_free_move(self, mock_get_info):
+    def test_update_position_free_move(self, mock_get_info, mock_screen_at):
+        """Saved free-move position on the primary screen is restored verbatim."""
         mock_get_info.return_value = self.mock_taskbar
-        
+
+        # Primary screen at (0,0)-1920x1080
+        primary = MagicMock()
+        primary.geometry.return_value = QRect(0, 0, 1920, 1080)
+        primary.name.return_value = "DISPLAY1"
+        mock_screen_at.return_value = primary
+
         self.config['free_move'] = True
         self.config['position_x'] = 888
         self.config['position_y'] = 999
-        
-        # Should use saved position if valid
-        # We need ScreenUtils validation to pass. Mock validation?
-        # Or just assume screens are big enough test environment.
-        # 888, 999 is inside 1920x1080.
-        
+
         self.manager.update_position()
         self.mock_widget.move.assert_called_with(888, 999)
+
+    @patch('PyQt6.QtWidgets.QApplication.screenAt')
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_free_move_restores_on_secondary_screen(self, mock_get_info, mock_screen_at):
+        """Regression for #133: saved coords on a secondary monitor must be restored,
+        even though get_taskbar_info() returns only the primary taskbar."""
+        mock_get_info.return_value = self.mock_taskbar  # primary taskbar
+
+        # Secondary screen to the left at (-1920, 0)-1920x1080
+        secondary = MagicMock()
+        secondary.geometry.return_value = QRect(-1920, 0, 1920, 1080)
+        secondary.name.return_value = "DISPLAY2"
+        mock_screen_at.return_value = secondary
+
+        self.config['free_move'] = True
+        self.config['position_x'] = -1000  # clearly on the secondary screen
+        self.config['position_y'] = 500
+
+        self.manager.update_position()
+        # Must restore exactly, not snap back to primary calculated pos.
+        self.mock_widget.move.assert_called_with(-1000, 500)
+
+    @patch('PyQt6.QtWidgets.QApplication.screenAt')
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_free_move_disconnected_monitor_falls_through(self, mock_get_info, mock_screen_at):
+        """Saved coords on a now-disconnected monitor must fall through to calculated
+        position rather than placing the widget off-screen."""
+        mock_get_info.return_value = self.mock_taskbar
+        mock_screen_at.return_value = None  # No monitor at that point
+
+        self.config['free_move'] = True
+        self.config['position_x'] = -1000
+        self.config['position_y'] = 500
+
+        with patch.object(self.manager._calculator, 'calculate_position',
+                          return_value=ScreenPosition(1500, 1040)):
+            self.manager.update_position()
+            # Should NOT have been moved to the disconnected coords.
+            self.mock_widget.move.assert_called_with(1500, 1040)
+
+    @patch('PyQt6.QtWidgets.QApplication.screenAt')
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_free_move_clamps_off_edge_position(self, mock_get_info, mock_screen_at):
+        """Saved coords slightly off the edge of an existing screen are clamped, not rejected."""
+        mock_get_info.return_value = self.mock_taskbar
+
+        primary = MagicMock()
+        primary.geometry.return_value = QRect(0, 0, 1920, 1080)
+        primary.name.return_value = "DISPLAY1"
+        mock_screen_at.return_value = primary
+
+        self.config['free_move'] = True
+        self.config['position_x'] = 1900  # widget width 100 -> right edge at 2000, off-screen
+        self.config['position_y'] = 1070  # widget height 40 -> bottom at 1110, off-screen
+
+        self.manager.update_position()
+        # Must be clamped onto the screen, not rejected.
+        args, _ = self.mock_widget.move.call_args
+        x, y = args
+        self.assertTrue(0 <= x <= 1920 - 100, f"x={x} not clamped to screen")
+        self.assertTrue(0 <= y <= 1080 - 40, f"y={y} not clamped to screen")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -239,6 +239,33 @@ class TestPositionManager(unittest.TestCase):
         self.assertTrue(0 <= x <= 1920 - 100, f"x={x} not clamped to screen")
         self.assertTrue(0 <= y <= 1080 - 40, f"y={y} not clamped to screen")
 
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_free_move_defers_when_widget_size_is_zero(self, mock_get_info):
+        """Defensive: if widget.width()/height() return 0 (widget not laid out
+        yet at startup), saved-position restore must defer rather than guess
+        the wrong screen via screenAt() with a corrupted center point.
+
+        get_calculated_position() also returns None for zero-sized widgets,
+        so the whole update is a no-op. A follow-up update_position() after
+        layout completes will succeed.
+        """
+        mock_get_info.return_value = self.mock_taskbar
+        # Force zero-size widget
+        self.mock_widget.width.return_value = 0
+        self.mock_widget.height.return_value = 0
+
+        self.config['free_move'] = True
+        # These saved coords are on a hypothetical secondary screen at x=-1920.
+        # Without the guard, screenAt(QPoint(-1000 + 0//2, 500 + 0//2)) would
+        # be tested against the WRONG point and probably land on a different
+        # screen than the widget actually belongs to.
+        self.config['position_x'] = -1000
+        self.config['position_y'] = 500
+
+        self.manager.update_position()
+        # No move called: zero-sized widget can't be positioned safely yet.
+        self.mock_widget.move.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes [#133](https://github.com/erez-c137/NetSpeedTray/issues/133): when `free_move` is enabled and the user drags the widget to a secondary monitor, the saved position is now correctly restored after restart instead of snapping back to the primary screen.

## Root cause
[`position_manager.py:_apply_saved_position()`](https://github.com/erez-c137/NetSpeedTray/blob/main/src/netspeedtray/core/position_manager.py#L458) validated saved coords against `self._state.taskbar_info.get_screen()`. `taskbar_info` comes from [`taskbar_utils.py:559`](https://github.com/erez-c137/NetSpeedTray/blob/main/src/netspeedtray/utils/taskbar_utils.py#L559), which **always returns the primary taskbar**. So coordinates on a secondary monitor failed `is_position_valid()` (they're outside the primary screen's rect), the function returned `False`, and the widget fell through to `_apply_calculated_position()` — which places it on the primary taskbar.

## Fix
Use `QApplication.screenAt(widget_center)` to identify the screen the saved coords actually belong to. Three cases:

1. **Screen found** → clamp coords onto that screen (handles minor edge overruns from DPI changes), apply.
2. **Screen disconnected** (`screenAt` returns `None`) → fall through to calculated position so the widget appears near the tray instead of off-screen.
3. **Coords slightly off-edge but screen exists** → clamp instead of rejecting (previously rejected, now repositioned cleanly).

Restore decisions now log at INFO so the next round of position bug reports include screen name and outcome — the #133 reporter's log had zero positioning events because everything was at DEBUG.

## Test plan
- [x] New unit test: `test_free_move_restores_on_secondary_screen` — regression for #133, secondary screen at `(-1920, 0)-1920x1080`, widget restored to `(-1000, 500)` instead of snapping to primary
- [x] New unit test: `test_free_move_disconnected_monitor_falls_through` — saved coords on a removed monitor fall through to calculated position
- [x] New unit test: `test_free_move_clamps_off_edge_position` — coords slightly past screen edge get clamped, not rejected
- [x] Existing `test_update_position_free_move` updated to mock `screenAt` and still passes
- [x] Full suite: `146 passed in 13.62s`
- [ ] **Manual smoke test on a multi-monitor setup** — enable free_move, drag widget to secondary screen, restart app, verify widget restored on secondary

## Risk
Low. Behavior change is strictly more correct (no path that previously worked now breaks):
- Primary-screen free_move users: identical behavior (`screenAt` returns primary, clamping is a no-op).
- Secondary-screen free_move users: now works (was broken).
- Disconnected-monitor users: graceful fallback (was off-screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)