### PR TITLE
feat(theme): live dark/light mode detection (#62)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **Live Theme Detection (#62):** The widget now updates its text color the moment Windows switches between Light and Dark mode, instead of waiting for the next app restart. Uses Qt 6.5+'s `colorSchemeChanged` signal in place of the previous WM_SETTINGCHANGE native event filter, which fired on every system setting change (mouse, language, accessibility). Runtime theme changes are applied in-memory only — flipping themes no longer churns the config file on disk. Only affects users with "Automatic" text color enabled (the default).
+
+---
+
 ## [1.3.1] - April 15, 2026
 
 ### Added

--- a/src/netspeedtray/core/system_events.py
+++ b/src/netspeedtray/core/system_events.py
@@ -11,10 +11,9 @@ import time
 import win32api
 import win32gui
 from typing import Optional
-import ctypes # Needed for MSG structure
 
-from PyQt6.QtCore import QObject, QTimer, pyqtSignal, QAbstractNativeEventFilter
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal
+from PyQt6.QtGui import QGuiApplication
 
 from netspeedtray.constants import timeouts
 from netspeedtray.utils.taskbar_utils import (
@@ -25,24 +24,6 @@ from netspeedtray.utils.win_event_hook import (
     EVENT_SYSTEM_MOVESIZEEND,
     WinEventHook
 )
-
-class ThemeChangeFilter(QAbstractNativeEventFilter):
-    """
-    Native event filter to capture WM_SETTINGCHANGE messages.
-    """
-    WM_SETTINGCHANGE = 0x001A
-
-    def __init__(self, handler):
-        super().__init__()
-        self.handler = handler
-
-    def nativeEventFilter(self, eventType, message):
-        if eventType == "windows_generic_MSG":
-            msg = ctypes.wintypes.MSG.from_address(int(message))
-            if msg.message == self.WM_SETTINGCHANGE:
-                # Emit signal directly from the filter
-                self.handler.theme_changed.emit()
-        return False, 0
 
 class SystemEventHandler(QObject):
     """
@@ -77,16 +58,14 @@ class SystemEventHandler(QObject):
         # State
         self._last_immediate_hide_time: float = 0.0
         self._is_paused = False
-        
-        # Native Filter
-        self.theme_filter: Optional[ThemeChangeFilter] = None
+        self._theme_signal_connected = False
 
     def start(self) -> None:
         """Starts all hooks and monitoring timers."""
         self.logger.debug("Starting SystemEventHandler...")
         self._setup_hooks()
         self._setup_timers()
-        self._install_native_filter()
+        self._connect_color_scheme_signal()
         self.logger.debug("SystemEventHandler started.")
 
     def stop(self) -> None:
@@ -97,7 +76,7 @@ class SystemEventHandler(QObject):
         if self.movesize_hook:
             self.movesize_hook.stop()
         self._taskbar_validity_timer.stop()
-        self._remove_native_filter()
+        self._disconnect_color_scheme_signal()
 
     def _setup_hooks(self) -> None:
         """Initializes and starts WinEventHooks."""
@@ -193,20 +172,42 @@ class SystemEventHandler(QObject):
         self._is_paused = False
         self.events_paused.emit(False)
 
-    def _install_native_filter(self) -> None:
-        """Installs the native event filter on the QApplication."""
-        if not self.theme_filter:
-            self.theme_filter = ThemeChangeFilter(self)
-            app = QApplication.instance()
-            if app:
-                app.installNativeEventFilter(self.theme_filter)
-                self.logger.debug("Native event filter installed for theme changes.")
+    def _connect_color_scheme_signal(self) -> None:
+        """Connect to Qt's native colorSchemeChanged signal.
 
-    def _remove_native_filter(self) -> None:
-        """Removes the native event filter."""
-        if self.theme_filter:
-            app = QApplication.instance()
-            if app:
-                app.removeNativeEventFilter(self.theme_filter)
-            self.theme_filter = None
-            self.logger.debug("Native event filter removed.")
+        Qt 6.5+ exposes a debounced, OS-agnostic signal for color-scheme
+        changes. Using it here replaces the previous WM_SETTINGCHANGE
+        native event filter, which fired on every system setting change
+        (mouse, language, accessibility, etc.) — not just theme.
+        """
+        if self._theme_signal_connected:
+            return
+        app = QGuiApplication.instance()
+        if app is None:
+            self.logger.warning("No QGuiApplication instance — cannot connect theme signal.")
+            return
+        try:
+            app.styleHints().colorSchemeChanged.connect(self._on_color_scheme_changed)
+            self._theme_signal_connected = True
+            self.logger.debug("Connected to QStyleHints.colorSchemeChanged.")
+        except Exception as e:
+            self.logger.warning("Failed to connect colorSchemeChanged: %s", e)
+
+    def _disconnect_color_scheme_signal(self) -> None:
+        if not self._theme_signal_connected:
+            return
+        app = QGuiApplication.instance()
+        if app is None:
+            return
+        try:
+            app.styleHints().colorSchemeChanged.disconnect(self._on_color_scheme_changed)
+        except (TypeError, RuntimeError):
+            pass
+        self._theme_signal_connected = False
+
+    def _on_color_scheme_changed(self, _scheme) -> None:
+        """Re-emit Qt's signal as our existing theme_changed signal."""
+        if self._is_paused:
+            return
+        self.logger.info("Color scheme changed; emitting theme_changed.")
+        self.theme_changed.emit()

--- a/src/netspeedtray/tests/unit/test_system_events.py
+++ b/src/netspeedtray/tests/unit/test_system_events.py
@@ -66,12 +66,41 @@ def test_taskbar_restarted_signal(system_handler, mock_hooks):
     MockHook, mock_instance = mock_hooks
     mock_slot = MagicMock()
     system_handler.taskbar_restarted.connect(mock_slot)
-    
+
     # Create the hook mock with a fake HWND
     mock_instance.hwnd_to_watch = 12345
     system_handler.movesize_hook = mock_instance
-    
+
     with patch('win32gui.IsWindow', return_value=False): # Force invalid window check
         system_handler._check_taskbar_validity()
-        
+
         mock_slot.assert_called_once()
+
+
+def test_color_scheme_change_emits_theme_changed_signal(system_handler):
+    """Regression for #62: Qt's colorSchemeChanged must re-emit theme_changed.
+
+    Bypasses the actual Qt signal wiring (which requires a running OS theme
+    change) and calls the handler directly to confirm the re-emit path works.
+    """
+    mock_slot = MagicMock()
+    system_handler.theme_changed.connect(mock_slot)
+
+    # Simulate Qt firing the colorSchemeChanged signal
+    from PyQt6.QtCore import Qt
+    system_handler._on_color_scheme_changed(Qt.ColorScheme.Dark)
+
+    mock_slot.assert_called_once()
+
+
+def test_color_scheme_change_suppressed_when_paused(system_handler):
+    """When events are paused (e.g. settings dialog open), theme changes
+    should not fire — same contract as other system events."""
+    mock_slot = MagicMock()
+    system_handler.theme_changed.connect(mock_slot)
+    system_handler._is_paused = True
+
+    from PyQt6.QtCore import Qt
+    system_handler._on_color_scheme_changed(Qt.ColorScheme.Light)
+
+    mock_slot.assert_not_called()

--- a/src/netspeedtray/views/widget/theme.py
+++ b/src/netspeedtray/views/widget/theme.py
@@ -58,9 +58,15 @@ class WidgetThemeManager:
             self.logger.warning(f"Could not perform theme-aware color sync: {e}")
 
     def on_theme_changed(self) -> None:
-        """Handles Windows theme change (Light/Dark mode)."""
-        self.logger.debug("Theme change detected. Refreshing styles.")
-        self.apply_theme_aware_defaults()
+        """Handles a runtime Windows theme change (Light <-> Dark).
+
+        Uses the in-memory update path (`update_color_for_live_theme`) so
+        flipping themes doesn't churn the config file on disk. The disk-
+        persisting `apply_theme_aware_defaults` is reserved for startup,
+        where syncing the saved color to the actual OS theme is desirable.
+        """
+        self.logger.info("Theme change detected; updating live colors.")
+        self.update_color_for_live_theme()
         self.widget.update()
 
     def update_color_for_live_theme(self) -> None:


### PR DESCRIPTION
## Summary
Phase 3b of v1.3.2. Closes [#62](https://github.com/erez-c137/NetSpeedTray/issues/62) — promised in January, never shipped.

The widget now updates its text color the moment Windows switches between Light and Dark mode, instead of waiting for the next app restart.

## Root cause + fix
Two problems with the existing wiring:

1. **Native event filter was too broad.** \`ThemeChangeFilter\` caught every \`WM_SETTINGCHANGE\` — which Windows fires on mouse settings, language, accessibility, environment variables, etc. — and triggered a registry read on every one. Replaced with Qt's debounced \`QGuiApplication.styleHints().colorSchemeChanged\` signal (Qt 6.5+, available in PyQt6 6.9 which we use).

2. **Runtime path persisted to disk every time.** \`on_theme_changed()\` was calling \`apply_theme_aware_defaults()\` which writes config to disk on every theme flip. Switched to \`update_color_for_live_theme()\` which updates in-memory only. The disk-persisting path stays at startup, where syncing the saved color to the OS theme is intentional.

## Scope
Only affects users with **Automatic** text color enabled (the default). Users who explicitly picked a custom color see no change — \`color_is_automatic == False\` short-circuits both paths.

## Test plan
- [x] **2 new unit tests** (\`test_color_scheme_change_emits_theme_changed_signal\`, \`test_color_scheme_change_suppressed_when_paused\`)
- [x] Existing system_events tests pass unchanged (6 total in the file)
- [x] Full unit suite: passes
- [ ] **Manual test on Win 11:** Settings → Personalization → Colors → toggle Dark/Light. Confirm widget text color flips within ~1 second without app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)