### PR TITLE
chore(logging): bump key state transitions to INFO

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **Log levels for field diagnosis:** Bumped four state-transition logs from DEBUG to INFO so bug-report logs include the breadcrumbs we need without users having to enable verbose logging. Affects `StatsMonitorThread` (init + polling interval changes + hardware monitor connection + run loop start) and `StatsController` (init mode + primary interface changes). Production logs will be marginally larger; the additions fire once or only when state actually changes, so volume stays low.
+
+---
+
 ## [1.3.1] - April 15, 2026
 
 ### Added

--- a/src/netspeedtray/core/controller.py
+++ b/src/netspeedtray/core/controller.py
@@ -58,7 +58,8 @@ class StatsController(QObject):
         from collections import deque
         self.recent_speeds: Dict[str, deque] = {}
 
-        self.logger.debug("StatsController initialized.")
+        mode = self.config.get("interface_mode", "auto")
+        self.logger.info("StatsController initialized (interface_mode=%s).", mode)
 
 
     def set_view(self, view: 'NetworkSpeedWidget') -> None:
@@ -278,11 +279,16 @@ class StatsController(QObject):
 
 
     def _update_primary_interface_name(self) -> None:
-        """Updates primary interface."""
+        """Updates primary interface, logging changes for field diagnosis."""
+        previous = self.primary_interface
         try:
             self.primary_interface = get_primary_interface_name()
         except Exception:
             self.primary_interface = None
+        if previous != self.primary_interface:
+            self.logger.info(
+                "Primary network interface changed: %r -> %r", previous, self.primary_interface
+            )
 
 
     def get_available_interfaces(self) -> List[str]:

--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -96,12 +96,14 @@ class StatsMonitorThread(QThread):
         self._power_pkg_counter: Optional[int] = None   # CPU package power (PKG)
         self._power_pp1_counter: Optional[int] = None    # Intel iGPU power (PP1)
 
-        self.logger.debug("StatsMonitorThread initialized with interval %.2fs", self.interval)
+        self.logger.info("StatsMonitorThread initialized with interval %.2fs", self.interval)
 
     def set_interval(self, interval: float) -> None:
         """Dynamically updates the polling interval."""
+        previous = self.interval
         self.interval = max(0.1, interval)
-        self.logger.debug("Monitoring interval updated to %.2fs", self.interval)
+        if previous != self.interval:
+            self.logger.info("Monitoring interval changed: %.2fs -> %.2fs", previous, self.interval)
 
     def update_config(self, config: Dict[str, Any]) -> None:
         """Updates internal config copy and resets hardware queries if needed."""
@@ -504,7 +506,7 @@ class StatsMonitorThread(QThread):
                         )
                     continue
                 self._wmi_ohm = obj
-                self.logger.debug("Hardware monitor: connected to %s (%d temp sensors)", ns, count)
+                self.logger.info("Hardware monitor: connected to %s (%d temp sensors).", ns, count)
                 return
             except Exception as e:
                 self.logger.debug("Hardware monitor: %s probe failed: %s", ns, e)
@@ -617,7 +619,7 @@ class StatsMonitorThread(QThread):
 
     def run(self) -> None:
         """Main monitoring loop."""
-        self.logger.debug("StatsMonitorThread starting loop...")
+        self.logger.info("StatsMonitorThread starting loop.")
 
         # Check once at thread startup, not per-iteration — is_rdp_session() is a
         # syscall and the session type does not change while the thread is running.


### PR DESCRIPTION
## Summary
Phase 2b of v1.3.2. Production bug-report logs were missing the breadcrumbs needed to triage recent issues (#133, #137, #138). The relevant events were logged at DEBUG, which isn't captured in production.

Rather than ship a "verbose logging" toggle in the UI (users would need to flip it *before* a bug happens, which never matches reality), this bumps the small set of important state-transition logs to INFO so every user's log already has the signal.

## Bumped to INFO
- \`StatsMonitorThread.__init__\` — once at startup
- \`StatsMonitorThread.set_interval\` — only when interval actually changes (now wrapped with a previous-value check)
- \`StatsMonitorThread\` WMI/LHM connect — once per backend probe success
- \`StatsMonitorThread.run\` — once at thread start
- \`StatsController.__init__\` — once, now includes interface_mode in the message
- \`StatsController._update_primary_interface_name\` — only when the resolved primary changes (newly wrapped to detect changes)

## Volume impact
Each new INFO log is gated by a "changed" check (or runs once at init). No per-tick INFO floods. Realistic addition: ~5-8 INFO lines per app session.

## Excluded modules
Skipped \`system_events.py\` (touched by PR #144) and \`position_manager.py\` (touched by PR #140) to avoid merge conflicts. Those modules will get a follow-up audit pass once the in-flight PRs land.

## Test plan
- [x] Full unit suite: 143 passed
- [ ] Manual: launch app, check log file at \`%APPDATA%\NetSpeedTray\NetSpeedTray.log\` contains the new INFO lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)