### PR TITLE
feat(position): preferred monitor for multi-monitor users (#72)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Preferred Monitor (#72):** A new dropdown in Settings → General lets users pin the widget to a specific monitor in multi-monitor setups instead of always landing on the primary taskbar. The setting stores the screen's stable Windows identifier (`\\.\DISPLAY1`), and gracefully falls back to primary if the saved monitor is no longer connected.
+
 ### Fixed
 - **Free-Move Widget Reverts to Primary Screen After Reboot (#133):** The saved free-move position is now validated against the screen it actually belongs to (via `QApplication.screenAt()`) instead of the primary screen's taskbar. Previously, dragging the widget to a secondary monitor and restarting would snap it back to the primary screen because the saved coordinates were rejected as "off-screen" by the primary-screen validator. If the original monitor has since been disconnected, the widget now falls back to its calculated position near the tray instead of remaining off-screen. Position-restore decisions are now logged at INFO level for easier field diagnosis.
 

--- a/src/netspeedtray/constants/config.py
+++ b/src/netspeedtray/constants/config.py
@@ -170,6 +170,7 @@ class ConfigConstants:
         "check_for_updates": True,
         "skipped_version": None,
         "last_update_check": None,
+        "preferred_monitor": None,
     }
     
     # --- Schema Definition for Modern Config Validation ---
@@ -244,6 +245,9 @@ class ConfigConstants:
         "check_for_updates": {"type": bool, "default": True},
         "skipped_version": {"type": (str, type(None)), "default": None},
         "last_update_check": {"type": (str, type(None)), "default": None},
+        # QScreen.name() identifier (e.g. "\\.\DISPLAY1"). None = use primary.
+        # If the saved screen isn't found at runtime, fall back to primary.
+        "preferred_monitor": {"type": (str, type(None)), "default": None},
     }
 
 

--- a/src/netspeedtray/constants/locales/de_DE.json
+++ b/src/netspeedtray/constants/locales/de_DE.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Nach &Updates suchen",
     "CHECK_FOR_UPDATES_LABEL": "Beim Start nach Updates suchen",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Update verfügbar",
     "UPDATE_AVAILABLE_TEXT": "Eine neue Version von NetSpeedTray ist verfügbar!\n\nAktuell: v{current}\nNeueste: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Herunterladen",

--- a/src/netspeedtray/constants/locales/en_US.json
+++ b/src/netspeedtray/constants/locales/en_US.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Check for &Updates",
     "CHECK_FOR_UPDATES_LABEL": "Check for updates on startup",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Update Available",
     "UPDATE_AVAILABLE_TEXT": "A new version of NetSpeedTray is available!\n\nCurrent: v{current}\nLatest: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Download",

--- a/src/netspeedtray/constants/locales/es_ES.json
+++ b/src/netspeedtray/constants/locales/es_ES.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Buscar &actualizaciones",
     "CHECK_FOR_UPDATES_LABEL": "Buscar actualizaciones al iniciar",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Actualización disponible",
     "UPDATE_AVAILABLE_TEXT": "¡Una nueva versión de NetSpeedTray está disponible!\n\nActual: v{current}\nÚltima: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Descargar",

--- a/src/netspeedtray/constants/locales/fr_FR.json
+++ b/src/netspeedtray/constants/locales/fr_FR.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Vérifier les &mises à jour",
     "CHECK_FOR_UPDATES_LABEL": "Vérifier les mises à jour au démarrage",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Mise à jour disponible",
     "UPDATE_AVAILABLE_TEXT": "Une nouvelle version de NetSpeedTray est disponible !\n\nActuelle : v{current}\nDernière : v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Télécharger",

--- a/src/netspeedtray/constants/locales/ko_KR.json
+++ b/src/netspeedtray/constants/locales/ko_KR.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "업데이트 확인(&U)",
     "CHECK_FOR_UPDATES_LABEL": "시작 시 업데이트 확인",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "업데이트 가능",
     "UPDATE_AVAILABLE_TEXT": "NetSpeedTray의 새 버전이 있습니다!\n\n현재: v{current}\n최신: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "다운로드",

--- a/src/netspeedtray/constants/locales/nl_NL.json
+++ b/src/netspeedtray/constants/locales/nl_NL.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Toon &App-activiteit",
     "CHECK_FOR_UPDATES_MENU_ITEM": "&Updates controleren",
     "CHECK_FOR_UPDATES_LABEL": "Bij het opstarten op updates controleren",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Update beschikbaar",
     "UPDATE_AVAILABLE_TEXT": "Een nieuwe versie van NetSpeedTray is beschikbaar!\n\nHuidig: v{current}\nNieuwste: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Downloaden",

--- a/src/netspeedtray/constants/locales/pl_PL.json
+++ b/src/netspeedtray/constants/locales/pl_PL.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Sprawdź &aktualizacje",
     "CHECK_FOR_UPDATES_LABEL": "Sprawdzaj aktualizacje przy uruchomieniu",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Dostępna aktualizacja",
     "UPDATE_AVAILABLE_TEXT": "Dostępna jest nowa wersja NetSpeedTray!\n\nObecna: v{current}\nNajnowsza: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Pobierz",

--- a/src/netspeedtray/constants/locales/ru_RU.json
+++ b/src/netspeedtray/constants/locales/ru_RU.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Проверить &обновления",
     "CHECK_FOR_UPDATES_LABEL": "Проверять обновления при запуске",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Доступно обновление",
     "UPDATE_AVAILABLE_TEXT": "Доступна новая версия NetSpeedTray!\n\nТекущая: v{current}\nПоследняя: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Скачать",

--- a/src/netspeedtray/constants/locales/sl_SI.json
+++ b/src/netspeedtray/constants/locales/sl_SI.json
@@ -314,6 +314,8 @@
     "SHOW_APP_ACTIVITY_MENU_ITEM": "Show &App Activity",
     "CHECK_FOR_UPDATES_MENU_ITEM": "Preveri &posodobitve",
     "CHECK_FOR_UPDATES_LABEL": "Ob zagonu preveri posodobitve",
+    "PREFERRED_MONITOR_LABEL": "Preferred Monitor",
+    "PREFERRED_MONITOR_PRIMARY": "Primary (auto)",
     "UPDATE_AVAILABLE_TITLE": "Posodobitev na voljo",
     "UPDATE_AVAILABLE_TEXT": "Na voljo je nova različica NetSpeedTray!\n\nTrenutna: v{current}\nNajnovejša: v{latest}",
     "UPDATE_DOWNLOAD_BUTTON": "Prenesi",

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -437,13 +437,15 @@ class PositionManager(QObject):
     def update_position(self, fresh_taskbar_info: Optional[TaskbarInfo] = None) -> None:
         """
         Main entry point to update the widget's position.
-        Uses fresh taskbar info if provided, otherwise fetches it.
+        Uses fresh taskbar info if provided, otherwise fetches it — honoring
+        the `preferred_monitor` setting (#72) when present.
         """
         try:
             if fresh_taskbar_info:
                 self._state.taskbar_info = fresh_taskbar_info
             else:
-                self._state.taskbar_info = get_taskbar_info()
+                preferred = self._state.config.get('preferred_monitor')
+                self._state.taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
             if self._apply_saved_position():
                 return
@@ -555,8 +557,9 @@ class PositionManager(QObject):
             return
 
         try:
-            # We re-fetch info here to be accurate
-            tb_info = get_taskbar_info()
+            # We re-fetch info here to be accurate, honoring preferred monitor.
+            preferred = self._state.config.get('preferred_monitor')
+            tb_info = get_taskbar_info(preferred_screen_name=preferred)
             if not tb_info:
                 return
 
@@ -579,7 +582,8 @@ class PositionManager(QObject):
         Helper for InputHandler to constrain dragging.
         """
         if not self._state.taskbar_info:
-             self._state.taskbar_info = get_taskbar_info()
+             preferred = self._state.config.get('preferred_monitor')
+             self._state.taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
         # FIX for #87: specific check for Free Move
         if self._state.config.get("free_move", False):

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -217,6 +217,30 @@ class TestPositionManager(unittest.TestCase):
             # Should NOT have been moved to the disconnected coords.
             self.mock_widget.move.assert_called_with(1500, 1040)
 
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_update_position_passes_preferred_monitor(self, mock_get_info):
+        """#72: update_position must forward `preferred_monitor` to get_taskbar_info."""
+        mock_get_info.return_value = self.mock_taskbar
+        self.config['preferred_monitor'] = '\\\\.\\DISPLAY2'
+
+        with patch.object(self.manager._calculator, 'calculate_position',
+                          return_value=ScreenPosition(0, 0)):
+            self.manager.update_position()
+
+        mock_get_info.assert_called_with(preferred_screen_name='\\\\.\\DISPLAY2')
+
+    @patch('netspeedtray.core.position_manager.get_taskbar_info')
+    def test_update_position_no_preferred_monitor_passes_none(self, mock_get_info):
+        """When the user hasn't set a preference, pass None — preserves legacy primary behavior."""
+        mock_get_info.return_value = self.mock_taskbar
+        # self.config has no 'preferred_monitor' key
+
+        with patch.object(self.manager._calculator, 'calculate_position',
+                          return_value=ScreenPosition(0, 0)):
+            self.manager.update_position()
+
+        mock_get_info.assert_called_with(preferred_screen_name=None)
+
     @patch('PyQt6.QtWidgets.QApplication.screenAt')
     @patch('netspeedtray.core.position_manager.get_taskbar_info')
     def test_free_move_clamps_off_edge_position(self, mock_get_info, mock_screen_at):

--- a/src/netspeedtray/tests/unit/test_settings_pages.py
+++ b/src/netspeedtray/tests/unit/test_settings_pages.py
@@ -109,6 +109,8 @@ def mock_i18n():
     i18n.UPDATE_MODE_EFFICIENT_LABEL = "Efficient"
     i18n.UPDATE_MODE_POWER_SAVER_LABEL = "Power Saver"
     i18n.CHECK_FOR_UPDATES_LABEL = "Check for updates on startup"
+    i18n.PREFERRED_MONITOR_LABEL = "Preferred Monitor"
+    i18n.PREFERRED_MONITOR_PRIMARY = "Primary (auto)"
 
     # Font Weight Labels (used in Win11Slider.setValueText)
     for key in constants.fonts.WEIGHT_MAP.values():

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -543,24 +543,48 @@ def get_all_taskbar_info() -> List[TaskbarInfo]:
     return taskbars
 
 
-def get_taskbar_info() -> TaskbarInfo:
+def get_taskbar_info(preferred_screen_name: Optional[str] = None) -> TaskbarInfo:
     """
-    Retrieves information about the primary taskbar.
+    Retrieves the taskbar to attach the widget to.
 
-    Selects the taskbar marked as primary from the list returned by
-    `get_all_taskbar_info()`. If no primary is explicitly found, it defaults
-    to the first taskbar in the list (which includes fallback handling).
+    By default returns the primary taskbar. If `preferred_screen_name` is
+    given and a secondary taskbar exists on that screen, returns *that*
+    taskbar instead — this is the implementation hook for the user-facing
+    "Preferred Monitor" setting (#72).
+
+    If the preferred screen is no longer present (monitor disconnected,
+    settings imported from a different machine, etc.), gracefully falls
+    back to the primary taskbar and logs the fallback at INFO so users
+    can see why their preference wasn't honored.
+
+    Args:
+        preferred_screen_name: Optional QScreen.name() (e.g. "\\\\.\\DISPLAY2").
 
     Returns:
-        TaskbarInfo: Details of the primary taskbar (or fallback).
+        TaskbarInfo for the preferred screen if found, else primary, else fallback.
     """
     try:
         all_taskbars = get_all_taskbar_info()
+
+        if preferred_screen_name:
+            for tb in all_taskbars:
+                screen = tb.get_screen()
+                if screen is not None and screen.name() == preferred_screen_name:
+                    logger.debug(
+                        "Preferred taskbar selected for screen '%s': HWND=%s",
+                        preferred_screen_name, tb.hwnd,
+                    )
+                    return tb
+            logger.info(
+                "Preferred monitor '%s' not found among %d taskbars; falling back to primary.",
+                preferred_screen_name, len(all_taskbars),
+            )
+
         primary_taskbar = next((tb for tb in all_taskbars if tb.is_primary), all_taskbars[0])
         logger.debug("Primary taskbar selected: HWND=%s (Is fallback: %s)", primary_taskbar.hwnd, primary_taskbar.hwnd == 0)
         return primary_taskbar
     except Exception as e:
-        logger.error("Error selecting primary taskbar info: %s. Returning fallback.", e, exc_info=True)
+        logger.error("Error selecting taskbar info: %s. Returning fallback.", e, exc_info=True)
         try:
             return TaskbarInfo.create_primary_fallback_taskbar_info()
         except RuntimeError:

--- a/src/netspeedtray/views/settings/pages/general.py
+++ b/src/netspeedtray/views/settings/pages/general.py
@@ -116,19 +116,50 @@ class GeneralPage(QWidget):
         entries are real QScreens labeled with their resolution. We store
         the screen's name() as userData so reselection survives reboots,
         while showing a friendlier label.
+
+        Called on construction AND on every showEvent so users who plug in
+        a monitor after the app started still see it in the dropdown.
         """
+        # Remember the current selection so we can preserve it across refresh.
+        previous_selection = self.preferred_monitor_combo.currentData() if self.preferred_monitor_combo.count() else None
+
+        # Temporarily disconnect to avoid firing on_change during the rebuild.
+        try:
+            self.preferred_monitor_combo.currentIndexChanged.disconnect(self.on_change)
+        except (TypeError, RuntimeError):
+            pass
+
         self.preferred_monitor_combo.clear()
         self.preferred_monitor_combo.addItem(self.i18n.PREFERRED_MONITOR_PRIMARY, userData=None)
 
         app = QGuiApplication.instance()
-        if app is None:
-            return
-        primary = app.primaryScreen()
-        for i, screen in enumerate(app.screens(), start=1):
-            geom = screen.geometry()
-            tag = " (primary)" if screen is primary else ""
-            label = f"Monitor {i}: {geom.width()}x{geom.height()}{tag}"
-            self.preferred_monitor_combo.addItem(label, userData=screen.name())
+        if app is not None:
+            primary = app.primaryScreen()
+            for i, screen in enumerate(app.screens(), start=1):
+                geom = screen.geometry()
+                tag = " (primary)" if screen is primary else ""
+                label = f"Monitor {i}: {geom.width()}x{geom.height()}{tag}"
+                self.preferred_monitor_combo.addItem(label, userData=screen.name())
+
+        # Restore previous selection if it still exists; otherwise fall back to "Primary (auto)".
+        if previous_selection is not None:
+            idx = self.preferred_monitor_combo.findData(previous_selection)
+            if idx >= 0:
+                self.preferred_monitor_combo.setCurrentIndex(idx)
+
+        # Reconnect the change signal.
+        self.preferred_monitor_combo.currentIndexChanged.connect(self.on_change)
+
+    def showEvent(self, event):  # type: ignore[override]
+        """Refresh the monitor dropdown whenever the page becomes visible.
+
+        Catches the case where a user plugs/unplugs a monitor while the app
+        is running, then opens Settings — the dropdown should reflect the
+        current monitor topology, not the topology at app launch.
+        """
+        super().showEvent(event)
+        if hasattr(self, "preferred_monitor_combo"):
+            self._populate_monitor_combo()
 
     def load_settings(self, config: Dict[str, Any], is_startup_enabled: bool):
         # Language

--- a/src/netspeedtray/views/settings/pages/general.py
+++ b/src/netspeedtray/views/settings/pages/general.py
@@ -1,9 +1,10 @@
 """
 General Settings Page.
 """
-from typing import Dict, Any, Callable
+from typing import Dict, Any, Callable, Optional
 
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QGuiApplication
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QGroupBox, QComboBox, QLabel, QGridLayout
 
 from netspeedtray import constants
@@ -94,11 +95,40 @@ class GeneralPage(QWidget):
         behavior_layout.addWidget(cfu_label, 4, 0, Qt.AlignmentFlag.AlignVCenter)
         behavior_layout.addWidget(self.check_for_updates, 4, 1, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
 
+        # Preferred Monitor (#72) — lets users pin the widget to a specific
+        # display in multi-monitor setups. Default (no selection) uses primary.
+        behavior_layout.addWidget(QLabel(self.i18n.PREFERRED_MONITOR_LABEL), 5, 0, Qt.AlignmentFlag.AlignVCenter)
+        self.preferred_monitor_combo = QComboBox()
+        self._populate_monitor_combo()
+        self.preferred_monitor_combo.currentIndexChanged.connect(self.on_change)
+        behavior_layout.addWidget(self.preferred_monitor_combo, 5, 1, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+
         behavior_layout.setColumnStretch(0, 0)
         behavior_layout.setColumnStretch(1, 1)
         layout.addWidget(behavior_group)
-        
+
         layout.addStretch()
+
+    def _populate_monitor_combo(self) -> None:
+        """Fill the preferred-monitor dropdown with detected screens.
+
+        First entry is always "Primary (auto)" mapped to None. Subsequent
+        entries are real QScreens labeled with their resolution. We store
+        the screen's name() as userData so reselection survives reboots,
+        while showing a friendlier label.
+        """
+        self.preferred_monitor_combo.clear()
+        self.preferred_monitor_combo.addItem(self.i18n.PREFERRED_MONITOR_PRIMARY, userData=None)
+
+        app = QGuiApplication.instance()
+        if app is None:
+            return
+        primary = app.primaryScreen()
+        for i, screen in enumerate(app.screens(), start=1):
+            geom = screen.geometry()
+            tag = " (primary)" if screen is primary else ""
+            label = f"Monitor {i}: {geom.width()}x{geom.height()}{tag}"
+            self.preferred_monitor_combo.addItem(label, userData=screen.name())
 
     def load_settings(self, config: Dict[str, Any], is_startup_enabled: bool):
         # Language
@@ -124,6 +154,14 @@ class GeneralPage(QWidget):
         # Tray Offset
         self.tray_offset.setValue(config.get("tray_offset_x", 0))
 
+        # Preferred monitor (#72) — match by stored screen name.
+        # If the saved monitor name doesn't match any detected screen (e.g.,
+        # monitor was disconnected since last save), the combo just stays at
+        # "Primary (auto)" and the runtime fallback in position_manager kicks in.
+        preferred_name = config.get("preferred_monitor")
+        idx = self.preferred_monitor_combo.findData(preferred_name)
+        self.preferred_monitor_combo.setCurrentIndex(idx if idx >= 0 else 0)
+
     def get_settings(self) -> Dict[str, Any]:
         # Get slider position and convert to update_rate value
         slider_position = self.update_rate.value()
@@ -136,7 +174,8 @@ class GeneralPage(QWidget):
             "keep_visible_fullscreen": self.keep_visible_fullscreen.isChecked(),
             "start_with_windows": self.start_with_windows.isChecked(),
             "tray_offset_x": self.tray_offset.value(),
-            "check_for_updates": self.check_for_updates.isChecked()
+            "check_for_updates": self.check_for_updates.isChecked(),
+            "preferred_monitor": self.preferred_monitor_combo.currentData(),
         }
 
     def _on_update_rate_changed(self, value: int) -> None:


### PR DESCRIPTION
## Summary
Phase 3a of v1.3.2. Closes [#72](https://github.com/erez-c137/NetSpeedTray/issues/72), promised in January.

A new dropdown in Settings → General lets users pin the widget to a specific monitor in multi-monitor setups instead of always landing on the primary taskbar.

> **Stacked on [#140](https://github.com/erez-c137/NetSpeedTray/pull/140)** (multi-monitor free-move restore). Merge #140 first, then this rebases cleanly.

## Why both PRs together fix multi-monitor pain
- **#140** ensured that *if* you dragged the widget to monitor 2, it would be restored there.
- **#72 (this PR)** ensures that you can *explicitly choose* monitor 2 without having to drag.

Together they address the recurring complaints in [#138](https://github.com/erez-c137/NetSpeedTray/issues/138) ("takes resolution from second, moves gadget on first") and [#133](https://github.com/erez-c137/NetSpeedTray/issues/133) (free-move on secondary).

## Implementation
- New config key \`preferred_monitor\` storing \`QScreen.name()\` — a stable Windows identifier like \`\\.\DISPLAY1\` that persists across reboots.
- \`get_taskbar_info()\` gains an optional \`preferred_screen_name\` parameter. Walks all detected taskbars and returns the one belonging to that screen, falling back to primary (with INFO log) if not found.
- \`PositionManager\` forwards the setting in \`update_position()\`, \`_check_for_tray_changes\`, and \`constrain_drag\`.
- Settings → General gets a new dropdown listing detected monitors with resolution labels. First entry is "Primary (auto)" mapped to None.

## Backward compatibility
- Default \`None\` preserves existing primary-monitor behavior for every existing user.
- Saved-but-disconnected monitor names trigger graceful fallback to primary, with an INFO log explaining why.

## Test plan
- [x] **2 new tests** (\`test_update_position_passes_preferred_monitor\`, \`test_update_position_no_preferred_monitor_passes_none\`)
- [x] Existing #133 multi-monitor restore tests still pass unchanged
- [x] Mock i18n updated with 2 new keys
- [x] Locale parity test passes
- [x] Full unit suite: 148 passed (up from 146 on PR #140)
- [ ] **Manual on multi-monitor setup:** Pick a non-primary monitor in the dropdown, save, verify widget appears on that monitor's taskbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)