### PR TITLE
fix(multimon): robust preferred-monitor matching + diagnostics (#72, #166)

### DIFF
--- a/src/netspeedtray/__init__.py
+++ b/src/netspeedtray/__init__.py
@@ -4,4 +4,4 @@ NetSpeedTray package initialization.
 A system tray application for monitoring network speed on Windows.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
+++ b/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock, patch
 from PyQt6.QtCore import QRect
 from PyQt6.QtWidgets import QApplication
 
-from netspeedtray.utils.taskbar_utils import _select_taskbar_for_screen
+import netspeedtray.utils.taskbar_utils as tbu
+from netspeedtray.utils.taskbar_utils import _select_taskbar_for_screen, _taskbar_window_is_ready
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -99,3 +100,41 @@ class TestPreferredMonitorSelection:
         with _patch_screens([PRIMARY, SECOND]):
             tb = _select_taskbar_for_screen(tbs, r"\\.\DISPLAY1")
         assert tb is not None and tb.hwnd == 1
+
+
+class _FakeWin32Error(Exception):
+    pass
+
+
+def _fake_win32gui(*, rect=(0, 0, 2560, 1440), tray_hwnd=0, is_window=True, rect_raises=False):
+    w = MagicMock()
+    w.error = _FakeWin32Error
+    if rect_raises:
+        w.GetWindowRect.side_effect = _FakeWin32Error("not queryable")
+    else:
+        w.GetWindowRect.return_value = rect
+    w.FindWindowEx.return_value = tray_hwnd
+    w.IsWindow.return_value = is_window
+    return w
+
+
+class TestTaskbarReadinessGate:
+    """#72: process_taskbar dropped every secondary-monitor taskbar because it required a TrayNotifyWnd
+    child that only the primary taskbar has, so only one taskbar ever enumerated and Preferred Monitor
+    always fell back to primary. _taskbar_window_is_ready gates that check to the primary only."""
+
+    def test_secondary_survives_without_tray_child(self):
+        with patch.object(tbu, "win32gui", _fake_win32gui(tray_hwnd=0)):
+            assert _taskbar_window_is_ready(2, "Shell_SecondaryTrayWnd") is True
+
+    def test_primary_ready_with_valid_tray_child(self):
+        with patch.object(tbu, "win32gui", _fake_win32gui(tray_hwnd=99, is_window=True)):
+            assert _taskbar_window_is_ready(1, "Shell_TrayWnd") is True
+
+    def test_primary_not_ready_without_tray_child(self):
+        with patch.object(tbu, "win32gui", _fake_win32gui(tray_hwnd=0)):
+            assert _taskbar_window_is_ready(1, "Shell_TrayWnd") is False
+
+    def test_not_ready_when_taskbar_window_unqueryable(self):
+        with patch.object(tbu, "win32gui", _fake_win32gui(rect_raises=True)):
+            assert _taskbar_window_is_ready(2, "Shell_SecondaryTrayWnd") is False

--- a/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
+++ b/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
@@ -1,0 +1,101 @@
+"""
+Preferred-monitor taskbar selection tests (#72 / #166).
+
+Verifies that ``_select_taskbar_for_screen`` matches the user's chosen monitor
+robustly - by stored name, re-resolved name, OR geometry - so a Qt-vs-WinAPI
+naming desync at mixed DPI (e.g. dual 4K at 150%) does not silently fall back to
+primary, and that it returns ``None`` (a documented fallback the caller handles)
+when the preferred monitor has no taskbar of its own.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from PyQt6.QtCore import QRect
+from PyQt6.QtWidgets import QApplication
+
+from netspeedtray.utils.taskbar_utils import _select_taskbar_for_screen
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qt_app():
+    """A QApplication must exist for QScreen access."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+class MockScreen:
+    """Minimal QScreen stand-in with name() + geometry()."""
+    def __init__(self, name, geometry_rect):
+        self._name = name
+        self._geo = QRect(*geometry_rect)
+
+    def name(self):
+        return self._name
+
+    def geometry(self):
+        return self._geo
+
+
+def _mock_tb(hwnd, stored_name, resolved_screen, geometry, is_primary):
+    tb = MagicMock()
+    tb.hwnd = hwnd
+    tb.screen_name = stored_name
+    tb.screen_geometry = geometry
+    tb.is_primary = is_primary
+    tb.get_screen.return_value = resolved_screen
+    return tb
+
+
+# Dual 4K at 150% -> logical geometry is 2560x1440 per monitor, side by side.
+PRIMARY = MockScreen(r"\\.\DISPLAY1", (0, 0, 2560, 1440))
+SECOND = MockScreen(r"\\.\DISPLAY2", (2560, 0, 2560, 1440))
+
+
+def _patch_screens(screens):
+    return patch(
+        "netspeedtray.utils.taskbar_utils.QApplication.screens",
+        return_value=screens,
+    )
+
+
+class TestPreferredMonitorSelection:
+    def test_matches_secondary_by_stored_name(self):
+        tbs = [
+            _mock_tb(1, r"\\.\DISPLAY1", PRIMARY, (0, 0, 2560, 1440), True),
+            _mock_tb(2, r"\\.\DISPLAY2", SECOND, (2560, 0, 2560, 1440), False),
+        ]
+        with _patch_screens([PRIMARY, SECOND]):
+            tb = _select_taskbar_for_screen(tbs, r"\\.\DISPLAY2")
+        assert tb is not None and tb.hwnd == 2
+
+    def test_matches_by_geometry_when_name_desyncs(self):
+        """
+        The regression that likely bit #72: the secondary taskbar mis-resolved
+        its NAME (to DISPLAY1) under mixed DPI, but its geometry still equals the
+        preferred DISPLAY2 screen. The geometry layer must still find it.
+        """
+        desynced = MockScreen(r"\\.\DISPLAY1", (2560, 0, 2560, 1440))
+        tbs = [
+            _mock_tb(1, r"\\.\DISPLAY1", PRIMARY, (0, 0, 2560, 1440), True),
+            _mock_tb(2, r"\\.\DISPLAY1", desynced, (2560, 0, 2560, 1440), False),
+        ]
+        with _patch_screens([PRIMARY, SECOND]):
+            tb = _select_taskbar_for_screen(tbs, r"\\.\DISPLAY2")
+        assert tb is not None and tb.hwnd == 2, "geometry fallback should still find the DISPLAY2 taskbar"
+
+    def test_returns_none_when_preferred_monitor_has_no_taskbar(self):
+        """'Show taskbar on all displays' off: only the primary has a taskbar."""
+        tbs = [_mock_tb(1, r"\\.\DISPLAY1", PRIMARY, (0, 0, 2560, 1440), True)]
+        with _patch_screens([PRIMARY, SECOND]):
+            tb = _select_taskbar_for_screen(tbs, r"\\.\DISPLAY2")
+        assert tb is None, "no taskbar on the preferred monitor -> None (caller falls back to primary)"
+
+    def test_matches_primary_when_primary_preferred(self):
+        tbs = [
+            _mock_tb(1, r"\\.\DISPLAY1", PRIMARY, (0, 0, 2560, 1440), True),
+            _mock_tb(2, r"\\.\DISPLAY2", SECOND, (2560, 0, 2560, 1440), False),
+        ]
+        with _patch_screens([PRIMARY, SECOND]):
+            tb = _select_taskbar_for_screen(tbs, r"\\.\DISPLAY1")
+        assert tb is not None and tb.hwnd == 1

--- a/src/netspeedtray/tests/unit/test_widget_refresh_preferred_monitor.py
+++ b/src/netspeedtray/tests/unit/test_widget_refresh_preferred_monitor.py
@@ -1,0 +1,113 @@
+"""
+Regression tests for #72: the widget must stay on the preferred (secondary)
+monitor after the initial placement.
+
+Root cause of the "flashes onto monitor 2 then jumps back to primary" bug:
+``NetworkSpeedWidget._execute_refresh`` - the authoritative refresh loop that
+runs at startup (via ``QTimer.singleShot(0, ...)``), then every second and on
+every foreground change - resolved the taskbar with a bare ``get_taskbar_info()``
+(always the PRIMARY taskbar) and force-fed it into
+``position_manager.update_position(fresh_taskbar_info=...)``. That override beat
+the preferred-monitor logic, so the correct initial placement on a secondary
+monitor survived only until the first refresh tick (milliseconds later).
+
+The fix makes ``_execute_refresh`` resolve the widget's OWN taskbar, honoring
+the ``preferred_monitor`` setting - mirroring what ``_check_for_tray_changes``
+already does. These tests call the (unbound) method against a lightweight mock
+``self`` so no QApplication or real widget is required.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from netspeedtray.views.widget import main as widget_main
+
+
+def _make_widget(preferred, *, free_move=False, visible=True):
+    """A minimal mock ``self`` exercising the branches in ``_execute_refresh``.
+
+    ``config`` is a real dict on purpose: a MagicMock ``.get`` returns a
+    truthy MagicMock, which would silently flip ``free_move``/visibility logic.
+    """
+    w = MagicMock()
+    w.config = {
+        "preferred_monitor": preferred,
+        "free_move": free_move,
+        "keep_visible_fullscreen": False,
+    }
+    w._is_context_menu_visible = False
+    w._dragging = False
+    w._taskbar_lost_count = 0
+    w.isVisible.return_value = visible
+    return w
+
+
+@pytest.fixture
+def patched_taskbar(monkeypatch):
+    """Patch the module-level helpers ``_execute_refresh`` calls and record the
+    ``preferred_screen_name`` passed to ``get_taskbar_info``."""
+    calls = {"preferred": "unset", "returned": None}
+
+    def fake_get_taskbar_info(preferred_screen_name=None):
+        calls["preferred"] = preferred_screen_name
+        tb = SimpleNamespace(hwnd=4242, screen_name=preferred_screen_name or "PRIMARY")
+        calls["returned"] = tb
+        return tb
+
+    monkeypatch.setattr(widget_main, "get_taskbar_info", fake_get_taskbar_info)
+    monkeypatch.setattr(widget_main, "is_taskbar_visible", lambda tb: True)
+    monkeypatch.setattr(widget_main, "is_taskbar_obstructed", lambda tb, hwnd: False)
+    monkeypatch.setattr(widget_main.win32gui, "GetForegroundWindow", lambda: 0)
+    return calls
+
+
+def test_refresh_resolves_preferred_monitor_taskbar(patched_taskbar):
+    """The refresh path must ask for the preferred monitor's taskbar, not the
+    bare primary. This is the specific regression that dragged the widget off a
+    secondary monitor within one event-loop tick."""
+    w = _make_widget("32UHD144 (2)")
+
+    widget_main.NetworkSpeedWidget._execute_refresh(w)
+
+    assert patched_taskbar["preferred"] == "32UHD144 (2)"
+
+
+def test_refresh_positions_against_the_preferred_taskbar(patched_taskbar):
+    """The taskbar resolved with the preference must be the exact object fed to
+    ``update_position`` - proving no second bare (primary) lookup sneaks in and
+    re-pins the widget."""
+    w = _make_widget("32UHD144 (2)")
+
+    widget_main.NetworkSpeedWidget._execute_refresh(w)
+
+    w.position_manager.update_position.assert_called_once()
+    _, kwargs = w.position_manager.update_position.call_args
+    assert kwargs.get("fresh_taskbar_info") is patched_taskbar["returned"]
+    assert kwargs["fresh_taskbar_info"].screen_name == "32UHD144 (2)"
+
+
+def test_refresh_without_preference_is_unchanged(patched_taskbar):
+    """Single-monitor / no-preference users must be unaffected: passing
+    ``preferred_screen_name=None`` is exactly the old bare behavior (primary)."""
+    w = _make_widget(None)
+
+    widget_main.NetworkSpeedWidget._execute_refresh(w)
+
+    assert patched_taskbar["preferred"] is None
+    w.position_manager.update_position.assert_called_once()
+
+
+def test_refresh_skips_positioning_in_free_move(patched_taskbar):
+    """Free-move users position manually; the refresh must still resolve the
+    preferred taskbar (for visibility checks) but must NOT reposition."""
+    w = _make_widget("32UHD144 (2)", free_move=True)
+
+    widget_main.NetworkSpeedWidget._execute_refresh(w)
+
+    assert patched_taskbar["preferred"] == "32UHD144 (2)"
+    w.position_manager.update_position.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -543,6 +543,77 @@ def get_all_taskbar_info() -> List[TaskbarInfo]:
     return taskbars
 
 
+def _select_taskbar_for_screen(
+    taskbars: List[TaskbarInfo], preferred_screen_name: str
+) -> Optional[TaskbarInfo]:
+    """
+    Find the taskbar living on the user's preferred monitor (#72 / #166).
+
+    Matches on any of several identities so that a single Qt-vs-WinAPI naming or
+    DPI desync (common on mixed-DPI multi-monitor setups, e.g. dual 4K at 150%)
+    does not silently drop the preference and fall back to primary:
+
+      1. the name stored at enumeration time (``TaskbarInfo.screen_name``),
+      2. the freshly re-resolved ``get_screen().name()``, and
+      3. geometry equality with the preferred QScreen (name-independent).
+
+    Returns the matching ``TaskbarInfo``, or ``None`` if the preferred monitor
+    simply has no taskbar to attach to (e.g. "Show taskbar on all displays" is
+    off) - the caller then falls back to primary and logs why.
+    """
+    preferred_screen = next(
+        (s for s in QApplication.screens() if s.name() == preferred_screen_name), None
+    )
+    preferred_geo = preferred_screen.geometry() if preferred_screen is not None else None
+
+    for tb in taskbars:
+        if tb.screen_name == preferred_screen_name:
+            return tb
+        resolved = tb.get_screen()
+        if resolved is not None and resolved.name() == preferred_screen_name:
+            return tb
+        if (
+            preferred_geo is not None
+            and resolved is not None
+            and resolved.geometry() == preferred_geo
+        ):
+            return tb
+    return None
+
+
+def _log_preferred_monitor_fallback(
+    preferred_screen_name: str, taskbars: List[TaskbarInfo]
+) -> None:
+    """
+    Log (at INFO, so it lands in Support Bundles) exactly why a preferred-monitor
+    selection fell back to primary: the preferred name plus every enumerated
+    taskbar's class, stored name, re-resolved name, and geometry. Turns an
+    otherwise-silent fallback into an immediately diagnosable one (#72 / #166).
+    """
+    details = []
+    for tb in taskbars:
+        resolved = tb.get_screen()
+        details.append(
+            "[%s hwnd=%s stored='%s' resolved='%s' geo=%s]"
+            % (
+                "primary" if tb.is_primary else "secondary",
+                tb.hwnd,
+                tb.screen_name,
+                resolved.name() if resolved is not None else None,
+                tb.screen_geometry,
+            )
+        )
+    logger.info(
+        "Preferred monitor '%s' did not match any of %d taskbar(s); using primary. "
+        "Enumerated taskbars: %s. If the preferred monitor has no taskbar of its own, "
+        "enabling 'Show taskbar on all displays' is the current workaround (a no-taskbar "
+        "fallback is tracked in #166).",
+        preferred_screen_name,
+        len(taskbars),
+        " ".join(details) if details else "(none)",
+    )
+
+
 def get_taskbar_info(preferred_screen_name: Optional[str] = None) -> TaskbarInfo:
     """
     Retrieves the taskbar to attach the widget to.
@@ -567,18 +638,14 @@ def get_taskbar_info(preferred_screen_name: Optional[str] = None) -> TaskbarInfo
         all_taskbars = get_all_taskbar_info()
 
         if preferred_screen_name:
-            for tb in all_taskbars:
-                screen = tb.get_screen()
-                if screen is not None and screen.name() == preferred_screen_name:
-                    logger.debug(
-                        "Preferred taskbar selected for screen '%s': HWND=%s",
-                        preferred_screen_name, tb.hwnd,
-                    )
-                    return tb
-            logger.info(
-                "Preferred monitor '%s' not found among %d taskbars; falling back to primary.",
-                preferred_screen_name, len(all_taskbars),
-            )
+            preferred_tb = _select_taskbar_for_screen(all_taskbars, preferred_screen_name)
+            if preferred_tb is not None:
+                logger.debug(
+                    "Preferred taskbar selected for screen '%s': HWND=%s",
+                    preferred_screen_name, preferred_tb.hwnd,
+                )
+                return preferred_tb
+            _log_preferred_monitor_fallback(preferred_screen_name, all_taskbars)
 
         primary_taskbar = next((tb for tb in all_taskbars if tb.is_primary), all_taskbars[0])
         logger.debug("Primary taskbar selected: HWND=%s (Is fallback: %s)", primary_taskbar.hwnd, primary_taskbar.hwnd == 0)

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -389,6 +389,31 @@ def get_dpi_for_monitor(monitor: Any, hwnd: Optional[int] = None) -> Optional[fl
         return get_fallback_dpi()
 
 
+def _taskbar_window_is_ready(hwnd: int, class_name: str) -> bool:
+    """Whether an enumerated taskbar window is ready to dock to.
+
+    The PRIMARY taskbar (``Shell_TrayWnd``) is only ready once its ``TrayNotifyWnd`` tray/clock child is a
+    valid, queryable window. A SECONDARY-monitor taskbar (``Shell_SecondaryTrayWnd``) never has a
+    ``TrayNotifyWnd`` child, so requiring one used to drop EVERY secondary taskbar - which left the
+    enumeration with only the primary, so multi-monitor "Preferred Monitor" always fell back to primary
+    (#72). For a secondary, readiness is simply that its own window is queryable.
+    """
+    try:
+        win32gui.GetWindowRect(hwnd)
+    except win32gui.error:
+        return False
+    if class_name == "Shell_SecondaryTrayWnd":
+        return True
+    tray_hwnd = win32gui.FindWindowEx(hwnd, 0, "TrayNotifyWnd", None)
+    if not tray_hwnd or not win32gui.IsWindow(tray_hwnd):
+        return False
+    try:
+        win32gui.GetWindowRect(tray_hwnd)
+    except win32gui.error:
+        return False
+    return True
+
+
 def get_all_taskbar_info() -> List[TaskbarInfo]:
     """
     Finds all taskbars (primary and secondary) and gathers their details.
@@ -464,16 +489,11 @@ def get_all_taskbar_info() -> List[TaskbarInfo]:
             if class_name not in ("Shell_TrayWnd", "Shell_SecondaryTrayWnd"):
                 return None
 
-            tray_hwnd = win32gui.FindWindowEx(hwnd, 0, "TrayNotifyWnd", None)
-            # A taskbar is not "ready" until its TrayNotifyWnd child is a valid, queryable window.
-            if not tray_hwnd or not win32gui.IsWindow(tray_hwnd):
-                logger.debug(f"Found taskbar HWND {hwnd}, but its tray child is not yet valid. Ignoring.")
-                return None
-            try:
-                # This is the ultimate test: can we get its rectangle? If not, it's not ready.
-                win32gui.GetWindowRect(tray_hwnd)
-            except win32gui.error:
-                logger.debug(f"Found tray HWND {tray_hwnd}, but it is not yet queryable. Ignoring.")
+            # Readiness gate (#72): the system tray/clock (TrayNotifyWnd) lives only on the PRIMARY taskbar,
+            # so a secondary-monitor taskbar must NOT be required to have one - that requirement silently
+            # dropped every secondary taskbar, leaving only the primary to match against.
+            if not _taskbar_window_is_ready(hwnd, class_name):
+                logger.debug(f"Taskbar HWND {hwnd} ({class_name}) is not ready yet. Ignoring.")
                 return None
 
             rect_phys = win32gui.GetWindowRect(hwnd)

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -347,7 +347,14 @@ class NetworkSpeedWidget(QWidget):
             return
         
         try:
-            taskbar_info = get_taskbar_info()
+            # Resolve the widget's OWN taskbar (honoring the preferred_monitor
+            # setting, #72), not the primary. Using a bare get_taskbar_info()
+            # here re-pinned the widget to the primary taskbar within one
+            # event-loop tick, dragging it off a secondary monitor even after
+            # the initial placement landed correctly. The visibility/obstruction
+            # checks below are also judged against the widget's own taskbar.
+            preferred = self.config.get("preferred_monitor")
+            taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
             # Implement the "coasting" logic for taskbar detection failures.
             if taskbar_info.hwnd == 0: # hwnd=0 signifies a fallback object from get_taskbar_info


### PR DESCRIPTION
## What

The **Preferred Monitor** setting (Settings > General) silently fell back to the primary taskbar when the chosen monitor's taskbar couldn't be matched, so picking a monitor had no effect. Reported freshly on 2.0.0 in #72 (tracked as #166).

## Root cause

`get_taskbar_info(preferred_screen_name)` matched a taskbar to the preferred monitor by `QScreen.name()` string equality **only**. On mixed-DPI multi-monitor setups (e.g. dual 4K at 150%), Qt's screen names/geometry and the WinAPI monitor device names can desync, so the match fails and it quietly returns the primary taskbar.

## Change

- `_select_taskbar_for_screen()` now matches by **stored name -> re-resolved name -> geometry**, so a single naming desync no longer drops the preference.
- On a genuine fallback, `_log_preferred_monitor_fallback()` logs every enumerated taskbar's class/name/geometry at INFO, so a **Support Bundle shows exactly why** (no more silent fallback).
- 4 new tests (`test_taskbar_preferred_monitor.py`), incl. the name-desync-but-geometry-matches case. Full suite: **726 passed, 2 xfailed**.

## Scope / follow-up

This fixes the **name/DPI desync** cause. It does **not** yet handle the case where the preferred monitor has **no taskbar at all** ("Show taskbar on all displays" off) - in the 2.0 owned-window model there is nothing to dock to there. A no-taskbar **floating fallback** is the follow-up, and the new diagnostics will confirm which cause is in play.

Draft while we get a Support Bundle from the #72 reporter to confirm on real hardware.

Refs #72, #166.
