### PR TITLE
build: ~50% smaller installer/portable (fix onedir double-pack)

### DIFF
--- a/build/build-exe-only.bat
+++ b/build/build-exe-only.bat
@@ -85,9 +85,13 @@ set "start_time=%TIME%"
 set "UPX_DIR_ARG="
 if exist "%BUILD_DIR%tools\upx-5.0.2-win64\upx.exe" set "UPX_DIR_ARG=--upx-dir %BUILD_DIR%tools\upx-5.0.2-win64"
 
+:: EXE-only build = a single self-contained file (onefile mode). build.bat leaves
+:: this unset and gets the slim onedir folder instead. setlocal scopes this var.
+set "NST_ONEFILE=1"
+
 "%ROOT_DIR%\.venv\Scripts\python.exe" -m PyInstaller --noconfirm --distpath "%DIST_DIR%" %UPX_DIR_ARG% netspeedtray.spec >> "%LOG_FILE%" 2>&1
 if errorlevel 1 (echo ERROR: PyInstaller compilation failed. Check %LOG_FILE% for details & exit /b 1)
-if not exist "%DIST_DIR%\NetSpeedTray\NetSpeedTray.exe" (echo ERROR: Executable not found after compilation & exit /b 1)
+if not exist "%DIST_DIR%\NetSpeedTray.exe" (echo ERROR: Executable not found after compilation & exit /b 1)
 set "end_time=%TIME%"
 call :log_elapsed "Compiling executable" "%start_time%" "%end_time%"
 
@@ -97,7 +101,7 @@ echo Moving executable to output directory...
 echo Moving executable to output directory... >> "%LOG_FILE%"
 set "start_time=%TIME%"
 mkdir "%OUTPUT_DIR%" 2>nul
-move "%DIST_DIR%\NetSpeedTray\NetSpeedTray.exe" "%OUTPUT_DIR%\NetSpeedTray-v%VERSION%.exe" > NUL
+move "%DIST_DIR%\NetSpeedTray.exe" "%OUTPUT_DIR%\NetSpeedTray-v%VERSION%.exe" > NUL
 if errorlevel 1 (echo ERROR: Failed to move executable & exit /b 1)
 set "end_time=%TIME%"
 call :log_elapsed "Moving executable" "%start_time%" "%end_time%"

--- a/build/netspeedtray.spec
+++ b/build/netspeedtray.spec
@@ -320,36 +320,74 @@ upx_exclude = [
 # Note: PyInstaller already auto-disables UPX for Qt plugins (e.g. qwindows.dll)
 # and CFG-enabled binaries, so those need no manual entry here.
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    [],
-    a.binaries,
-    a.datas,
-    name='NetSpeedTray',
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=bool(upx_dir),
-    upx_dir=upx_dir,
-    upx_exclude=upx_exclude,
-    runtime_tmpdir=None,
-    console=False,
-    disable_windowed_traceback=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-    icon='..\\assets\\NetSpeedTray.ico',
-    version='version_info.txt'
-)
+# --- Build mode: ONEDIR (release, default) vs ONEFILE (dev/test) ---
+# ONEDIR (default): a small bootstrap exe + an `_internal/` folder that holds the
+#   dependencies exactly once. Roughly HALF the size of onefile, and faster to
+#   launch (no self-extraction to a temp dir on every run). This is what
+#   build.bat ships (installer + portable zip) and what setup.iss expects.
+# ONEFILE (NST_ONEFILE=1): a single self-contained exe - convenient for quick
+#   testing or handing someone one portable file. Produced by build-exe-only.bat.
+#
+# The previous spec did BOTH at once: the EXE bundled a.binaries/a.datas
+# (onefile) AND COLLECT re-copied them loose into the folder, so the release
+# folder carried the whole payload twice (~2x on-disk). Splitting the two modes
+# fixes that.
+_onefile = bool(os.environ.get('NST_ONEFILE'))
 
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    strip=False,
-    upx=bool(upx_dir),
-    upx_exclude=upx_exclude,
-    name='NetSpeedTray'
-)
+if _onefile:
+    print('[netspeedtray.spec] Build mode: ONEFILE (single self-contained exe).')
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        a.binaries,
+        a.datas,
+        name='NetSpeedTray',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=bool(upx_dir),
+        upx_dir=upx_dir,
+        upx_exclude=upx_exclude,
+        runtime_tmpdir=None,
+        console=False,
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+        icon='..\\assets\\NetSpeedTray.ico',
+        version='version_info.txt'
+    )
+else:
+    print('[netspeedtray.spec] Build mode: ONEDIR (bootstrap exe + _internal/).')
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name='NetSpeedTray',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=bool(upx_dir),
+        upx_dir=upx_dir,
+        upx_exclude=upx_exclude,
+        runtime_tmpdir=None,
+        console=False,
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+        icon='..\\assets\\NetSpeedTray.ico',
+        version='version_info.txt'
+    )
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=bool(upx_dir),
+        upx_exclude=upx_exclude,
+        name='NetSpeedTray'
+    )


### PR DESCRIPTION
## What

The installer and portable zip were carrying every dependency **twice**, so they were roughly **2x larger** than necessary. This fixes that - about **half the download size**, with no functional change.

## Root cause

The spec built the exe **onefile** (bundling `a.binaries` / `a.datas` into the exe) **and then** ran `COLLECT`, which re-copied all those same dependencies **loose** into `dist/NetSpeedTray/`. So the release folder held the whole payload twice: once compressed inside the exe, once expanded alongside it. The app also effectively ran as onefile (self-extracting to a temp dir on launch).

## Change

- The spec now builds a **true onedir** by default: a small bootstrap exe + an `_internal/` folder holding the dependencies **once**. This is what `build.bat` and `setup.iss` already assumed (they ship `dist/NetSpeedTray/*` and wipe `_internal/` on upgrade), so **no changes were needed there**.
- A self-contained **onefile** is built only when `NST_ONEFILE=1`, which `build-exe-only.bat` sets - so the quick dev/test build is still a single portable exe.

## Result (measured on a v2.0.0 build)

| Artifact | Before | After | Cut |
|---|---|---|---|
| Installer | 86.9 MB | **41.5 MB** | **-52%** |
| Portable zip | 98.8 MB | **53.7 MB** | **-46%** |

Onedir also launches faster (no per-run temp extraction).

## Verified

- Onedir bundle loads and runs headless from a clean unzip of the portable: `NetSpeedTray.exe --export-csv --period 24h` exits 0 and writes valid CSV/JSON - proving the full numpy / sqlite / PyQt6 import chain resolves from `_internal/`.
- `build-exe-only.bat` still produces a working **54 MB standalone** onefile exe (via `NST_ONEFILE=1`).
- The existing OpenSSL bundle guard in the spec still passes.

## Possible follow-up (deliberately NOT in this PR)

The two biggest remaining files are `opengl32sw.dll` (~19.7 MB, Qt's software-OpenGL fallback) and numpy's OpenBLAS (~19.5 MB). OpenBLAS is required by numpy. `opengl32sw.dll` is a tempting cut for a pure Widgets/QPainter app that never touches OpenGL - but the spec deliberately keeps it as the "highest-risk cut" (some broken-GPU / RDP / VM setups fall back to it), so it should be tested on varied hardware before removing. It would shave a few more MB off both artifacts.
