### PR TITLE
fix(graph): CJK graph labels render with a system font, not tofu (#161)

### DIFF
--- a/src/netspeedtray/tests/unit/test_cjk_graph_font.py
+++ b/src/netspeedtray/tests/unit/test_cjk_graph_font.py
@@ -1,0 +1,95 @@
+"""
+CJK graph-font tests (#161).
+
+The matplotlib graph must not render tofu boxes (missing-glyph rectangles) for
+the axis / series labels under Japanese, Korean, or Chinese locales. These tests
+verify that the font we select actually contains a glyph for every character in
+the *real* localized labels (via FreeType's char->glyph index; index 0 is the
+".notdef"/tofu glyph). No screen or QApplication needed.
+
+On a machine without the relevant CJK system font (e.g. a barebones CI runner),
+the coverage tests skip rather than fail - matching the runtime behavior, where
+`configure_cjk_font` is a safe no-op if no CJK font is installed.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from netspeedtray.utils.mpl_fonts import (
+    pick_cjk_font,
+    configure_cjk_font,
+    _script_for_language,
+)
+
+_LOCALES_DIR = Path(__file__).resolve().parents[2] / "constants" / "locales"
+_GRAPH_LABEL_KEYS = ["DOWNLOAD_LABEL", "UPLOAD_LABEL", "ORDER_TYPE_CPU", "ORDER_TYPE_GPU"]
+
+
+def _load_labels(locale: str, keys):
+    data = json.loads((_LOCALES_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+    return {k: data[k] for k in keys if k in data and isinstance(data[k], str)}
+
+
+def _missing_glyphs(font_name: str, text: str):
+    """Chars in `text` that the named font has NO glyph for (would render as tofu)."""
+    import matplotlib.font_manager as fm
+    from matplotlib.ft2font import FT2Font
+
+    face = FT2Font(fm.findfont(fm.FontProperties(family=font_name)))
+    return [c for c in text if not c.isspace() and face.get_char_index(ord(c)) == 0]
+
+
+class TestScriptMapping:
+    def test_cjk_locales_map_to_scripts(self):
+        assert _script_for_language("ja_JP") == "ja"
+        assert _script_for_language("ko_KR") == "ko"
+        assert _script_for_language("zh_CN") == "zh"
+        assert _script_for_language("zh-TW") == "zh"
+
+    def test_non_cjk_and_empty_map_to_none(self):
+        for loc in ("en_US", "de_DE", "fr_FR", "ru_RU", "sl_SI", "", None):
+            assert _script_for_language(loc) is None
+
+
+class TestPickAndConfigure:
+    def test_non_cjk_is_a_noop(self):
+        for loc in ("en_US", "de_DE", "", None):
+            assert pick_cjk_font(loc) is None
+            assert configure_cjk_font(loc) is None
+
+    @pytest.mark.parametrize(
+        "locale, sample",
+        [("ja_JP", "使用率"), ("ko_KR", "사용량")],
+    )
+    def test_real_labels_have_no_tofu(self, locale, sample):
+        font = pick_cjk_font(locale)
+        if font is None:
+            pytest.skip(f"no {locale} system font installed (e.g. barebones CI runner)")
+
+        # A representative script sample must be fully covered.
+        assert not _missing_glyphs(font, sample), f"'{font}' lacks glyphs for {sample!r}"
+
+        # The ACTUAL shipped graph labels must be fully covered - this is the fix.
+        labels = _load_labels(locale, _GRAPH_LABEL_KEYS)
+        assert labels, f"no graph-label keys found in {locale}.json"
+        for key, text in labels.items():
+            missing = _missing_glyphs(font, text)
+            assert not missing, f"'{font}' lacks glyphs {missing} for {key}={text!r} ({locale})"
+
+    def test_configure_sets_rcparams(self):
+        import matplotlib as mpl
+
+        font = pick_cjk_font("ja_JP")
+        if font is None:
+            pytest.skip("no Japanese system font installed")
+
+        saved = {k: mpl.rcParams[k] for k in ("font.sans-serif", "font.family", "axes.unicode_minus")}
+        try:
+            chosen = configure_cjk_font("ja_JP")
+            assert chosen == font
+            assert mpl.rcParams["font.sans-serif"][0] == font, "CJK font must be first in the fallback list"
+            assert mpl.rcParams["axes.unicode_minus"] is False, "unicode minus disabled for CJK-font safety"
+        finally:
+            for k, v in saved.items():
+                mpl.rcParams[k] = v

--- a/src/netspeedtray/utils/mpl_fonts.py
+++ b/src/netspeedtray/utils/mpl_fonts.py
@@ -1,0 +1,98 @@
+"""
+Locale-aware CJK font selection for the matplotlib graph (#161).
+
+The graph's default font (DejaVu Sans, bundled with matplotlib) has no CJK
+glyphs, so the axis / peak / series labels render as tofu boxes (the empty
+rectangle) under Japanese, Korean, and Chinese locales. This module picks a
+CJK-capable font that already ships with Windows - a *system* font, so nothing
+is bundled and the installer stays slim - and points matplotlib at it for those
+locales only. Non-CJK locales are left completely untouched (DejaVu Sans as
+before).
+
+The picked fonts all cover Latin + digits too, so mixed labels (e.g. a
+localized word next to a number) render in one consistent font rather than
+mixing two.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+logger = logging.getLogger("NetSpeedTray.MplFonts")
+
+# Windows system fonts, best-first per script. Every entry also covers Latin.
+_CJK_CANDIDATES: Dict[str, List[str]] = {
+    "ja": ["Yu Gothic UI", "Yu Gothic", "Meiryo", "MS Gothic", "MS UI Gothic", "Microsoft YaHei"],
+    "ko": ["Malgun Gothic", "Gulim", "Dotum", "Batang", "Microsoft YaHei"],
+    "zh": ["Microsoft YaHei", "Microsoft JhengHei", "SimSun", "SimHei", "Malgun Gothic"],
+}
+
+
+def _script_for_language(language: Optional[str]) -> Optional[str]:
+    """Map a locale code (e.g. ``ja_JP``) to a CJK script key, or ``None``."""
+    if not language:
+        return None
+    lang = str(language).lower().replace("-", "_").split("_")[0]
+    if lang == "ja":
+        return "ja"
+    if lang == "ko":
+        return "ko"
+    if lang == "zh":
+        return "zh"
+    return None
+
+
+def pick_cjk_font(language: Optional[str]) -> Optional[str]:
+    """
+    Return the name of the first *installed* CJK font suitable for ``language``,
+    or ``None`` if the locale is not CJK or no candidate font is installed.
+
+    Pure function - no matplotlib state is mutated - so it is cheap and safe to
+    unit-test.
+    """
+    script = _script_for_language(language)
+    if script is None:
+        return None
+    try:
+        import matplotlib.font_manager as fm
+        installed = {f.name for f in fm.fontManager.ttflist}
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Could not enumerate installed fonts: %s", e)
+        return None
+    for name in _CJK_CANDIDATES[script]:
+        if name in installed:
+            return name
+    return None
+
+
+def configure_cjk_font(language: Optional[str]) -> Optional[str]:
+    """
+    If ``language`` is a CJK locale, point matplotlib's default sans-serif at an
+    installed CJK system font (prepended; DejaVu Sans kept as the Latin fallback)
+    and disable the fancy unicode minus (U+2212), which some CJK fonts lack.
+
+    Idempotent and safe to call on every graph render. Returns the chosen font
+    name, or ``None`` when nothing needed to change (non-CJK locale, or no CJK
+    font installed - in which case the graph renders exactly as before).
+    """
+    font = pick_cjk_font(language)
+    if font is None:
+        script = _script_for_language(language)
+        if script is not None:
+            logger.warning(
+                "No CJK-capable system font found for locale '%s'; graph labels "
+                "may show as boxes. Expected one of: %s",
+                language, _CJK_CANDIDATES[script],
+            )
+        return None
+    try:
+        import matplotlib as mpl
+        sans = [f for f in mpl.rcParams.get("font.sans-serif", []) if f != font]
+        mpl.rcParams["font.sans-serif"] = [font] + sans
+        mpl.rcParams["font.family"] = "sans-serif"
+        mpl.rcParams["axes.unicode_minus"] = False  # some CJK fonts lack U+2212
+        logger.info("Graph font set to '%s' for CJK locale '%s'.", font, language)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.error("Failed to set CJK graph font: %s", e)
+        return None
+    return font

--- a/src/netspeedtray/views/graph/renderer.py
+++ b/src/netspeedtray/views/graph/renderer.py
@@ -18,6 +18,7 @@ from netspeedtray import constants
 from netspeedtray.constants import styles as style_constants
 from netspeedtray.constants.renderer import RendererConstants
 from netspeedtray.utils.helpers import calculate_monotone_cubic_interpolation
+from netspeedtray.utils.mpl_fonts import configure_cjk_font
 import matplotlib.colors as mcolors
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
@@ -37,7 +38,11 @@ class GraphRenderer(QObject):
         self.logger = logger or logging.getLogger(__name__)
         self.i18n = i18n
         self.parent_widget = parent_widget
-        
+
+        # Ensure CJK graph labels (ja/ko/zh) render with real glyphs instead of
+        # tofu boxes (#161). Uses a Windows system font; a no-op for other locales.
+        configure_cjk_font(getattr(self.i18n, "language", None))
+
         # UI Elements
         self.figure = None
         self.canvas = None


### PR DESCRIPTION
## What

Fixes the tofu boxes (missing-glyph rectangles) in the graph's axis / series labels under Japanese and Korean locales - part 2 of #161.

## Root cause

The graph never configured a matplotlib font, so it used the default **DejaVu Sans**, which has no CJK glyphs. Any localized label (Download / Upload / CPU / GPU) in `ja_JP` / `ko_KR` rendered as boxes.

## Fix

New `utils/mpl_fonts.configure_cjk_font(locale)`:
- for CJK locales **only**, points matplotlib's `font.sans-serif` at an installed **Windows system** CJK font (`Yu Gothic` for ja, `Malgun Gothic` for ko, `Microsoft YaHei` for zh), with DejaVu kept as the Latin fallback;
- disables the fancy unicode minus (U+2212), which some CJK fonts lack;
- **bundles no font**, so the installer size is unchanged (nice alongside #172);
- non-CJK locales are a complete no-op (DejaVu as before).

Called from `GraphRenderer.__init__`, so it covers both the standalone Graph window and the Monitor's Network / Hardware tabs (both use `GraphRenderer`).

## Verified

`test_cjk_graph_font.py` (6 tests) loads the **actual shipped** `ja_JP` / `ko_KR` graph labels and asserts the chosen font has a real glyph (FreeType char index != `.notdef`) for **every character** - i.e. no tofu. On this machine it picked `Yu Gothic` (ja) and `Malgun Gothic` (ko), and every label is fully covered. The coverage tests skip gracefully on a runner without CJK fonts (and the runtime path is a safe no-op there too). Full suite: **728 passed**.

## Note

Glyph coverage was verified programmatically (no screen access), so a quick **visual confirm** of the graph in Japanese/Korean is worth a glance before merge - but the FreeType coverage check is a strong proxy for "no tofu."

Refs #161.
