### PR TITLE
fix(helpers): format_data_size tier promotion (999_999 B -> 1.0 MB, not 1000.0 KB) + tests

### DIFF
--- a/src/netspeedtray/tests/unit/test_format_data_size.py
+++ b/src/netspeedtray/tests/unit/test_format_data_size.py
@@ -1,0 +1,79 @@
+"""
+Tests for `format_data_size` (helpers.py) - the shared decimal (base-1000) byte
+formatter behind the data-cap usage card and five Monitor surfaces. It was
+previously untested despite being load-bearing for the cap accounting (the
+"used" glance and the cap it's compared against both route through it).
+
+The headline case is the tier-promotion rounding bug: a value just under a
+boundary (e.g. 999_999 B) scales to 999.999 KB, which rounds to 1000.0 - so it
+must read "1.0 MB", not "1000.0 KB".
+"""
+import pytest
+
+from netspeedtray.utils.helpers import format_data_size
+
+
+class _I18n:
+    BYTES_UNIT = "B"
+    KB_UNIT = "KB"
+    MB_UNIT = "MB"
+    GB_UNIT = "GB"
+    TB_UNIT = "TB"
+    PB_UNIT = "PB"
+
+
+I = _I18n()
+
+
+@pytest.mark.parametrize("data_bytes, expected", [
+    (0,                (0.0, "B")),
+    (1,                (1.0, "B")),
+    (500,              (500.0, "B")),
+    (999,              (999.0, "B")),
+    (1_000,            (1.0, "KB")),
+    (1_500,            (1.5, "KB")),
+    (1_500_000,        (1.5, "MB")),
+    (1_000_000_000,    (1.0, "GB")),
+    # The rounding-promotion bug: just under a boundary must promote a tier,
+    # never render as "1000.x <smaller-unit>".
+    (999_999,          (1.0, "MB")),
+    (999_999_999,      (1.0, "GB")),
+    (999_999_999_999,  (1.0, "TB")),
+    # ...but a value that genuinely rounds DOWN must stay in its tier.
+    (999_994,          (999.99, "KB")),
+    (999_940,          (999.94, "KB")),
+])
+def test_boundaries_and_promotion(data_bytes, expected):
+    assert format_data_size(data_bytes, I) == expected
+
+
+def test_negative_clamps_to_zero():
+    assert format_data_size(-5, I) == (0.0, "B")
+    assert format_data_size(-999_999_999, I) == (0.0, "B")
+
+
+def test_precision_argument():
+    # 1_536_000 B == 1.536 MB
+    assert format_data_size(1_536_000, I, precision=0) == (2.0, "MB")   # rounds 1.536 -> 2
+    assert format_data_size(1_536_000, I, precision=1) == (1.5, "MB")
+    assert format_data_size(1_536_000, I, precision=3) == (1.536, "MB")
+
+
+def test_promotion_respects_precision_zero():
+    # precision=0: 999_999 B -> 999.999 KB -> round -> 1000 -> promote -> 1 MB.
+    assert format_data_size(999_999, I, precision=0) == (1.0, "MB")
+
+
+def test_never_promotes_past_top_unit():
+    # A value beyond PB must stay in PB (the top unit), not overflow the label list.
+    huge = 5_000 * 1000 ** 5   # 5000 PB in bytes
+    value, unit = format_data_size(huge, I)
+    assert unit == "PB"
+    assert value >= 1000.0     # legitimately large in PB, not falsely promoted
+
+
+def test_type_error_on_non_number():
+    with pytest.raises(TypeError):
+        format_data_size("100", I)
+    with pytest.raises(TypeError):
+        format_data_size(None, I)

--- a/src/netspeedtray/utils/helpers.py
+++ b/src/netspeedtray/utils/helpers.py
@@ -325,8 +325,18 @@ def format_data_size(data_bytes: int | float, i18n, precision: int = 2) -> Tuple
         formatted_value = round(value, precision)
     except TypeError:
         logger_instance.error("TypeError during rounding in format_data_size. Value: %s, Precision: %s", value, precision, exc_info=True)
-        return round(value, 0), UNITS_DATA_SIZE[unit_index] 
-        
+        return round(value, 0), UNITS_DATA_SIZE[unit_index]
+
+    # Rounding can push a just-under-boundary value up to the base: e.g. 999_999 B
+    # scales to 999.999 KB, which rounds to 1000.0 - so without this we'd show
+    # "1000.0 KB" instead of "1.0 MB" (and "1000.0 MB" instead of "1.0 GB", etc.).
+    # Promote one more tier. A single re-check suffices: after promotion the value
+    # is < 1 and can't reach the base again. Guard against the top unit (PB).
+    if formatted_value >= BASE_DATA_SIZE and unit_index < len(UNITS_DATA_SIZE) - 1:
+        value /= BASE_DATA_SIZE
+        unit_index += 1
+        formatted_value = round(value, precision)
+
     return formatted_value, UNITS_DATA_SIZE[unit_index]
 
 


### PR DESCRIPTION
## What

`format_data_size()` - the shared decimal (base-1000) byte formatter behind the **data-cap usage glance** and 5 Monitor surfaces - rendered values just under a tier boundary one unit too small: **999,999 B showed as "1000.0 KB" instead of "1.0 MB"** (and 999,999,999 B as "1000.0 MB" instead of "1.0 GB"), at every tier.

## Root cause

It scaled the *raw* value down to `< 1000`, then rounded. A value like 999.999 KB rounds to `1000.0` - but the unit had already been fixed as KB. Reproduced on the shipped code:

```
      999,999 -> (1000.0, 'KB')
  999,999,999 -> (1000.0, 'MB')
      999,994 -> (999.99, 'KB')   # correctly rounds DOWN, unaffected
```

## Fix

After rounding, if the result reached the base (1000), promote one more tier - so it reads "1.0 MB". A single re-check suffices (the promoted value is < 1 and can't reach the base again), and it's guarded against the top unit (PB).

## Tests

Adds `test_format_data_size.py` (18 cases). The function had **zero direct tests** despite being load-bearing for the data-cap accounting - flagged independently by the improvement sweep. Covers: tier boundaries, the promotion bug, round-DOWN cases that must NOT promote (999,994 B stays 999.99 KB), the precision argument, the negative clamp, the top-unit guard, and TypeError on non-numbers. Full suite: **740 passed**.

Pure function - fully verifiable without hardware or a screen.
