### PR TITLE
fix(settings): spinbox up-arrow clicks now land (explicit stepper geometry, #169)

### DIFF
--- a/src/netspeedtray/tests/unit/test_spinbox_stepper_style.py
+++ b/src/netspeedtray/tests/unit/test_spinbox_stepper_style.py
@@ -1,0 +1,52 @@
+"""Regression guards for #169 ("Plan speed" spinbox: down arrow works, up arrow doesn't).
+
+Root cause: the settings stylesheet gave QSpinBox a border + padding but defined no
+::up-button/::down-button geometry, so Qt laid the native steppers under the styled edit
+field's right edge. The up-button ended up (partly) beneath the edit field and its clicks
+were swallowed, while the down-button (further right / lower) still worked. The fix reserves
+explicit, fixed-width stepper buttons so the edit field can never overlap them.
+"""
+from PyQt6.QtWidgets import QSpinBox, QStyle, QStyleOptionSpinBox
+
+from netspeedtray.utils.styles import dialog_style
+
+
+def test_dialog_style_defines_spinbox_stepper_geometry(q_app):
+    """The QSS must explicitly define both stepper buttons with a reserved width (deterministic,
+    style-independent) - deleting this reintroduces the swallowed-up-button bug."""
+    qss = dialog_style()
+    for sel in ("QSpinBox::up-button", "QSpinBox::down-button",
+                "QSpinBox::up-arrow", "QSpinBox::down-arrow"):
+        assert sel in qss, f"missing {sel} in dialog_style()"
+    up_block = qss.split("QSpinBox::up-button", 1)[1].split("}", 1)[0]
+    assert "width:" in up_block, "up-button must reserve a fixed width"
+
+
+def test_spinbox_edit_field_does_not_overlap_up_button(q_app):
+    """With the dialog stylesheet applied, the edit field must not extend into the up-button
+    sub-control (the geometric root of #169). Both button rects must be hittable (non-degenerate)."""
+    s = QSpinBox()
+    s.setRange(0, 100000)
+    s.setStyleSheet(dialog_style())
+    s.resize(180, 32)
+    opt = QStyleOptionSpinBox()
+    try:
+        s.initStyleOption(opt)
+    except Exception:
+        pass
+    opt.rect = s.rect()
+    st = s.style()
+
+    def sub(sc):
+        return st.subControlRect(QStyle.ComplexControl.CC_SpinBox, opt, sc, s)
+
+    up = sub(QStyle.SubControl.SC_SpinBoxUp)
+    dn = sub(QStyle.SubControl.SC_SpinBoxDown)
+    ed = sub(QStyle.SubControl.SC_SpinBoxEditField)
+
+    assert up.width() > 0 and up.height() > 0, f"up-button rect degenerate: {up}"
+    assert dn.width() > 0 and dn.height() > 0, f"down-button rect degenerate: {dn}"
+    # the edit field's right edge must stay left of the up-button (+1px tolerance for rounding)
+    assert ed.x() + ed.width() <= up.x() + 1, (
+        f"edit field ({ed.x()}..{ed.x()+ed.width()}) overlaps up-button (starts {up.x()})"
+    )

--- a/src/netspeedtray/utils/styles.py
+++ b/src/netspeedtray/utils/styles.py
@@ -65,6 +65,29 @@ def combo_chevron_url(color_hex: str) -> str:
         return ""
 
 
+def spin_arrow_url(up: bool, color_hex: str) -> str:
+    """Up/down chevron for a QSpinBox's stepper buttons, cached like ``combo_chevron_url``.
+
+    Qt drops the native stepper arrows the moment ``::up-button``/``::down-button`` are QSS-styled.
+    We supply our own themed chevrons AND (in ``dialog_style``) give the buttons an explicit width,
+    which stops the styled edit field from overlapping the up-button and swallowing its clicks - the
+    root of #169 ("down arrow works, up arrow doesn't"), since the native side-by-side layout puts the
+    up-button under the edit field's right edge. Degrades to no image (empty string) on failure.
+    """
+    try:
+        from netspeedtray.utils.helpers import get_app_data_path
+        codepoint = 0xE70E if up else 0xE70D  # Fluent ChevronUp / ChevronDown
+        key = hashlib.md5(f"{codepoint}_{color_hex}".encode("utf-8")).hexdigest()[:8]
+        cache_dir = os.path.join(get_app_data_path(), "cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        path = os.path.join(cache_dir, f"spin_{key}_v1.png")
+        if not os.path.exists(path):
+            fluent_icon(codepoint, 10, color_hex).pixmap(QSize(10, 10)).save(path, "PNG")
+        return path.replace("\\", "/")
+    except Exception:
+        return ""
+
+
 def font(token: tuple) -> QFont:
     """
     Build a QFont for a Fluent type token - a ``(style_name, pixel_size, weight)`` tuple
@@ -169,6 +192,10 @@ def dialog_style() -> str:
     input_bg = "#383838" if dark_mode_active else "#FFFFFF"
     # A themed dropdown chevron (Qt drops the native arrow once ::drop-down is styled).
     chevron_url = combo_chevron_url("#C8C8C8" if dark_mode_active else "#505050")
+    # Themed up/down chevrons for spinbox steppers (see spin_arrow_url / #169).
+    _spin_glyph = "#C8C8C8" if dark_mode_active else "#505050"
+    spin_up_url = spin_arrow_url(True, _spin_glyph)
+    spin_down_url = spin_arrow_url(False, _spin_glyph)
 
     accent_qcolor = get_accent_color()
     accent_rgb = f"rgb({accent_qcolor.red()}, {accent_qcolor.green()}, {accent_qcolor.blue()})"
@@ -272,6 +299,39 @@ def dialog_style() -> str:
         }}
         QComboBox::down-arrow {{
             image: url("{chevron_url}");
+        }}
+        /* Explicit spinbox stepper geometry. Without this Qt lays the native up/down
+           buttons under the styled edit field's right edge, so the up-button's clicks
+           get swallowed while the down-button (further right) still works - the #169
+           "up arrow doesn't work" bug. Reserving a fixed-width, stacked pair keeps the
+           edit field clear of both and restores a themed, unambiguous stepper. */
+        QSpinBox::up-button, QDoubleSpinBox::up-button {{
+            subcontrol-origin: border;
+            subcontrol-position: top right;
+            width: 20px;
+            border-left: 1px solid {border_color};
+            border-top-right-radius: 4px;
+        }}
+        QSpinBox::down-button, QDoubleSpinBox::down-button {{
+            subcontrol-origin: border;
+            subcontrol-position: bottom right;
+            width: 20px;
+            border-left: 1px solid {border_color};
+            border-bottom-right-radius: 4px;
+        }}
+        QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,
+        QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
+            background-color: {accent_rgb};
+        }}
+        QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {{
+            image: url("{spin_up_url}");
+            width: 10px;
+            height: 10px;
+        }}
+        QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {{
+            image: url("{spin_down_url}");
+            width: 10px;
+            height: 10px;
         }}
         QComboBox QAbstractItemView {{
             background-color: {input_bg};


### PR DESCRIPTION
## What

Gives the settings `QSpinBox` steppers explicit `::up-button` / `::down-button` geometry, so the up arrow is clickable. Fixes the geometric root of #169 ("Plan speed" spinbox: *down arrow works, but the up arrow doesn't*). Also covers the Data-cap dialog spinboxes, which share `dialog_style()`.

## Root cause

The QSS styled `QSpinBox` with a border + padding but defined **no** stepper-button geometry. Qt then lays the native up/down buttons under the styled edit field's right edge. On the **Windows 11 style** the two buttons sit side by side, so the edit field overlaps the **left (up)** button while the **right (down)** button stays clear:

```
CURRENT (windows11, real "Plan speed" spinbox):
  EDIT  x9 .. 135
  UP    x118 .. 142   <- edit field's right edge (135) sits inside the up-button
  DOWN  x142 .. 166   <- clear of the edit field
```

A click on the up arrow is resolved as an edit-field click and does nothing; the down arrow works. That is exactly the reported asymmetry.

## Fix

Reserve fixed-width, **stacked** `::up-button` / `::down-button` with themed chevrons (new `spin_arrow_url` helper, cached like `combo_chevron_url`). The edit field now ends before the buttons:

```
FIXED:
  EDIT  x9 .. 143
  UP    x152 .. 173  (top)      overlap = none
  DOWN  x152 .. 173  (bottom)
```

## Verified

- `QStyle.subControlRect` on the **real** `ConnectionSettings` "Plan speed" spinbox: overlap eliminated under **windows11, windowsvista, and Fusion**; both steppers clickable (up 0->10, down 50->40).
- Visual render: clean stacked, themed steppers.
- New regression tests: a deterministic QSS-contract check (fails if the geometry is removed) + an edit-field/up-button no-overlap check. Full suite **724 passed, 2 xfailed**.

## Honest caveat

I could **not** reproduce the swallowed click on my own machine at 100-200% DPI (a centered synthetic click on the up-button still fired), so this targets the **confirmed geometric overlap** rather than an observed local failure. The overlap is real and style-correct as the cause, but I would like the reporter to confirm on a test build before we call #169 closed.
