### PR TITLE
fix(monitor): show display-settings gear only on the Hardware tab (#170)

### DIFF
--- a/src/netspeedtray/tests/unit/test_monitor_settings_flyout.py
+++ b/src/netspeedtray/tests/unit/test_monitor_settings_flyout.py
@@ -76,16 +76,19 @@ def test_settings_changed_rerenders_active_graph(q_app):
     win._on_settings_changed()                                   # no-op (no crash) when no host yet
 
 
-def test_gear_persistent_enabled_only_on_hardware(q_app):
+def test_gear_visible_only_on_hardware_and_flyout_dismissed(q_app):
     win = _window()
-    # The gear is PERSISTENT (always visible - hiding it made it flicker on every pivot); it's only
-    # *enabled* on Hardware, where it has an effect, and dimmed/disabled elsewhere.
-    win._on_tab_changed(1)                       # Network - gear has no effect here
+    # The gear only configures the Hardware graph, so it's shown on Hardware and hidden elsewhere
+    # (#170). Its layout slot is retained when hidden, so hiding it never reflows the header - which is
+    # why it used to be kept persistent-but-dimmed. Leaving Hardware also dismisses an open flyout.
+    win._on_tab_changed(2)                       # Hardware - gear relevant + visible
     assert not win._gear.isHidden()
-    assert not win._gear.isEnabled()
-    win._on_tab_changed(2)                       # Hardware - gear is relevant
-    assert not win._gear.isHidden()
-    assert win._gear.isEnabled()
+    win._open_settings_flyout()
+    assert win._settings_flyout is not None
+    win._on_tab_changed(1)                       # Network - gear hidden, flyout dismissed
+    assert win._gear.isHidden()
+    assert win._gear.sizePolicy().retainSizeWhenHidden() is True
+    assert win._settings_flyout.isHidden()
 
 
 def test_flyout_reused_not_rebuilt(q_app):

--- a/src/netspeedtray/tests/unit/test_monitor_window.py
+++ b/src/netspeedtray/tests/unit/test_monitor_window.py
@@ -55,6 +55,25 @@ def test_hardware_tab_always_visible(q_app):
     assert not off._tab_bar._buttons["hardware"].isHidden()
 
 
+def test_gear_visible_only_on_hardware_tab(q_app):
+    """The display-settings gear configures only the Hardware graph, so it shows on the Hardware tab
+    and hides on Overview/Network - a persistent but inert gear on the other tabs confused users
+    (#170). Its layout slot is retained when hidden so hiding it never reflows the header (the reason
+    it used to be kept persistent-but-dimmed)."""
+    w = MonitorWindow(_main_widget(), _cfg(monitor_cpu_enabled=True), I18nStrings("en_US"))
+    hw = next(i for i, d in enumerate(w._descriptors) if d.tab_id == "hardware")
+    ov = next(i for i, d in enumerate(w._descriptors) if d.tab_id == "overview")
+
+    w._on_tab_changed(ov)
+    assert w._gear.isHidden(), "gear must be hidden on Overview"
+    w._on_tab_changed(hw)
+    assert not w._gear.isHidden(), "gear must be shown on Hardware"
+    w._on_tab_changed(ov)
+    assert w._gear.isHidden(), "gear must hide again when leaving Hardware"
+    # retained slot => hiding never reflows the header (no pivot flicker)
+    assert w._gear.sizePolicy().retainSizeWhenHidden() is True
+
+
 def test_monitor_forces_hardware_collection_while_open(q_app):
     # The Monitor flips the stats thread's override on while open (set in showEvent) and reverts it
     # on close - so its Overview/Hardware screens show hardware even with the widget's flags off.

--- a/src/netspeedtray/views/monitor/window.py
+++ b/src/netspeedtray/views/monitor/window.py
@@ -86,6 +86,10 @@ class MonitorWindow(QWidget):
         header.addWidget(self._tab_bar)
         header.addStretch(1)
         self._gear = QToolButton()
+        _gear_sp = self._gear.sizePolicy()
+        _gear_sp.setRetainSizeWhenHidden(True)   # keep the header slot when hidden so hiding never reflows (#170)
+        self._gear.setSizePolicy(_gear_sp)
+        self._gear.setVisible(False)             # shown only on the Hardware tab (set in _on_tab_changed)
         self._gear.setText(chr(0xE713))   # Segoe Fluent Icons "Settings" - monochrome, obeys QSS colour
         self._gear.setCursor(Qt.CursorShape.PointingHandCursor)
         self._gear.setToolTip(self._tr("MONITOR_SETTINGS_TIP", "Monitor display settings"))
@@ -174,10 +178,12 @@ class MonitorWindow(QWidget):
             self._stack.removeWidget(old)
             old.deleteLater()
         self._stack.setCurrentIndex(index)
-        # The display-settings gear opens the Hardware-graph options. Keep it PERSISTENT (never hide -
-        # hiding made it flicker in/out on pivot); just enable it on Hardware and dim it elsewhere.
+        # The display-settings gear only configures the Hardware graph, so it shows on the Hardware tab
+        # and hides elsewhere (a visible-but-inert gear on Overview/Network confused users - #170). Its
+        # layout slot is retained when hidden (setRetainSizeWhenHidden at construction), so hiding it
+        # never reflows the header - which is what used to make it flicker in/out on pivot.
         is_hw = (d.tab_id == "hardware")
-        self._gear.setEnabled(is_hw)
+        self._gear.setVisible(is_hw)
         if not is_hw and self._settings_flyout is not None:
             self._settings_flyout.hide()
         # Remember the active tab so the Monitor reopens where the user left it.


### PR DESCRIPTION
## What

The Monitor's display-settings **gear** now shows only on the **Hardware** tab, instead of staying visible (but disabled) on Overview and Network. Closes the confusion in #170 ("the gear only works when the Hardware tab is active").

## Why it was persistent before

The gear configures the Hardware graph's display options, so it was only ever *enabled* on Hardware. It was kept **visible-but-dimmed** elsewhere because plain show/hide made it **flicker in and out on every tab pivot** (the header re-flowed as the gear's slot appeared/disappeared).

## Fix

Set `retainSizeWhenHidden(True)` on the gear so its layout slot is preserved even when hidden, then hide it off the Hardware tab. Because the slot never changes, the header can't reflow, so there's no pivot flicker. The gear now simply appears when it does something and is gone when it doesn't.

## Verified

- New/updated tests: gear hidden on Overview/Network, shown on Hardware, `retainSizeWhenHidden` set, and an open settings flyout is dismissed when leaving Hardware. Full suite **723 passed, 2 xfailed**.

Per the owner's call: "unless we add settings to the other pages, might as well hide it."
