### PR TITLE
fix(widget): fixed-width CPU/GPU percent so the readout stops sliding (#179)

### DIFF
--- a/src/netspeedtray/tests/unit/test_renderer_logic.py
+++ b/src/netspeedtray/tests/unit/test_renderer_logic.py
@@ -38,6 +38,20 @@ def test_speed_band_handles_bad_input():
     """Non-numeric input must fall back to the default band, never raise."""
     assert WidgetRenderer._speed_band(None, 10.0, 1.0) == "default"
 
+
+def test_hw_percent_is_fixed_width_field():
+    """CPU/GPU percent renders as a fixed 3-char, right-justified field so its character count stays
+    constant across the 1/2/3 digit boundary. That is what keeps the side-by-side right-anchor (and
+    a network readout to its left) from sliding by a digit as CPU/GPU cross 9<->10 - issue #179.
+    Right-justified with spaces, NOT zero-padded, so it stays readable ('  9%' not '009%')."""
+    f = WidgetRenderer._fmt_hw_percent
+    assert f(9) == "  9%"
+    assert f(10) == " 10%"
+    assert f(100) == "100%"
+    assert f(0) == "  0%"
+    assert f(7.8) == "  7%"          # truncates toward zero, same as the old int(val)
+    assert all(len(f(v)) == 4 for v in (0, 5, 9, 10, 42, 99, 100))  # always 4 chars
+
 def test_peak_label_placement_logic():
     # Mock dependencies for GraphRenderer
     parent_widget = MagicMock()

--- a/src/netspeedtray/tests/unit/test_widget_render_gui.py
+++ b/src/netspeedtray/tests/unit/test_widget_render_gui.py
@@ -146,3 +146,28 @@ def test_hardware_stats_render_smoke(q_app):
     ptr.setsize(img.height() * img.width() * 4)
     arr = np.frombuffer(ptr, dtype=np.uint8).reshape((img.height(), img.width(), 4))
     assert int((arr[:, :, 3] >= 250).sum()) > 30, "hardware stats drew almost nothing"
+
+
+def test_hw_percent_content_width_stable_across_digits(q_app):
+    """Integration proof for #179: the CPU% segment's measured content width is IDENTICAL at 9%,
+    10% and 100%. That width is exactly what widget_paint feeds into the side-by-side right-anchor
+    (align_dx = widget_width - content_width), so a constant width means the whole block - including
+    a network readout drawn to its left - can no longer slide by a digit as CPU crosses 9<->10.
+    Guarded to fonts with tabular figures (space==digit), which the default Segoe UI has; CI fallback
+    fonts make the padding best-effort, so we skip the exact-equality assertion there rather than fail."""
+    cfg = dict(constants.config.defaults.DEFAULT_CONFIG)
+    cfg.update({"hardware_label_style": "text", "monitor_cpu_enabled": True, "monitor_gpu_enabled": False})
+    r = WidgetRenderer(cfg, I18nStrings("en_US"))
+    if r.metrics.horizontalAdvance(" ") != r.metrics.horizontalAdvance("0"):
+        pytest.skip("test font lacks tabular space==digit metrics; the padding is best-effort there")
+
+    def content_w(cpu):
+        img = QImage(320, 56, QImage.Format.Format_ARGB32)
+        img.fill(QColor(0, 0, 0, 0))
+        p = QPainter(img)
+        r.draw_hardware_stats(p, float(cpu), None, 320, 56, r.config)
+        p.end()
+        return r.get_last_text_rect().width()
+
+    w9, w10, w100 = content_w(9), content_w(10), content_w(100)
+    assert w9 == w10 == w100, f"CPU% segment width still jitters: 9->{w9}, 10->{w10}, 100->{w100}"

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -389,6 +389,22 @@ class WidgetRenderer:
 
 
 
+    @staticmethod
+    def _fmt_hw_percent(val: float) -> str:
+        """CPU/GPU percent as a fixed 3-char field ("  9%" / " 42%" / "100%").
+
+        Right-justifying to 3 digits keeps the DRAWN width constant across the 1<->2<->3 digit
+        boundary. It matters because in the side-by-side layout the whole readout is right-anchored
+        to the tray every frame from the LIVE measured content width (widget_paint.render_widget),
+        so an unpadded "9%" vs "10%" shoved the entire block - including a network readout sitting
+        to its left - sideways by one digit as CPU/GPU crossed 9<->10. That is the #179 jitter. The
+        layout manager already reserves " 100%" worst-case width (views/widget/layout.py:239,255),
+        so this fixed field fits with no window resize. Plain space (not the U+2007 figure space):
+        the default UI font (Segoe UI) has tabular figures where a space and a digit share one
+        advance, and a plain space never risks a missing-glyph box in a user-chosen font.
+        """
+        return f"{int(val):>3d}%"
+
     def draw_hardware_stats(self, painter: QPainter, cpu_usage: Optional[float], gpu_usage: Optional[float],
                            width: int, height: int, config: RenderConfig,
                            cpu_temp: Optional[float] = None, gpu_temp: Optional[float] = None,
@@ -434,7 +450,7 @@ class WidgetRenderer:
 
             render_rows = []
             for (label, val, temp, mem_info, color_hex, power) in enabled_stats:
-                main_text = f"{int(val)}%"
+                main_text = self._fmt_hw_percent(val)
 
                 # Unified parenthetical suffix: "(43°C, 7.8W)", "(43°C)", "(7.8W)", or "(N/A)"
                 suffix = self._build_hw_suffix(temp, power, show_temps, show_power)


### PR DESCRIPTION
## What

Renders the CPU/GPU percent as a fixed-width 3-char field (`"  9%"` / `" 42%"` / `"100%"`) so the widget readout stops sliding left/right as the value crosses the 9<->10 digit boundary. Fixes #179.

## Root cause (it is NOT a resize)

Investigated with a multi-agent pass. The widget already reserves worst-case width (`views/widget/layout.py:239,255` reserve `" 100%"`) and does **not** resize on a value change (`update_cpu_usage`/`update_gpu_usage` only repaint). The jitter is internal to the paint path:

- In the side-by-side layout, `widget_paint.render_widget` **right-anchors the whole readout to the tray every frame**, computing `align_dx = widget_width - content_width - PADDING` from the **live measured** content width.
- The percent was drawn unpadded as `f"{int(val)}%"`, so the CPU/GPU segment's measured width shrank by one digit when the value went `10 -> 9`.
- Smaller content width -> larger `align_dx` -> the entire block (including a network readout drawn to its **left**) shifts right by one digit, then snaps back next tick.

That is exactly the reporter's "Network jumps left and right" symptom.

## Fix

`main_text = f"{int(val):>3d}%"` (via a documented `_fmt_hw_percent` helper). The drawn width is now constant, so the measured content width no longer changes with the digit count and the anchor holds still. It fits inside the already-reserved `" 100%"` width (no window resize). Plain space rather than the U+2007 figure space, since the default Segoe UI has tabular figures (space advance == digit advance, verified across 9-72pt) and a plain space can never render as a missing-glyph box in a user's custom font.

## Verified

- **Integration test** (real render path, real font): the CPU% segment's measured content width is **identical at 9%, 10% and 100%** - it fails on the old code and passes on the fix. Guarded to tabular-figure fonts so non-Windows CI stays green.
- Format unit test (`"  9%"`/`" 42%"`/`"100%"`, not zero-padded). Full suite **724 passed, 2 xfailed**.

## Honest scope

This stabilizes the CPU/GPU **percent**, which is what the reporter described. RAM/VRAM (`"9.9/16.0G"`), the temp/power suffix, and 4-digit network speeds are also live-width and feed the same right-anchor, so they can still nudge the block on their own digit changes. The complete fix for all of them is a follow-up: make the right-anchor use the layout manager's **reserved** width instead of the live measurement. Tracked separately; this PR closes the reported case.
