### PR TITLE
fix(widget): stable, aligned, compact side-by-side hardware readout (#179)

### DIFF
--- a/src/netspeedtray/constants/layout.py
+++ b/src/netspeedtray/constants/layout.py
@@ -46,8 +46,9 @@ class LayoutConstants:
     SMALL_TASKBAR_HEIGHT_THRESHOLD: Final[int] = 34
     HORIZONTAL_LAYOUT_SEPARATOR: Final[str] = " | "
     MINI_GRAPH_HORIZONTAL_WIDTH: Final[int] = 40
-    # Segment gaps for Side-by-Side mode (Network | CPU/GPU)
-    WIDGET_SEGMENT_GAP_AFTER_NETWORK_PX: Final[int] = 18
+    # Segment gaps for Side-by-Side mode (Network | CPU/GPU). Kept compact so the network readout sits
+    # close to the hardware rather than floating far from it.
+    WIDGET_SEGMENT_GAP_AFTER_NETWORK_PX: Final[int] = 10
     WIDGET_SEGMENT_GAP_BETWEEN_HARDWARE_PX: Final[int] = 5
 
     def __init__(self) -> None:

--- a/src/netspeedtray/constants/renderer.py
+++ b/src/netspeedtray/constants/renderer.py
@@ -15,7 +15,7 @@ class RendererConstants:
     # Breathing room kept between the RIGHT-ALIGNED side-by-side content and the widget's tray-side edge,
     # so the readout doesn't crowd the tray-overflow chevron once it's anchored right. Larger than
     # TEXT_MARGIN (which only kept text off the very edge) - this is deliberate visual padding.
-    RIGHT_ANCHOR_PADDING: Final[int] = 4
+    RIGHT_ANCHOR_PADDING: Final[int] = 7
     GRAPH_MARGIN: Final[int] = 3
     GRAPH_LEFT_PADDING: Final[int] = 2
     GRAPH_RIGHT_PADDING: Final[int] = 2

--- a/src/netspeedtray/constants/renderer.py
+++ b/src/netspeedtray/constants/renderer.py
@@ -15,7 +15,7 @@ class RendererConstants:
     # Breathing room kept between the RIGHT-ALIGNED side-by-side content and the widget's tray-side edge,
     # so the readout doesn't crowd the tray-overflow chevron once it's anchored right. Larger than
     # TEXT_MARGIN (which only kept text off the very edge) - this is deliberate visual padding.
-    RIGHT_ANCHOR_PADDING: Final[int] = 8
+    RIGHT_ANCHOR_PADDING: Final[int] = 4
     GRAPH_MARGIN: Final[int] = 3
     GRAPH_LEFT_PADDING: Final[int] = 2
     GRAPH_RIGHT_PADDING: Final[int] = 2

--- a/src/netspeedtray/tests/unit/test_renderer_logic.py
+++ b/src/netspeedtray/tests/unit/test_renderer_logic.py
@@ -39,18 +39,16 @@ def test_speed_band_handles_bad_input():
     assert WidgetRenderer._speed_band(None, 10.0, 1.0) == "default"
 
 
-def test_hw_percent_is_fixed_width_field():
-    """CPU/GPU percent renders as a fixed 3-char, right-justified field so its character count stays
-    constant across the 1/2/3 digit boundary. That is what keeps the side-by-side right-anchor (and
-    a network readout to its left) from sliding by a digit as CPU/GPU cross 9<->10 - issue #179.
-    Right-justified with spaces, NOT zero-padded, so it stays readable ('  9%' not '009%')."""
+def test_hw_percent_is_plain_text():
+    """The percent is plain text now; the fixed percent COLUMN in draw_hardware_stats provides the
+    constant width (right-aligned when memory is inline, left-aligned above a memory row), so the
+    value reads naturally and still lines up. Regression guard against re-padding the string."""
     f = WidgetRenderer._fmt_hw_percent
-    assert f(9) == "  9%"
-    assert f(10) == " 10%"
+    assert f(9) == "9%"
+    assert f(10) == "10%"
     assert f(100) == "100%"
-    assert f(0) == "  0%"
-    assert f(7.8) == "  7%"          # truncates toward zero, same as the old int(val)
-    assert all(len(f(v)) == 4 for v in (0, 5, 9, 10, 42, 99, 100))  # always 4 chars
+    assert f(0) == "0%"
+    assert f(7.8) == "7%"            # truncates toward zero
 
 def test_peak_label_placement_logic():
     # Mock dependencies for GraphRenderer

--- a/src/netspeedtray/tests/unit/test_renderer_logic.py
+++ b/src/netspeedtray/tests/unit/test_renderer_logic.py
@@ -38,6 +38,20 @@ def test_speed_band_handles_bad_input():
     """Non-numeric input must fall back to the default band, never raise."""
     assert WidgetRenderer._speed_band(None, 10.0, 1.0) == "default"
 
+
+def test_hw_percent_is_fixed_width_field():
+    """CPU/GPU percent renders as a fixed 3-char, right-justified field so its character count stays
+    constant across the 1/2/3 digit boundary. That is what keeps the side-by-side right-anchor (and
+    a network readout to its left) from sliding by a digit as CPU/GPU cross 9<->10 - issue #179.
+    Right-justified with spaces, NOT zero-padded, so it stays readable ('  9%' not '009%')."""
+    f = WidgetRenderer._fmt_hw_percent
+    assert f(9) == "  9%"
+    assert f(10) == " 10%"
+    assert f(100) == "100%"
+    assert f(0) == "  0%"
+    assert f(7.8) == "  7%"          # truncates toward zero, same as the old int(val)
+    assert all(len(f(v)) == 4 for v in (0, 5, 9, 10, 42, 99, 100))  # always 4 chars
+
 def test_peak_label_placement_logic():
     # Mock dependencies for GraphRenderer
     parent_widget = MagicMock()

--- a/src/netspeedtray/tests/unit/test_widget_render_gui.py
+++ b/src/netspeedtray/tests/unit/test_widget_render_gui.py
@@ -146,3 +146,28 @@ def test_hardware_stats_render_smoke(q_app):
     ptr.setsize(img.height() * img.width() * 4)
     arr = np.frombuffer(ptr, dtype=np.uint8).reshape((img.height(), img.width(), 4))
     assert int((arr[:, :, 3] >= 250).sum()) > 30, "hardware stats drew almost nothing"
+
+
+def test_hw_percent_content_width_stable_across_digits(q_app):
+    """Integration proof for #179: the CPU% segment's measured content width is IDENTICAL at 9%,
+    10% and 100%. That width is exactly what widget_paint feeds into the side-by-side right-anchor
+    (align_dx = widget_width - content_width), so a constant width means the whole block - including
+    a network readout drawn to its left - can no longer slide by a digit as CPU crosses 9<->10.
+    Guarded to fonts with tabular figures (space==digit), which the default Segoe UI has; CI fallback
+    fonts make the padding best-effort, so we skip the exact-equality assertion there rather than fail."""
+    cfg = dict(constants.config.defaults.DEFAULT_CONFIG)
+    cfg.update({"hardware_label_style": "text", "monitor_cpu_enabled": True, "monitor_gpu_enabled": False})
+    r = WidgetRenderer(cfg, I18nStrings("en_US"))
+    if r.metrics.horizontalAdvance(" ") != r.metrics.horizontalAdvance("0"):
+        pytest.skip("test font lacks tabular space==digit metrics; the padding is best-effort there")
+
+    def content_w(cpu):
+        img = QImage(320, 56, QImage.Format.Format_ARGB32)
+        img.fill(QColor(0, 0, 0, 0))
+        p = QPainter(img)
+        r.draw_hardware_stats(p, float(cpu), None, 320, 56, r.config)
+        p.end()
+        return r.get_last_text_rect().width()
+
+    w9, w10, w100 = content_w(9), content_w(10), content_w(100)
+    assert w9 == w10 == w100, f"CPU% segment width still jitters: 9->{w9}, 10->{w10}, 100->{w100}"

--- a/src/netspeedtray/utils/widget_paint.py
+++ b/src/netspeedtray/utils/widget_paint.py
@@ -253,11 +253,16 @@ def render_widget(painter: QPainter, rect: QRect, renderer: WidgetRenderer, conf
             renderer.reset_content_bounds()
             _draw_side_by_side(mp, renderer, width, height, config, metrics, layout_mode, network_width)
             mp.end()
-            content_w = renderer.get_content_bounds().width()
-            if 0 < content_w < width:
-                # Keep deliberate breathing room from the tray-side edge (not just TEXT_MARGIN) so the
-                # right-anchored readout doesn't crowd the tray-overflow chevron.
-                align_dx = max(0, width - content_w - constants.renderer.RIGHT_ANCHOR_PADDING)
+            bounds = renderer.get_content_bounds()
+            # Anchor from the content's RIGHT EDGE, not its width: the network segment is right-aligned
+            # inside its own slot (draw_network_speeds), so the bounds no longer start at x=0. Using the
+            # width here double-counted that shift and pushed the readout past the tray edge, clipping the
+            # unit ("Mbps" -> "Mbp"). The right edge already includes the shift, so the anchor is correct.
+            content_right = bounds.x() + bounds.width()
+            if 0 < content_right <= width:
+                # Keep deliberate breathing room from the tray-side edge so the right-anchored readout
+                # doesn't crowd the tray-overflow chevron.
+                align_dx = max(0, width - content_right - constants.renderer.RIGHT_ANCHOR_PADDING)
         except Exception:
             align_dx = 0
         finally:

--- a/src/netspeedtray/utils/widget_paint.py
+++ b/src/netspeedtray/utils/widget_paint.py
@@ -149,7 +149,8 @@ def _draw_side_by_side(painter: QPainter, renderer: WidgetRenderer, width: int, 
                 renderer.draw_mini_graph(painter, net_w, height, config, list(metrics.net_history), layout)
                 painter.restore()
             up_bytes, dw_bytes = metrics.net_bytes()
-            renderer.draw_network_speeds(painter, up_bytes, dw_bytes, width, height, config, layout, x_offset=current_x)
+            renderer.draw_network_speeds(painter, up_bytes, dw_bytes, width, height, config, layout,
+                                         x_offset=current_x, slot_width=network_width)
         elif key == "cpu" and config.monitor_cpu_enabled:
             ram = (metrics.ram_used, metrics.ram_total) if config.monitor_ram_enabled else None
             renderer.draw_hardware_stats(painter, metrics.cpu_usage, None, width, height, config,

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -448,54 +448,76 @@ class WidgetRenderer:
             show_temps = getattr(config, "show_hardware_temps", False)
             show_power = getattr(config, "show_hardware_power", False)
 
-            render_rows = []
+            style = getattr(config, 'hardware_label_style', 'icons_colored')
+            sp = self.metrics.horizontalAdvance(" ")
+
+            # Keep percent / suffix / memory as SEPARATE cells (not one concatenated string) so each sits
+            # in its own fixed-width column. That lines the rows up (the "|" and RAM/VRAM align across CPU
+            # and GPU even when one has a temp sensor and the other doesn't) AND makes the segment width
+            # CONSTANT as values cross digit boundaries - so the whole readout stops sliding and never
+            # clips. Worst-case column widths are computed once and are identical for every row.
+            rows = []
             for (label, val, temp, mem_info, color_hex, power) in enabled_stats:
-                main_text = self._fmt_hw_percent(val)
-
-                # Unified parenthetical suffix: "(43°C, 7.8W)", "(43°C)", "(7.8W)", or "(N/A)"
-                suffix = self._build_hw_suffix(temp, power, show_temps, show_power)
-                if suffix:
-                    main_text += f" {suffix}"
-
-                mem_text = ""
+                mem_text, total = "", 0.0
                 if mem_info and mem_info[0] is not None:
-                    used, total = mem_info
-                    mem_text = f"{used:.1f}/{total:.1f}G" if total and total > 0 else f"{used:.1f}G"
+                    used, total = mem_info[0], (mem_info[1] or 0.0)
+                    mem_text = f"{used:.1f}/{total:.1f}G" if total > 0 else f"{used:.1f}G"
+                rows.append({'label': label, 'color': color_hex, 'total': total,
+                             'pct': self._fmt_hw_percent(val),
+                             'suffix': self._build_hw_suffix(temp, power, show_temps, show_power),
+                             'mem': mem_text})
 
-                if mem_text:
-                    if is_compact:
-                        main_text += f" | {mem_text}"
-                        render_rows.append({'label': label, 'text': main_text, 'color': color_hex, 'draw_icon': True})
-                    else:
-                        render_rows.append({'label': label, 'text': main_text, 'color': color_hex, 'draw_icon': True})
-                        render_rows.append({'label': label, 'text': mem_text, 'color': color_hex, 'draw_icon': False})
-                else:
-                    render_rows.append({'label': label, 'text': main_text, 'color': color_hex, 'draw_icon': True})
-                    
-            total_height = line_height * len(render_rows)
+            label_col = (max(self.metrics.horizontalAdvance(r['label']) for r in rows) + 4) if style == "text" else 14
+            pct_col = self.metrics.horizontalAdvance("100%")   # the >3d percent is already a fixed 4-char field
+            if show_temps and show_power:
+                suffix_ref = "(99°C, 250.0W)"
+            elif show_power:
+                suffix_ref = "(250.0W)"
+            elif show_temps:
+                suffix_ref = "(99°C)"
+            else:
+                suffix_ref = ""
+            suffix_col = (sp + self.metrics.horizontalAdvance(suffix_ref)) if suffix_ref else 0
+
+            any_mem = any(r['mem'] for r in rows)
+            totals = [r['total'] for r in rows if r['total'] > 0]
+            t = max(totals) if totals else 0.0
+            mem_num_col = self.metrics.horizontalAdvance(f"{t:.1f}/{t:.1f}G" if t > 0 else "9999G") if any_mem else 0
+            sep_col = self.metrics.horizontalAdvance(" | ")
+            inline_mem = is_compact
+            mem_col = (sep_col + mem_num_col) if (any_mem and inline_mem) else 0
+
+            extra_rows = 0 if inline_mem else sum(1 for r in rows if r['mem'])
+            total_height = line_height * (len(rows) + extra_rows)
             top_y = int((height - total_height) / 2 + ascent)
             current_x = x_offset + margin
-            
-            style = getattr(config, 'hardware_label_style', 'icons_colored')
-            for i, row in enumerate(render_rows):
-                y_pos = top_y + (i * line_height)
-                if row['draw_icon']:
-                    if style == "text":
-                        painter.setPen(QPen(QColor(row['color'])))
-                        painter.drawText(current_x, y_pos, row['label'])
-                        val_x = current_x + self.metrics.horizontalAdvance(row['label']) + 4
-                    else:
-                        self._draw_icon(painter, row['label'], current_x, y_pos, QColor(row['color']))
-                        val_x = current_x + 14
+
+            stat_col = label_col + pct_col + suffix_col + mem_col
+            seg_w = max(stat_col, (label_col + mem_num_col) if (any_mem and not inline_mem) else 0)
+
+            y = top_y
+            for r in rows:
+                if style == "text":
+                    painter.setPen(QPen(QColor(r['color'])))
+                    painter.drawText(current_x, y, r['label'])
                 else:
-                    val_x = current_x # Align with icon, no indent!
-                
+                    self._draw_icon(painter, r['label'], current_x, y, QColor(r['color']))
+                vx = current_x + label_col
                 painter.setPen(self.default_color)
-                painter.drawText(val_x, y_pos, row['text'])
-                
-            # Update bounding rect for accurate spacing in side-by-side or grouped layout views
-            max_text_width = max((14 if row['draw_icon'] else 0) + self.metrics.horizontalAdvance(row['text']) for row in render_rows)
-            self._last_text_rect = QRect(x_offset, top_y, max_text_width + margin, total_height)
+                painter.drawText(vx, y, r['pct'])                       # fixed-width percent
+                if suffix_col and r['suffix']:
+                    painter.drawText(vx + pct_col + sp, y, r['suffix'])  # live suffix in its worst-case column
+                if inline_mem and mem_col and r['mem']:
+                    mx = vx + pct_col + suffix_col
+                    painter.drawText(mx, y, " | ")
+                    # right-align the number in its column so the trailing 'G' lines up across rows
+                    painter.drawText(mx + mem_col - self.metrics.horizontalAdvance(r['mem']), y, r['mem'])
+                y += line_height
+                if not inline_mem and r['mem']:
+                    painter.drawText(vx, y, r['mem'])                    # memory on its own row (single-stat modes)
+                    y += line_height
+
+            self._last_text_rect = QRect(x_offset, top_y, seg_w + margin, total_height)
             self._extend_content_bounds(self._last_text_rect)
 
         except Exception as e:

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -523,7 +523,10 @@ class WidgetRenderer:
                     painter.drawText(mx + mem_col - self.metrics.horizontalAdvance(r['mem']), y, r['mem'])
                 y += line_height
                 if not inline_mem and r['mem']:
-                    painter.drawText(vx, y, r['mem'])                    # memory on its own row (single-stat modes)
+                    # right-align memory to the segment's right edge, so its right bound lines up with the
+                    # %/temp above it (per #179 feedback) instead of floating left under the value column
+                    mem_right = current_x + seg_w
+                    painter.drawText(mem_right - self.metrics.horizontalAdvance(r['mem']), y, r['mem'])
                     y += line_height
 
             self._last_text_rect = QRect(x_offset, top_y, seg_w + margin, total_height)

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -389,6 +389,22 @@ class WidgetRenderer:
 
 
 
+    @staticmethod
+    def _fmt_hw_percent(val: float) -> str:
+        """CPU/GPU percent as a fixed 3-char field ("  9%" / " 42%" / "100%").
+
+        Right-justifying to 3 digits keeps the DRAWN width constant across the 1<->2<->3 digit
+        boundary. It matters because in the side-by-side layout the whole readout is right-anchored
+        to the tray every frame from the LIVE measured content width (widget_paint.render_widget),
+        so an unpadded "9%" vs "10%" shoved the entire block - including a network readout sitting
+        to its left - sideways by one digit as CPU/GPU crossed 9<->10. That is the #179 jitter. The
+        layout manager already reserves " 100%" worst-case width (views/widget/layout.py:239,255),
+        so this fixed field fits with no window resize. Plain space (not the U+2007 figure space):
+        the default UI font (Segoe UI) has tabular figures where a space and a digit share one
+        advance, and a plain space never risks a missing-glyph box in a user-chosen font.
+        """
+        return f"{int(val):>3d}%"
+
     def draw_hardware_stats(self, painter: QPainter, cpu_usage: Optional[float], gpu_usage: Optional[float],
                            width: int, height: int, config: RenderConfig,
                            cpu_temp: Optional[float] = None, gpu_temp: Optional[float] = None,
@@ -434,7 +450,7 @@ class WidgetRenderer:
 
             render_rows = []
             for (label, val, temp, mem_info, color_hex, power) in enabled_stats:
-                main_text = f"{int(val)}%"
+                main_text = self._fmt_hw_percent(val)
 
                 # Unified parenthetical suffix: "(43°C, 7.8W)", "(43°C)", "(7.8W)", or "(N/A)"
                 suffix = self._build_hw_suffix(temp, power, show_temps, show_power)

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -246,7 +246,7 @@ class WidgetRenderer:
             
         painter.fillRect(rect, self._cached_bg_color)
 
-    def draw_network_speeds(self, painter: QPainter, upload: float, download: float, width: int, height: int, config: RenderConfig, layout_mode: str = 'vertical', x_offset: int = 0, fixed_width: Optional[int] = None) -> None:
+    def draw_network_speeds(self, painter: QPainter, upload: float, download: float, width: int, height: int, config: RenderConfig, layout_mode: str = 'vertical', x_offset: int = 0, slot_width: Optional[int] = None, fixed_width: Optional[int] = None) -> None:
         """Draws current upload and download speeds."""
         try:
             # Format speeds
@@ -296,6 +296,14 @@ class WidgetRenderer:
             vertical_gap = 1
             margin = constants.renderer.TEXT_MARGIN
             
+            # Right-align the whole readout inside its reserved slot (side_by_side) so the network hugs
+            # the hardware instead of floating left in the worst-case width. The slack lands on the left,
+            # toward the app icons; both rows shift equally so the arrows stay mutually aligned.
+            max_unit_width = max(self.metrics.horizontalAdvance(up_unit), self.metrics.horizontalAdvance(dw_unit)) if not config.hide_unit_suffix else 0
+            block_width = max_arrow_width + arrow_gap + number_area_width + unit_gap + max_unit_width
+            if slot_width and slot_width > block_width + 2 * margin:
+                x_offset += slot_width - block_width - 2 * margin
+
             # Fixed Offsets (Arrow and Number start are fixed)
             arrow_x = x_offset + margin
             number_x = arrow_x + max_arrow_width + arrow_gap
@@ -320,8 +328,7 @@ class WidgetRenderer:
             bot_raw = upload if bot_is_upload else download
             self._draw_speed_line(painter, bot_is_upload, bot_val, bot_unit, bot_raw, arrow_x, number_x, unit_x, dw_y, config, number_area_width)
 
-            # Update bounding rect for context menu positioning
-            max_unit_width = max(self.metrics.horizontalAdvance(up_unit), self.metrics.horizontalAdvance(dw_unit)) if not config.hide_unit_suffix else 0
+            # Update bounding rect for context menu positioning (max_unit_width computed above)
             total_width = (unit_x - arrow_x) + max_unit_width
             self._last_text_rect = QRect(arrow_x, top_y, total_width, total_height)
             self._extend_content_bounds(self._last_text_rect)
@@ -500,9 +507,12 @@ class WidgetRenderer:
                     self._draw_icon(painter, r['label'], current_x, y, QColor(r['color']))
                 vx = current_x + label_col
                 painter.setPen(self.default_color)
-                # inline memory (stacked): right-align the percent so the suffix/"|" sit one space past
-                # the % and line up across rows. Otherwise left-align so it lines up under a memory row.
-                px = (vx + pct_col - self.metrics.horizontalAdvance(r['pct'])) if (inline_mem and any_mem) else vx
+                # Right-align the percent in its column whenever something trails it on the same row (a
+                # suffix, or inline memory) so "8% (48C)" / "8% | 11.8/15.7G" stay tight and line up across
+                # rows. Left-align only when the percent is alone above a memory row (CPU+RAM), so it lines
+                # up with the memory beneath it.
+                has_trailing = (inline_mem and mem_col and r['mem']) or bool(suffix_col and r['suffix'])
+                px = (vx + pct_col - self.metrics.horizontalAdvance(r['pct'])) if has_trailing else vx
                 painter.drawText(px, y, r['pct'])
                 if suffix_col and r['suffix']:
                     painter.drawText(vx + pct_col + sp, y, r['suffix'])  # live suffix in its worst-case column

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -391,19 +391,15 @@ class WidgetRenderer:
 
     @staticmethod
     def _fmt_hw_percent(val: float) -> str:
-        """CPU/GPU percent as a fixed 3-char field ("  9%" / " 42%" / "100%").
+        """CPU/GPU percent as plain text ("9%" / "100%").
 
-        Right-justifying to 3 digits keeps the DRAWN width constant across the 1<->2<->3 digit
-        boundary. It matters because in the side-by-side layout the whole readout is right-anchored
-        to the tray every frame from the LIVE measured content width (widget_paint.render_widget),
-        so an unpadded "9%" vs "10%" shoved the entire block - including a network readout sitting
-        to its left - sideways by one digit as CPU/GPU crossed 9<->10. That is the #179 jitter. The
-        layout manager already reserves " 100%" worst-case width (views/widget/layout.py:239,255),
-        so this fixed field fits with no window resize. Plain space (not the U+2007 figure space):
-        the default UI font (Segoe UI) has tabular figures where a space and a digit share one
-        advance, and a plain space never risks a missing-glyph box in a user-chosen font.
+        The FIXED percent COLUMN in draw_hardware_stats (not this string) provides the constant width
+        now, so the value reads naturally: it's right-aligned in that column when memory is inline
+        (stacked - keeps the "|" lined up across rows) and left-aligned when memory is on its own row
+        (single-stat modes - lines up under the percent). Either way the segment width never changes,
+        so the readout no longer slides or clips (#179 and the side-by-side alignment work).
         """
-        return f"{int(val):>3d}%"
+        return f"{int(val)}%"
 
     def draw_hardware_stats(self, painter: QPainter, cpu_usage: Optional[float], gpu_usage: Optional[float],
                            width: int, height: int, config: RenderConfig,
@@ -504,7 +500,10 @@ class WidgetRenderer:
                     self._draw_icon(painter, r['label'], current_x, y, QColor(r['color']))
                 vx = current_x + label_col
                 painter.setPen(self.default_color)
-                painter.drawText(vx, y, r['pct'])                       # fixed-width percent
+                # inline memory (stacked): right-align the percent so the suffix/"|" sit one space past
+                # the % and line up across rows. Otherwise left-align so it lines up under a memory row.
+                px = (vx + pct_col - self.metrics.horizontalAdvance(r['pct'])) if (inline_mem and any_mem) else vx
+                painter.drawText(px, y, r['pct'])
                 if suffix_col and r['suffix']:
                     painter.drawText(vx + pct_col + sp, y, r['suffix'])  # live suffix in its worst-case column
                 if inline_mem and mem_col and r['mem']:

--- a/src/netspeedtray/views/settings/pages/hardware.py
+++ b/src/netspeedtray/views/settings/pages/hardware.py
@@ -38,7 +38,8 @@ class HardwarePage(QWidget):
 
         self.monitor_ram = Win11Toggle(label_text="")
         self.monitor_ram.toggled.connect(self.on_change)
-        layout.addWidget(SettingCard(self.i18n.MONITOR_RAM_LABEL, control=self.monitor_ram))
+        self._ram_card = SettingCard(self.i18n.MONITOR_RAM_LABEL, control=self.monitor_ram)
+        layout.addWidget(self._ram_card)
 
         self.monitor_gpu = Win11Toggle(label_text="")
         self.monitor_gpu.toggled.connect(self._on_monitor_toggled)
@@ -46,7 +47,8 @@ class HardwarePage(QWidget):
 
         self.monitor_vram = Win11Toggle(label_text="")
         self.monitor_vram.toggled.connect(self.on_change)
-        layout.addWidget(SettingCard(self.i18n.MONITOR_VRAM_LABEL, control=self.monitor_vram))
+        self._vram_card = SettingCard(self.i18n.MONITOR_VRAM_LABEL, control=self.monitor_vram)
+        layout.addWidget(self._vram_card)
 
         self.show_temps = Win11Toggle(label_text="")
         self.show_temps.toggled.connect(self.on_change)
@@ -173,12 +175,16 @@ class HardwarePage(QWidget):
         eff.setOpacity(1.0 if enabled else 0.4)
 
     def _sync_dependent_cards(self) -> None:
-        """Temperature & power are drawn appended to the CPU/GPU utilisation readout, so with BOTH of
-        those monitors off there is nowhere for them to render - gray them out so the toggles can't
-        promise something that never shows (Win11 dependent-control pattern)."""
-        has_util = self.monitor_cpu.isChecked() or self.monitor_gpu.isChecked()
+        """Several readouts ride on the CPU/GPU utilisation lines, so gray their toggles out when there's
+        nowhere for them to render (Win11 dependent-control pattern): temperature & power need at least
+        one of CPU/GPU on; RAM rides on the CPU line, and VRAM on the GPU line, so each is grayed when its
+        host monitor is off - otherwise turning on RAM with CPU off promised something that never shows."""
+        cpu_on, gpu_on = self.monitor_cpu.isChecked(), self.monitor_gpu.isChecked()
+        has_util = cpu_on or gpu_on
         self._set_card_enabled(self._temps_card, has_util)
         self._set_card_enabled(self._power_card, has_util)
+        self._set_card_enabled(self._ram_card, cpu_on)
+        self._set_card_enabled(self._vram_card, gpu_on)
 
     def get_settings(self) -> Dict[str, Any]:
         return {

--- a/src/netspeedtray/views/widget/layout.py
+++ b/src/netspeedtray/views/widget/layout.py
@@ -243,16 +243,23 @@ class WidgetLayoutManager:
                     mem_total = 0.0
                     if monitor_ram:
                         rt = getattr(self.widget, 'ram_total', 0.0) or 0.0
-                        if rt <= 0:
+                        if rt <= 0:   # RAM total is knowable synchronously - use it so we reserve tight, not huge
                             try:
                                 import psutil
                                 rt = psutil.virtual_memory().total / (1024 ** 3)
                             except Exception:
-                                rt = 99.9
+                                rt = 32.0
                         mem_total = max(mem_total, rt)
                     if monitor_vram:
+                        # Use the real VRAM total when known; do NOT bloat to a 99.9 default when it isn't -
+                        # the renderer shows VRAM used-only and aligns it to the (known) RAM column, so a big
+                        # default just widened the whole widget for nothing.
                         vt = getattr(self.widget, 'vram_total', 0.0) or 0.0
-                        mem_total = max(mem_total, vt if vt > 0 else 99.9)
+                        if vt > 0:
+                            mem_total = max(mem_total, vt)
+                    # Only if nothing is known yet (e.g. VRAM-only at cold start) fall back to a modest column.
+                    if (monitor_ram or monitor_vram) and mem_total <= 0:
+                        mem_total = 32.0
                     mem_ref = f"{mem_total:.1f}/{mem_total:.1f}G" if mem_total > 0 else ""
 
                     cpu_width = 0

--- a/src/netspeedtray/views/widget/layout.py
+++ b/src/netspeedtray/views/widget/layout.py
@@ -233,36 +233,50 @@ class WidgetLayoutManager:
                     else:
                         hw_suffix_width = 0
 
+                    # Worst-case memory column, reserved for BOTH stacked rows so they align and never
+                    # clip. Uses the machine TOTAL (used can never exceed it), not a live used value: a
+                    # live ram_used is None at cold start, which previously SKIPPED this reservation and
+                    # clipped the readout (e.g. "11.6/15.7G" -> "1") until the user toggled hardware off/on.
+                    # Falls back to psutil RAM / a generous default when a total isn't known yet; any slack
+                    # lands on the LEFT (toward the app icons), not as a gap. Matches the renderer's fixed
+                    # memory column (utils/widget_renderer.draw_hardware_stats), which uses max(totals).
+                    mem_total = 0.0
+                    if monitor_ram:
+                        rt = getattr(self.widget, 'ram_total', 0.0) or 0.0
+                        if rt <= 0:
+                            try:
+                                import psutil
+                                rt = psutil.virtual_memory().total / (1024 ** 3)
+                            except Exception:
+                                rt = 99.9
+                        mem_total = max(mem_total, rt)
+                    if monitor_vram:
+                        vt = getattr(self.widget, 'vram_total', 0.0) or 0.0
+                        mem_total = max(mem_total, vt if vt > 0 else 99.9)
+                    mem_ref = f"{mem_total:.1f}/{mem_total:.1f}G" if mem_total > 0 else ""
+
                     cpu_width = 0
                     if "cpu" in display_order and monitor_cpu:
-                        cpu_val = int(getattr(self.widget, 'cpu_usage', 0))
                         cpu_width = label_offset + self.metrics.horizontalAdvance(" 100%")
                         if hw_suffix_width:
                             cpu_width += hw_suffix_width
-                        if monitor_ram and getattr(self.widget, 'ram_used', None) is not None:
-                            used = getattr(self.widget, 'ram_used', 0)
-                            total = getattr(self.widget, 'ram_total', -1.0)
-                            mem_text = f"{used:.1f}/{total:.1f}G" if total and total > 0 else f"{used:.1f}G"
+                        if monitor_ram and mem_ref:
                             if stack_hw: # inline
-                                cpu_width += self.metrics.horizontalAdvance(f" | {mem_text}")
+                                cpu_width += self.metrics.horizontalAdvance(f" | {mem_ref}")
                             else: # row
-                                cpu_width = max(cpu_width, self.metrics.horizontalAdvance(mem_text))
+                                cpu_width = max(cpu_width, self.metrics.horizontalAdvance(mem_ref))
                         cpu_width += margin # Reclaim Left Margin offset budget from draw_hardware_stats
-                                
+
                     gpu_width = 0
                     if "gpu" in display_order and monitor_gpu:
-                        gpu_val = int(getattr(self.widget, 'gpu_usage', 0))
                         gpu_width = label_offset + self.metrics.horizontalAdvance(" 100%")
                         if hw_suffix_width:
                             gpu_width += hw_suffix_width
-                        if monitor_vram and getattr(self.widget, 'vram_used', None) is not None:
-                            used = getattr(self.widget, 'vram_used', 0)
-                            total = getattr(self.widget, 'vram_total', -1.0)
-                            mem_text = f"{used:.1f}/{total:.1f}G" if total and total > 0 else f"{used:.1f}G"
+                        if monitor_vram and mem_ref:
                             if stack_hw: # inline
-                                gpu_width += self.metrics.horizontalAdvance(f" | {mem_text}")
+                                gpu_width += self.metrics.horizontalAdvance(f" | {mem_ref}")
                             else: # row
-                                gpu_width = max(gpu_width, self.metrics.horizontalAdvance(mem_text))
+                                gpu_width = max(gpu_width, self.metrics.horizontalAdvance(mem_ref))
                         gpu_width += margin # Reclaim Left Margin offset budget
                             
                     if stack_hw and monitor_cpu and monitor_gpu:


### PR DESCRIPTION
## What

Reworks the side-by-side hardware readout so it stays **aligned, still, and compact**, and fixes a language-change clip. Fixes #179 (and the follow-on layout issues surfaced during on-device testing by @CMTriX).

## The problems (all one root: live-width layout)

- The whole block **slid sideways** by a digit when a CPU/GPU percentage ticked over (9->10, 99->100), because the tray-side anchor measured the live text width.
- **RAM/VRAM didn't line up** between the CPU and GPU rows when one had a temp sensor and the other didn't.
- After a **language change + restart**, the memory reading **clipped** ("11.6/15.7G" -> "1") until hardware was toggled off/on, because the reservation was gated on a live `ram_used` that's empty at cold start.
- The network readout **floated far left** of the hardware, and there was too much dead space to the tray.

## The fix

- `draw_hardware_stats` draws **percent / suffix / memory as fixed-width columns** (percent plain text, positioned in its column; memory right-justified), so rows align and the segment width is constant.
- `layout.py` reserves the memory column from the machine **total** (via psutil when not yet populated), not a live value.
- Network is **right-aligned in its reserved slot** so it hugs the hardware; the side-by-side anchor uses the content **right edge** (not width) so the unit can't clip.
- Gaps trimmed; **Show RAM / Show VRAM grey out** when their CPU/GPU monitor is off.

## Verified

Rendered every scenario offscreen via the real `WidgetLayoutManager` (owner-approved). Idle/busy renders are pixel-identical width (no movement); columns align; nothing clips. Full suite passes.

## Note

**Supersedes #181** - this branch includes #181's percent commit as its base, then replaces the `>3d` approach with the fixed-column layout (the percent is plain text now). Close #181 in favour of this.
