### PR TITLE
fix(hardware): honest LHM guidance now that WMI is gone in v0.9.5+ (#134)

### DIFF
--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -88,8 +88,7 @@ class StatsMonitorThread(QThread):
         # LibreHardwareMonitor / OpenHardwareMonitor WMI object.
         # None = not yet tried, False = tried and unavailable, object = connected.
         self._wmi_ohm: Any = None
-        self._ohm_empty_ns_logged: set = set()  # Namespaces already warned about (log once)
-        self._ohm_probe_failed_logged: set = set()  # Namespaces whose probe-failure was already logged
+        self._ohm_guidance_logged: bool = False  # One-time "no sensor source" guidance, logged only when NO namespace connects
         self._lhm_notice_emitted: bool = False  # One-time notification flag
         self._lhm_check_polls: int = 0  # Count polls before emitting notice
         self._nvidia_smi_path: Optional[str] = self._get_cached_path("nvidia-smi")
@@ -611,6 +610,14 @@ class StatsMonitorThread(QThread):
         """
         if self._wmi_ohm is not None or not win32com.client:
             return
+        # Probe every namespace BEFORE deciding on any user-facing guidance: a working
+        # fallback (e.g. a live root\OpenHardwareMonitor) must not trigger a misleading
+        # "install LHM v0.9.4" note just because the LHM namespace happens to be absent
+        # (issue #134 / CMTriX - his sensors came from a live OHM publisher). Per-namespace
+        # outcomes stay at DEBUG; the single actionable line is logged once, after the loop,
+        # only if NOTHING connected.
+        saw_empty_namespace = False
+        probe_errors: List[str] = []
         for ns in ("root\\LibreHardwareMonitor", "root\\OpenHardwareMonitor"):
             try:
                 obj = win32com.client.GetObject(f"winmgmts:{ns}")
@@ -620,36 +627,35 @@ class StatsMonitorThread(QThread):
                 results = obj.ExecQuery("SELECT SensorType FROM Sensor")
                 count = sum(1 for _ in results)
                 if count == 0:
-                    if ns not in self._ohm_empty_ns_logged:
-                        self._ohm_empty_ns_logged.add(ns)
-                        self.logger.info(
-                            "Hardware monitor: %s namespace exists but has 0 sensors. "
-                            "Ensure LibreHardwareMonitor is running as Administrator.", ns
-                        )
+                    saw_empty_namespace = True
+                    self.logger.debug("Hardware monitor: %s exists but exposes 0 sensors.", ns)
                     continue
                 self._wmi_ohm = obj
                 self.logger.info("Hardware monitor: connected to %s (%d sensors).", ns, count)
                 return
             except Exception as e:
-                # Surface the first failure per namespace at INFO so a support bundle
-                # shows whether LHM/OHM was simply not running (issue #130); quieter after.
-                if ns not in self._ohm_probe_failed_logged:
-                    self._ohm_probe_failed_logged.add(ns)
-                    tool = ns.rsplit("\\", 1)[-1]  # LibreHardwareMonitor / OpenHardwareMonitor
-                    # 0x8004100e (WBEM_E_INVALID_NAMESPACE) means the namespace does
-                    # not exist - which happens both when the tool isn't running AND
-                    # when LibreHardwareMonitor v0.9.5+ is running (it removed its WMI
-                    # provider in the ".NET 10 build"). Don't advise "run as admin"
-                    # here: for a missing namespace that's misleading. The genuine
-                    # "running but not elevated" case is the 0-sensors branch above.
-                    self.logger.info(
-                        "Hardware monitor: %s namespace not found (%s). Start %s if it "
-                        "is not running. Note: LibreHardwareMonitor v0.9.5+ removed its "
-                        "WMI provider, so CPU/GPU temps and power need LHM v0.9.4 (the "
-                        "last WMI-capable release).", ns, e, tool
-                    )
-                else:
-                    self.logger.debug("Hardware monitor: %s probe failed: %s", ns, e)
+                # A missing namespace (0x8004100e WBEM_E_INVALID_NAMESPACE) is normal when
+                # that particular tool isn't the one running - keep it quiet here.
+                tool = ns.rsplit("\\", 1)[-1]  # LibreHardwareMonitor / OpenHardwareMonitor
+                probe_errors.append(f"{tool}: {e}")
+                self.logger.debug("Hardware monitor: %s probe failed: %s", ns, e)
+        # Nothing connected across all namespaces. Surface ONE actionable line, once.
+        if not self._ohm_guidance_logged:
+            self._ohm_guidance_logged = True
+            if saw_empty_namespace:
+                # Genuine "running but not elevated" case: a namespace exists, 0 sensors.
+                self.logger.info(
+                    "Hardware monitor: a sensor namespace exists but exposes 0 sensors. "
+                    "Run LibreHardwareMonitor as Administrator to expose CPU/GPU temps and power."
+                )
+            else:
+                # No namespace at all: tool not running, or LHM v0.9.5+ (which removed WMI).
+                self.logger.info(
+                    "Hardware monitor: no CPU/GPU sensor source found (%s). Start "
+                    "LibreHardwareMonitor if it is not running. Note: LibreHardwareMonitor "
+                    "v0.9.5+ removed its WMI provider, so temps and power need LHM v0.9.4 "
+                    "(the last WMI-capable release).", "; ".join(probe_errors)
+                )
         # Leave _wmi_ohm as None so we retry next poll (LHM may not be running yet)
 
     def _poll_cpu_temperature(self) -> Optional[float]:

--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -636,9 +636,17 @@ class StatsMonitorThread(QThread):
                 if ns not in self._ohm_probe_failed_logged:
                     self._ohm_probe_failed_logged.add(ns)
                     tool = ns.rsplit("\\", 1)[-1]  # LibreHardwareMonitor / OpenHardwareMonitor
+                    # 0x8004100e (WBEM_E_INVALID_NAMESPACE) means the namespace does
+                    # not exist - which happens both when the tool isn't running AND
+                    # when LibreHardwareMonitor v0.9.5+ is running (it removed its WMI
+                    # provider in the ".NET 10 build"). Don't advise "run as admin"
+                    # here: for a missing namespace that's misleading. The genuine
+                    # "running but not elevated" case is the 0-sensors branch above.
                     self.logger.info(
-                        "Hardware monitor: %s not available (%s). Run %s as Administrator "
-                        "to expose CPU/GPU temps and power.", ns, e, tool
+                        "Hardware monitor: %s namespace not found (%s). Start %s if it "
+                        "is not running. Note: LibreHardwareMonitor v0.9.5+ removed its "
+                        "WMI provider, so CPU/GPU temps and power need LHM v0.9.4 (the "
+                        "last WMI-capable release).", ns, e, tool
                     )
                 else:
                     self.logger.debug("Hardware monitor: %s probe failed: %s", ns, e)

--- a/src/netspeedtray/tests/unit/test_hardware_monitoring.py
+++ b/src/netspeedtray/tests/unit/test_hardware_monitoring.py
@@ -234,6 +234,47 @@ class TestHardwareMonitoring:
             # Should NOT have cached the connection - still None for retry
             assert monitor_thread._wmi_ohm is None
 
+    def test_init_ohm_wmi_no_v094_guidance_when_fallback_connects(self, monitor_thread):
+        """LHM namespace absent but a live OpenHardwareMonitor namespace has sensors:
+        connect to OHM and do NOT emit the misleading 'need LHM v0.9.4' guidance
+        (issue #134 - CMTriX's sensors came from a live OHM publisher, not stale data)."""
+        monitor_thread._wmi_ohm = None
+        monitor_thread._ohm_guidance_logged = False
+        monitor_thread.logger = MagicMock()
+
+        ohm_obj = MagicMock()
+        ohm_obj.ExecQuery.return_value = [MagicMock() for _ in range(68)]  # 68 live sensors
+
+        def fake_get_object(path):
+            if "LibreHardwareMonitor" in path:
+                raise Exception("(-2147217394, 'OLE error 0x8004100e', None, None)")
+            return ohm_obj  # root\OpenHardwareMonitor
+
+        with patch('win32com.client.GetObject', side_effect=fake_get_object), \
+             patch('pythoncom.CoInitialize'):
+            monitor_thread._init_ohm_wmi()
+
+        assert monitor_thread._wmi_ohm is ohm_obj  # connected via the OHM fallback
+        templates = " ".join(str(c.args[0]) for c in monitor_thread.logger.info.call_args_list if c.args)
+        assert "v0.9.4" not in templates, "must not cry wolf when a fallback namespace connects"
+        assert monitor_thread._ohm_guidance_logged is False  # no guidance was needed
+
+    def test_init_ohm_wmi_guidance_once_when_nothing_connects(self, monitor_thread):
+        """When no namespace connects at all, emit the 'need v0.9.4' guidance exactly once."""
+        monitor_thread._wmi_ohm = None
+        monitor_thread._ohm_guidance_logged = False
+        monitor_thread.logger = MagicMock()
+
+        with patch('win32com.client.GetObject', side_effect=Exception("0x8004100e")), \
+             patch('pythoncom.CoInitialize'):
+            monitor_thread._init_ohm_wmi()
+            monitor_thread._init_ohm_wmi()  # a second poll must not re-log the guidance
+
+        assert monitor_thread._wmi_ohm is None
+        guidance = [c for c in monitor_thread.logger.info.call_args_list
+                    if c.args and "v0.9.4" in str(c.args[0])]
+        assert len(guidance) == 1, "guidance must be logged exactly once across retries"
+
     # ------------------------------------------------------------------
     # CPU temperature polling
     # ------------------------------------------------------------------

--- a/src/netspeedtray/views/temp_onboarding_dialog.py
+++ b/src/netspeedtray/views/temp_onboarding_dialog.py
@@ -19,8 +19,11 @@ from PyQt6.QtWidgets import (
 from netspeedtray.utils import styles as su
 from netspeedtray.utils.dwm import apply_win11_chrome
 
-# The download lives on the project's releases page; opened in the user's browser.
-LHM_RELEASES_URL = "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases"
+# LibreHardwareMonitor v0.9.5+ dropped its WMI provider (the ".NET 10 build"
+# change, Jan 2026), so temps/power only work with v0.9.4 - the last WMI-capable
+# release. Pin the download there until we read LHM's HTTP server instead (2.1).
+# Opened in the user's browser.
+LHM_RELEASES_URL = "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/tag/v0.9.4"
 
 
 class TempOnboardingDialog(QDialog):


### PR DESCRIPTION
## What

LibreHardwareMonitor **removed its WMI provider in v0.9.5** (the ".NET 10 build" change, Jan 2026). The publishing API it relied on (`System.Management.Instrumentation`) is .NET-Framework-only, so `root\LibreHardwareMonitor` no longer exists in *any* current LHM build - elevated or not, Framework or Core. This is why #134's reporter gets `0x8004100e` (WBEM_E_INVALID_NAMESPACE) even with an elevated Framework build whose UI shows sensors (LHM reads those in-process, not via WMI).

We can't restore the data over WMI (that's a 2.1 item: read LHM's HTTP `data.json`), but our *guidance* was actively misleading. This PR makes it honest:

- **`monitor_thread._init_ohm_wmi`**: on `INVALID_NAMESPACE` we told users to "Run as Administrator" - chasing a permission problem that doesn't exist. That branch fires when the namespace is *absent* (tool not running, or LHM v0.9.5+). The message now says so and points at v0.9.4. The genuine not-elevated case is the separate `count == 0` branch, which keeps its admin advice.
- **`temp_onboarding_dialog.LHM_RELEASES_URL`**: the "Get LibreHardwareMonitor" link pointed at the generic releases page, which now serves WMI-less v0.9.5/0.9.6 - so following our own onboarding produced a broken result. Now pinned at the **v0.9.4** release (last WMI-capable).

## Scope / risk
- No data-path change; the affected message is a raw log string (no i18n touch).
- The onboarding URL test asserts only the `github.com/LibreHardwareMonitor/` prefix, which the tag URL still satisfies (passes).

Diagnosis details in #134.