### PR TITLE
fix(taskbar): stop the no-taskbar preferred-monitor fallback logging every second

### DIFF
--- a/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
+++ b/src/netspeedtray/tests/unit/test_taskbar_preferred_monitor.py
@@ -138,3 +138,25 @@ class TestTaskbarReadinessGate:
     def test_not_ready_when_taskbar_window_unqueryable(self):
         with patch.object(tbu, "win32gui", _fake_win32gui(rect_raises=True)):
             assert _taskbar_window_is_ready(2, "Shell_SecondaryTrayWnd") is False
+
+
+def test_preferred_monitor_fallback_logs_once_per_state(caplog):
+    """The no-taskbar fallback logs once per distinct state, not once per (~1s) reposition tick (#188)."""
+    import logging
+
+    tbu._last_fallback_log_key = None
+    tb = _mock_tb(1, r"\.\DISPLAY1", PRIMARY, (0, 0, 2560, 1440), is_primary=True)
+
+    def count():
+        return sum(1 for r in caplog.records if "did not match" in r.getMessage())
+
+    try:
+        with caplog.at_level(logging.INFO, logger="NetSpeedTray.TaskbarUtils"):
+            for _ in range(3):  # three per-second ticks, same state
+                tbu._log_preferred_monitor_fallback("XENEON EDGE", [tb])
+            assert count() == 1, "identical fallback state must log only once, not per tick"
+
+            tbu._log_preferred_monitor_fallback("OTHER MON", [tb])  # preference changed -> logs again
+            assert count() == 2, "a genuine state change should re-log once"
+    finally:
+        tbu._last_fallback_log_key = None  # don't leak module state to other tests

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -601,6 +601,14 @@ def _select_taskbar_for_screen(
     return None
 
 
+# The preferred-monitor fallback is logged at most once per distinct state, not once per reposition
+# tick. get_taskbar_info() runs on the ~1s safety-net loop, so an unmatched preferred monitor (a
+# taskbar-less accessory display like the Corsair Xeneon Edge, #188) otherwise spammed this INFO line
+# every second and bloated Support Bundles. Keyed on (preferred, taskbar set) so a genuine topology
+# change (monitor plugged/unplugged, or a changed preference) still logs once more.
+_last_fallback_log_key: Optional[tuple] = None
+
+
 def _log_preferred_monitor_fallback(
     preferred_screen_name: str, taskbars: List[TaskbarInfo]
 ) -> None:
@@ -609,7 +617,16 @@ def _log_preferred_monitor_fallback(
     selection fell back to primary: the preferred name plus every enumerated
     taskbar's class, stored name, re-resolved name, and geometry. Turns an
     otherwise-silent fallback into an immediately diagnosable one (#72 / #166).
+
+    Throttled to once per distinct (preferred, taskbar-set) state so the ~1s
+    safety-net refresh can't spam it (#188).
     """
+    global _last_fallback_log_key
+    key = (preferred_screen_name, tuple(sorted((tb.hwnd, tb.screen_name) for tb in taskbars)))
+    if key == _last_fallback_log_key:
+        return
+    _last_fallback_log_key = key
+
     details = []
     for tb in taskbars:
         resolved = tb.get_screen()


### PR DESCRIPTION
## What

Throttles the "preferred monitor has no taskbar → using primary" INFO log so it fires **once per distinct state** instead of **once every ~1 second**.

## Why

`get_taskbar_info()` runs on the ~1s safety-net refresh loop. When a preferred monitor has no taskbar of its own — a taskbar-less accessory display like the **Corsair Xeneon Edge** (#188), or any secondary monitor with "Show taskbar on all displays" off — it logged the same `_log_preferred_monitor_fallback` INFO line every tick. A reporter's log was **248 KB, almost entirely this one line**, which bloats Support Bundles and buries real events.

## How

A module-level `_last_fallback_log_key` keyed on `(preferred_screen_name, taskbar set)`. The log fires once per distinct state and re-fires on a genuine topology change (monitor plugged/unplugged, or a changed preference), but is skipped on repeat ticks. The cheap key check runs before building the (more expensive) diagnostic detail string.

- **INFO-level logging only — no change to positioning behavior.**
- +1 unit test (`test_preferred_monitor_fallback_logs_once_per_state`).
- Full unit suite: **767 passed, 2 xfailed.**

Surfaced by a support bundle on #188 (the free-float feature itself is tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMYiaw88CzarcLA7EkLmDr
