### PR TITLE
feat(widget): right-align to the tray + fix secondary-clock overlap (#186) & chevron gap (#161)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 - **Network identity on the widget - see *which* Wi-Fi network you're on, not just how fast.** A new optional indicator shows the Wi-Fi **band** (2.4G / 5G / 6G) - the one thing Windows hides at a glance - and, optionally, the **network name (SSID)**, as a small pill/badge beside your speed (the name and band combine into one capsule). Turn it on in **Settings > Network > Network identity**. The band can be shown *Always* (neutral), *Color-coded* (2.4G amber / 5G green / 6G blue), or **Alert only** - a red `2.4G` appears *only* when your PC has silently dropped to the slow band, and the widget stays clean otherwise. Directly answers "did my PC quietly rejoin 2.4 GHz after the last reconnect?".
   - **About the Location permission (please read):** the band works on every PC and needs **no permission**. The **network name (SSID)** is different - **Windows only reveals the SSID to apps that have Location access** - so choosing to show the name asks you to turn on Windows Location. This is a **Windows privacy gate, not GPS or tracking**: NetSpeedTray does not use your position; it reads the network name **locally, only to show it on the widget**, and never stores or transmits it. A one-time in-app explainer spells this out, with a button straight to the Location settings and a "just show the band" option. See the [Privacy Policy](privacy.md) for the full detail.
 
+### Changed
+- **The readout hugs the system tray more consistently.** In Cycle mode and the single-metric (CPU-only / GPU-only) layouts, a narrower reading used to leave a small gap between the widget and the system tray. Every mode now right-aligns its content to the tray edge, so the widget sits flush against the tray with the spare width tucked onto the app-icon side, where it's invisible. (#106)
+
+### Fixed
+- **The widget could crowd the "show hidden icons" (∧) button.** Its right edge sat flush against the tray chevron, making that button awkward to click. It now keeps a small gap so the chevron stays fully clickable. (#161)
+- **Pinned to a second monitor, the widget could land on the clock.** On a secondary display whose taskbar has no system tray of its own, the widget's default position could overlap that monitor's date/time. It now leaves room for the clock (tunable via `secondary_clock_reserve_px` for wide date formats); as always, dragging it once remembers your exact spot. (#186)
+- **Runaway logging on taskbar-less monitors.** When a preferred monitor had no taskbar, NetSpeedTray wrote its "falling back to the primary taskbar" note to the log every second, bloating log files and Support Bundles. It now logs that once per change. (#191)
+
 ---
 
 ## [2.0.1] - Unreleased

--- a/src/netspeedtray/constants/config.py
+++ b/src/netspeedtray/constants/config.py
@@ -81,6 +81,9 @@ class ConfigConstants:
     DEFAULT_START_WITH_WINDOWS: Final[bool] = True
     DEFAULT_TRAY_OFFSET_X: Final[int] = 0
     DEFAULT_TRAY_OFFSET_Y: Final[int] = 3
+    # A Win11 secondary-monitor taskbar has no tray/clock child HWND to hug, so on a preferred
+    # secondary display we reserve this many logical px off the screen edge to clear its clock (#186).
+    DEFAULT_SECONDARY_CLOCK_RESERVE_PX: Final[int] = 75
     DEFAULT_LEGEND_POSITION: Final[str] = data.legend_position.DEFAULT_LEGEND_POSITION
     DEFAULT_SHOW_LEGEND: Final[bool] = False
 
@@ -173,6 +176,7 @@ class ConfigConstants:
         "short_unit_labels": DEFAULT_SHORT_UNIT_LABELS,
         "tray_offset_x": DEFAULT_TRAY_OFFSET_X,
         "tray_offset_y": DEFAULT_TRAY_OFFSET_Y,
+        "secondary_clock_reserve_px": DEFAULT_SECONDARY_CLOCK_RESERVE_PX,
         "graph_window_pos": None,
         "settings_window_pos": None,
         "app_activity_window_pos": None,
@@ -308,6 +312,7 @@ class ConfigConstants:
         # negative offset; clamping it to 0 snapped the widget back left on the next reposition.
         "tray_offset_x": {"type": int, "default": DEFAULT_TRAY_OFFSET_X, "min": -500, "max": 500},
         "tray_offset_y": {"type": int, "default": DEFAULT_TRAY_OFFSET_Y, "min": 0, "max": 500},
+        "secondary_clock_reserve_px": {"type": int, "default": DEFAULT_SECONDARY_CLOCK_RESERVE_PX, "min": 0, "max": 500},
         "graph_window_pos": {"type": (dict, type(None)), "default": None},
         "settings_window_pos": {"type": (dict, type(None)), "default": None},
         "app_activity_window_pos": {"type": (dict, type(None)), "default": None},

--- a/src/netspeedtray/constants/layout.py
+++ b/src/netspeedtray/constants/layout.py
@@ -50,6 +50,9 @@ class LayoutConstants:
     # close to the hardware rather than floating far from it.
     WIDGET_SEGMENT_GAP_AFTER_NETWORK_PX: Final[int] = 10
     WIDGET_SEGMENT_GAP_BETWEEN_HARDWARE_PX: Final[int] = 5
+    # Minimum gap (logical px) kept between the widget's tray-side edge and the tray boundary /
+    # the "^" show-hidden-icons chevron, so the widget never abuts it and steals its clicks (#161 pt1).
+    TRAY_EDGE_MIN_GAP_PX: Final[int] = 8
 
     def __init__(self) -> None:
         self.validate()

--- a/src/netspeedtray/core/input_handler.py
+++ b/src/netspeedtray/core/input_handler.py
@@ -147,7 +147,9 @@ class InputHandler(QObject):
                 from netspeedtray.utils.taskbar_utils import get_taskbar_info
                 from netspeedtray import constants
                 
-                tb_info = get_taskbar_info()
+                # Resolve against the PREFERRED taskbar (a secondary drag must not measure its offset
+                # against the primary taskbar's geometry) (#186).
+                tb_info = get_taskbar_info(preferred_screen_name=config.get("preferred_monitor"))
                 edge = tb_info.get_edge_position()
                 dpi_scale = tb_info.dpi_scale if tb_info.dpi_scale > 0 else 1.0
                 
@@ -162,9 +164,14 @@ class InputHandler(QObject):
                     if tray_rect:
                         right_boundary = tray_rect[0] / dpi_scale
                     else:
+                        # Secondary taskbar (no tray HWND): match the calculator's clock reserve (#186)
+                        # so the saved offset keeps the widget in the same clock-clear spot.
+                        reserve = config.get("secondary_clock_reserve_px",
+                                             constants.config.defaults.DEFAULT_SECONDARY_CLOCK_RESERVE_PX)
                         screen = tb_info.get_screen()
-                        right_boundary = float(screen.geometry().right() + 1) if screen else (tb_info.rect[2] / dpi_scale)
-                    
+                        screen_right = float(screen.geometry().right() + 1) if screen else (tb_info.rect[2] / dpi_scale)
+                        right_boundary = screen_right - reserve
+
                     # Current Widget X
                     current_x_log = self.widget.pos().x() # Use logical pos from pos()
                     widget_width = self.widget.width()

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -271,16 +271,26 @@ class PositionCalculator:
         y_center = y_origin + (visible_tb_height - widget_height) / 2.0
         y = round(y_center)
         
-        # Calculate X: align to right (system tray side) with offset.
-        # right_boundary is the left edge of the tray/notification area when available.
+        # Calculate X: align to the right (system-tray side), keeping the widget clear of the tray.
         tray_rect = taskbar_info.get_tray_rect()
-        right_boundary = round(tray_rect[0] / dpi_scale) if tray_rect else (full_geom.right() + 1)
+        offset = config.get('tray_offset_x', constants.config.defaults.DEFAULT_TRAY_OFFSET_X)
+        if tray_rect:
+            # Normal taskbar: hug the tray's left edge, but floor the gap so the widget never abuts
+            # the show-hidden-icons "^" chevron and steals its clicks (#161 pt1).
+            right_boundary = round(tray_rect[0] / dpi_scale)
+            offset = max(offset, constants.layout.TRAY_EDGE_MIN_GAP_PX)
+        else:
+            # A Win11 SECONDARY taskbar (Shell_SecondaryTrayWnd) has no TrayNotifyWnd child, so
+            # get_tray_rect() is None. Its clock is shell-drawn with no HWND to hug; reserve an
+            # estimate of the clock width off the screen edge instead of landing on it (#186).
+            reserve = config.get('secondary_clock_reserve_px',
+                                 constants.config.defaults.DEFAULT_SECONDARY_CLOCK_RESERVE_PX)
+            right_boundary = (full_geom.right() + 1) - reserve
 
         # left_boundary is the right edge of the task list/app-icons region when available.
         tasklist_rect = taskbar_info.tasklist_rect
         left_boundary = round(tasklist_rect[2] / dpi_scale) if tasklist_rect else full_geom.left()
 
-        offset = config.get('tray_offset_x', constants.config.defaults.DEFAULT_TRAY_OFFSET_X)
         x = round(right_boundary - widget_width - offset)
         
         # Safety check: don't overlap with app icons on left
@@ -395,7 +405,9 @@ class PositionCalculator:
                     vis_bot = round(taskbar_info.rect[3] / dpi_scale)
                 fixed_y = round((vis_top + vis_bot) / 2.0 - widget_height / 2.0)
                 
-                right_boundary = (round(taskbar_info.get_tray_rect()[0] / dpi_scale) - widget_width) if taskbar_info.get_tray_rect() else (screen.geometry().right() - widget_width)
+                # Keep the same tray-side gap as the auto-placement, so a user can't drag the widget
+                # flush against the "^" chevron (#161 pt1).
+                right_boundary = (round(taskbar_info.get_tray_rect()[0] / dpi_scale) - widget_width - constants.layout.TRAY_EDGE_MIN_GAP_PX) if taskbar_info.get_tray_rect() else (screen.geometry().right() - widget_width)
                 left_boundary = (round(taskbar_info.tasklist_rect[2] / dpi_scale) + constants.layout.DEFAULT_PADDING) if taskbar_info.tasklist_rect else screen.geometry().left()
                 
                 constrained_x = max(left_boundary, min(desired_pos.x(), right_boundary))

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -27,18 +27,40 @@ class TestPositionCalculator(unittest.TestCase):
         self.mock_taskbar.hwnd = 12345
 
     def test_calculate_position_bottom_edge(self):
-        """Test position calculation for bottom taskbar."""
+        """Test position calculation for bottom taskbar (offset >= the #161 tray-edge floor)."""
         widget_size = (100, 40) # w, h
-        config = {'tray_offset_x': 5}
-        
+        config = {'tray_offset_x': 10}   # >= TRAY_EDGE_MIN_GAP_PX (8), so the floor doesn't alter it
+
         # Expected Y: tb_top + (tb_height - widget_h) / 2
         # TB Top = 1040, H = 40. Widget H = 40. Y = 1040 + (40-40)/2 = 1040.
-        # Expected X: Tray Left (1700) - Widget W (100) - Offset (5) = 1595.
-        
+        # Expected X: Tray Left (1700) - Widget W (100) - Offset (10) = 1590.
+
         pos = self.calculator.calculate_position(self.mock_taskbar, widget_size, config)
-        
-        self.assertEqual(pos.x, 1595)
+
+        self.assertEqual(pos.x, 1590)
         self.assertEqual(pos.y, 1040)
+
+    def test_tray_edge_min_gap_floor(self):
+        """#161 pt1: a below-floor tray offset (incl. 0) is raised to TRAY_EDGE_MIN_GAP_PX so the
+        widget never abuts the '^' chevron; a larger user offset is preserved."""
+        gap = constants.layout.TRAY_EDGE_MIN_GAP_PX
+        # offset 0 -> floored to `gap`: x = 1700 - 100 - gap
+        pos = self.calculator.calculate_position(self.mock_taskbar, (100, 40), {'tray_offset_x': 0})
+        self.assertEqual(pos.x, 1700 - 100 - gap)
+        # a larger user offset survives untouched
+        pos2 = self.calculator.calculate_position(self.mock_taskbar, (100, 40), {'tray_offset_x': 40})
+        self.assertEqual(pos2.x, 1700 - 100 - 40)
+
+    def test_secondary_taskbar_reserves_clock_width(self):
+        """#186: a preferred secondary taskbar has no tray rect, so the widget anchors a clock-reserve
+        off the screen edge instead of landing on the clock."""
+        self.mock_taskbar.get_tray_rect.return_value = None   # Win11 secondary: no TrayNotifyWnd
+        reserve = constants.config.defaults.DEFAULT_SECONDARY_CLOCK_RESERVE_PX
+        pos = self.calculator.calculate_position(self.mock_taskbar, (100, 40), {})
+        # right_boundary = full_geom.right()+1 - reserve; QRect(0,0,1920,1080).right()==1919 -> +1==1920.
+        # x = right_boundary - width - offset(0)
+        screen_edge = self.mock_screen.geometry.return_value.right() + 1   # 1920
+        self.assertEqual(pos.x, (screen_edge - reserve) - 100)
 
     def test_calculate_position_fallback(self):
         """Test fallback when taskbar is invalid."""

--- a/src/netspeedtray/utils/widget_paint.py
+++ b/src/netspeedtray/utils/widget_paint.py
@@ -248,22 +248,24 @@ def render_widget(painter: QPainter, rect: QRect, renderer: WidgetRenderer, conf
     if font is not None:
         painter.setFont(font)
 
-    # Right-align the side-by-side content so the widget's worst-case width reservation (the anti-jiggle
-    # "888.8"/"100%" headroom, plus any hidden GPU/VRAM segment) shows up as space on the LEFT - toward
-    # the app icons, where it's invisible - instead of a gap between the content and the system tray.
-    # Only side_by_side over-reserves like this; single-metric modes fill their width (graph or one
-    # block) and vertical docking is sized to the taskbar. We have to MEASURE first because the renderer
-    # computes its segment rects from font metrics during the draw, not before - so we run one draw onto
-    # a throwaway surface (the mini-graph's point cache, keyed by data, is simply warmed by it).
+    # Right-align the content so the widget's worst-case width reservation (the anti-jiggle "888.8"/"100%"
+    # headroom, any hidden GPU/VRAM segment, and in cycle mode the widest-phase reserve) shows up as space
+    # on the LEFT - toward the app icons, where it's invisible - instead of a gap between the content and
+    # the system tray (#106). side_by_side over-reserves across segments; cycle over-reserves because it's
+    # sized to the widest phase but draws one narrower phase. network_only/cpu_only/combined already fill
+    # their width and vertical docking is sized to the taskbar. We MEASURE first because the renderer
+    # computes its segment rects from font metrics during the draw, not before - so we run one draw onto a
+    # throwaway surface (the mini-graph's point cache, keyed by data, is simply warmed by it).
     align_dx = 0
-    if mode == "side_by_side" and layout_mode != "vertical" and width > 0:
+    if (mode == "side_by_side" or config.widget_display_mode == "cycle") and layout_mode != "vertical" and width > 0:
         try:
             probe = QImage(max(1, width), max(1, height), QImage.Format.Format_ARGB32_Premultiplied)
             mp = QPainter(probe)
             if font is not None:
                 mp.setFont(font)
             renderer.reset_content_bounds()
-            _draw_side_by_side(mp, renderer, width, height, config, metrics, layout_mode, network_width)
+            # Mode-generic probe: measures side_by_side OR the single resolved cycle phase.
+            _draw_foreground(mp, renderer, width, height, config, metrics, mode, layout_mode, network_width)
             mp.end()
             bounds = renderer.get_content_bounds()
             # Anchor from the content's RIGHT EDGE, not its width: the network segment is right-aligned

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -607,12 +607,16 @@ class WidgetRenderer:
                     self._draw_icon(painter, r['label'], current_x, y, QColor(r['color']))
                 vx = current_x + label_col
                 painter.setPen(self.default_color)
-                # Right-align the percent in its column whenever something trails it on the same row (a
-                # suffix, or inline memory) so "8% (48C)" / "8% | 11.8/15.7G" stay tight and line up across
-                # rows. Left-align only when the percent is alone above a memory row (CPU+RAM), so it lines
-                # up with the memory beneath it.
+                # Right-align the percent in its fixed "100%" column whenever something trails it on the
+                # same row (a suffix, or inline memory) so "8% (48C)" / "8% | 11.8/15.7G" stay tight and
+                # line up across rows. Also right-align when the percent is the row's ONLY content (no
+                # suffix, no memory anywhere) so a sub-100 value hugs the tray instead of leaving the
+                # fixed-column surplus as a gap (#106). Left-align ONLY when it sits alone above a stacked
+                # memory row (CPU+RAM), so it lines up with the memory beneath it (#179).
                 has_trailing = (inline_mem and mem_col and r['mem']) or bool(suffix_col and r['suffix'])
-                px = (vx + pct_col - self.metrics.horizontalAdvance(r['pct'])) if has_trailing else vx
+                has_mem_below = (not inline_mem) and bool(r['mem'])
+                right_align_pct = has_trailing or not has_mem_below
+                px = (vx + pct_col - self.metrics.horizontalAdvance(r['pct'])) if right_align_pct else vx
                 painter.drawText(px, y, r['pct'])
                 if suffix_col and r['suffix']:
                     painter.drawText(vx + pct_col + sp, y, r['suffix'])  # live suffix in its worst-case column


### PR DESCRIPTION
## What

v2.1 **item 3** — the widget-width / right-align work on the position/width spine, with the two adjacent position bugs folded in (`#186`, `#161-pt1`).

Closes #186, closes #161.

> **Stacked on #190** (network identity); the base is `feat/network-identity`. Retarget to `main` once #190 merges.

## Three fixes

### #106 — dead-space right-align
`side_by_side` and `network_only` already hug the tray; this closes the two residual gaps:
- The right-align **probe now fires for `cycle`** mode (which is sized to the widest phase but draws one narrower phase) and is **mode-generic** (measures the resolved phase via `_draw_foreground`).
- In the hardware readout, a sub-100 **percent with nothing trailing now right-aligns** in its fixed `100%` column instead of sitting left — so `cpu_only`/`gpu_only`/`combined` hug the tray. Anti-jiggle preserved (only the draw position moves; the reserve is unchanged).

> Note: `#106` here is the internal work-item label for this dead-space fix. GitHub issue #106 is a separate, already-closed report, so only #186 and #161 auto-close when this merges.

### #161 pt1 — chevron drag-through ✅ live-verified
The widget's tray-side edge landed **flush** on `tray_rect[0]` = the "^" show-hidden-icons chevron (default `tray_offset_x=0`), abutting/stealing its clicks. Floor the gap to `TRAY_EDGE_MIN_GAP_PX` (8 px) in both auto-placement and drag-constrain; larger user offsets are preserved. **Measured live: widget right edge 1690 vs chevron 1698 → 8 px gap.**

### #186 — secondary-monitor clock overlap ⚠️ needs a 2-monitor box
A Win11 secondary taskbar has no `TrayNotifyWnd`, so `get_tray_rect()` is `None` and the right boundary silently fell back to the **screen edge** — dropping the widget on that monitor's clock. Reserve `secondary_clock_reserve_px` (default 75, configurable) off the screen edge in the tray-less branch, and resolve the drag-save against the preferred monitor. **Unit-tested; final visual confirmation needs a two-monitor Win11 setup** (or @Mythos to retest).

## Tests
+3 position tests (gap floor, secondary reserve, updated bottom-edge). Full suite **807 passed, 2 xfailed**.

## Live verification (single-monitor 1920×1080, bottom taskbar)
- **#161**: widget right edge 1690, chevron 1698 → **8 px gap** ✅
- **#106** side_by_side: content hugs the tray (CPU `2%` right-aligned) ✅
- **#186**: not verifiable on one monitor — unit-tested only ⚠️

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMYiaw88CzarcLA7EkLmDr
