### PR TITLE
fix(update): portable ZIP self-update via guided checksum-verified download (#195)

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -112,6 +112,11 @@ if not exist "!RELEASE_DIR!" mkdir "!RELEASE_DIR!"
 :: Move the installer into the release directory
 move "%INSTALLER_DIR%\NetSpeedTray-%VERSION%-x64-Setup.exe" "!RELEASE_DIR!\" > NUL
 
+:: Mark this as the portable build so it uses the guided folder-copy update flow at runtime (#195).
+:: The Inno installer was already built above (Stage 4), so this file lands ONLY inside the zip, never
+:: in the installed copy. Keep the filename in sync with constants.app.PORTABLE_MARKER_FILENAME.
+echo portable> "%DIST_DIR%\NetSpeedTray\portable.marker"
+
 :: Create the portable zip archive
 echo Creating portable zip file...
 powershell -Command "Compress-Archive -Path '%DIST_DIR%\NetSpeedTray' -DestinationPath '!RELEASE_DIR!\%PORTABLE_DIR_NAME%-%VERSION%.zip' -Force" >> "%LOG_FILE%" 2>&1

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - **The widget could crowd the "show hidden icons" (∧) button.** Its right edge sat flush against the tray chevron, making that button awkward to click. It now keeps a small gap so the chevron stays fully clickable. (#161)
 - **Pinned to a second monitor, the widget could land on the clock.** On a secondary display whose taskbar has no system tray of its own, the widget's default position could overlap that monitor's date/time. It now leaves room for the clock (tunable via `secondary_clock_reserve_px` for wide date formats); as always, dragging it once remembers your exact spot. (#186)
 - **Runaway logging on taskbar-less monitors.** When a preferred monitor had no taskbar, NetSpeedTray wrote its "falling back to the primary taskbar" note to the log every second, bloating log files and Support Bundles. It now logs that once per change. (#191)
+- **The portable version couldn't install updates.** On the portable ZIP build, "Download Update" launched the installer, which can't update an unzipped folder in place - so nothing happened. The portable build now runs a guided update: it downloads the new version, verifies the whole download's checksum against the official release, extracts it, and opens it ready for you to copy over your folder (your settings, kept in `%APPDATA%`, are untouched). (#195)
 
 ---
 

--- a/src/netspeedtray/constants/app.py
+++ b/src/netspeedtray/constants/app.py
@@ -13,6 +13,11 @@ class AppConstants:
     ICON_FILENAME: Final[str] = "NetSpeedTray.ico"
     GITHUB_OWNER: Final[str] = "erez-c137"
     GITHUB_REPO: Final[str] = "NetSpeedTray"
+    # Marker file the portable ZIP ships next to the EXE (added at package time in build.bat, just
+    # before Compress-Archive). Its presence is how the app knows it's the portable build and should
+    # use the guided (folder-copy) update flow instead of the Inno installer flow (#195). The installer
+    # copy never contains it. NOTE: build.bat writes this literal name - keep the two in sync.
+    PORTABLE_MARKER_FILENAME: Final[str] = "portable.marker"
 
     def __init__(self) -> None:
         self.validate()

--- a/src/netspeedtray/constants/locales/de_DE.json
+++ b/src/netspeedtray/constants/locales/de_DE.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Update verfügbar",
     "UPDATE_DOWNLOADING_TITLE": "Update wird heruntergeladen",
     "UPDATE_FALLBACK_MESSAGE": "Das In-App-Update konnte nicht abgeschlossen werden. Die Download-Seite wird stattdessen geöffnet.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Eine neue Version von NetSpeedTray ist verfügbar!\n\nAktuell: v{current}\nNeueste: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Neu in v{latest}",
     "WELCOME_2_0_TITLE": "Willkommen bei NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/en_US.json
+++ b/src/netspeedtray/constants/locales/en_US.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Update Available",
     "UPDATE_DOWNLOADING_TITLE": "Downloading update",
     "UPDATE_FALLBACK_MESSAGE": "Couldn't complete the in-app update. Opening the download page instead.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "A new version of NetSpeedTray is available!\n\nCurrent: v{current}\nLatest: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "What's new in v{latest}",
     "WELCOME_2_0_TITLE": "Welcome to NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/es_ES.json
+++ b/src/netspeedtray/constants/locales/es_ES.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Actualización disponible",
     "UPDATE_DOWNLOADING_TITLE": "Descargando actualización",
     "UPDATE_FALLBACK_MESSAGE": "No se pudo completar la actualización en la aplicación. Se abrirá la página de descarga en su lugar.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "¡Una nueva versión de NetSpeedTray está disponible!\n\nActual: v{current}\nÚltima: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Novedades en v{latest}",
     "WELCOME_2_0_TITLE": "Te damos la bienvenida a NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/fr_FR.json
+++ b/src/netspeedtray/constants/locales/fr_FR.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Mise à jour disponible",
     "UPDATE_DOWNLOADING_TITLE": "Téléchargement de la mise à jour",
     "UPDATE_FALLBACK_MESSAGE": "Impossible de terminer la mise à jour intégrée. Ouverture de la page de téléchargement à la place.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Une nouvelle version de NetSpeedTray est disponible !\n\nActuelle : v{current}\nDernière : v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Nouveautés de la v{latest}",
     "WELCOME_2_0_TITLE": "Bienvenue dans NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/ja_JP.json
+++ b/src/netspeedtray/constants/locales/ja_JP.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "更新があります",
     "UPDATE_DOWNLOADING_TITLE": "更新をダウンロード中",
     "UPDATE_FALLBACK_MESSAGE": "アプリ内更新を完了できませんでした。代わりにダウンロードページを開きます。",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "NetSpeedTray の新しいバージョンが利用可能です!\n\n現在 : v{current}\n最新 : v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "v{latest} の新機能",
     "WELCOME_2_0_TITLE": "NetSpeedTray 2.0 へようこそ",

--- a/src/netspeedtray/constants/locales/ko_KR.json
+++ b/src/netspeedtray/constants/locales/ko_KR.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "업데이트 가능",
     "UPDATE_DOWNLOADING_TITLE": "업데이트 다운로드 중",
     "UPDATE_FALLBACK_MESSAGE": "앱 내 업데이트를 완료할 수 없습니다. 대신 다운로드 페이지를 엽니다.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "NetSpeedTray의 새 버전을 사용할 수 있습니다!\n\n현재: v{current}\n최신: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "v{latest} 새로운 기능",
     "WELCOME_2_0_TITLE": "NetSpeedTray 2.0에 오신 것을 환영합니다",

--- a/src/netspeedtray/constants/locales/nl_NL.json
+++ b/src/netspeedtray/constants/locales/nl_NL.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Update beschikbaar",
     "UPDATE_DOWNLOADING_TITLE": "Update downloaden",
     "UPDATE_FALLBACK_MESSAGE": "Kan de in-app-update niet voltooien. De downloadpagina wordt in plaats daarvan geopend.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Een nieuwe versie van NetSpeedTray is beschikbaar!\n\nHuidig: v{current}\nNieuwste: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Nieuw in v{latest}",
     "WELCOME_2_0_TITLE": "Welkom bij NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/pl_PL.json
+++ b/src/netspeedtray/constants/locales/pl_PL.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Dostępna aktualizacja",
     "UPDATE_DOWNLOADING_TITLE": "Pobieranie aktualizacji",
     "UPDATE_FALLBACK_MESSAGE": "Nie udało się ukończyć aktualizacji w aplikacji. Zamiast tego zostanie otwarta strona pobierania.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Dostępna jest nowa wersja NetSpeedTray!\n\nObecna: v{current}\nNajnowsza: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Nowości w v{latest}",
     "WELCOME_2_0_TITLE": "Witamy w NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/ru_RU.json
+++ b/src/netspeedtray/constants/locales/ru_RU.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Доступно обновление",
     "UPDATE_DOWNLOADING_TITLE": "Загрузка обновления",
     "UPDATE_FALLBACK_MESSAGE": "Не удалось выполнить обновление в приложении. Вместо этого откроется страница загрузки.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Доступна новая версия NetSpeedTray!\n\nТекущая: v{current}\nПоследняя: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Что нового в v{latest}",
     "WELCOME_2_0_TITLE": "Добро пожаловать в NetSpeedTray 2.0",

--- a/src/netspeedtray/constants/locales/sl_SI.json
+++ b/src/netspeedtray/constants/locales/sl_SI.json
@@ -213,6 +213,8 @@
     "UPDATE_AVAILABLE_TITLE": "Posodobitev na voljo",
     "UPDATE_DOWNLOADING_TITLE": "Prenašanje posodobitve",
     "UPDATE_FALLBACK_MESSAGE": "Posodobitve v aplikaciji ni bilo mogoče dokončati. Namesto tega bo odprta stran za prenos.",
+    "UPDATE_PORTABLE_READY_TITLE": "Update ready to install",
+    "UPDATE_PORTABLE_READY_MESSAGE": "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\nTo finish updating: close NetSpeedTray, then copy everything from that folder into your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.",
     "UPDATE_AVAILABLE_TEXT": "Na voljo je nova različica NetSpeedTray!\n\nTrenutna: v{current}\nNajnovejša: v{latest}",
     "UPDATE_RELEASE_NOTES_LABEL": "Novosti v {latest}",
     "WELCOME_2_0_TITLE": "Dobrodošli v NetSpeedTray 2.0",

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -11,19 +11,32 @@ the old behavior - so the worst case is never worse than before):
 Both the download AND the (potentially network-blocking) signature verification run on
 the worker thread, so the UI never freezes. The download host doesn't have to be
 trusted: the Authenticode + publisher-pin gate is what authorizes execution.
+
+Portable builds can't be updated by an installer (it targets Program Files, not the folder the user
+unzipped), so in portable mode the same worker runs a guided flow instead (#195). A PyInstaller onedir
+ZIP is many files, not one signed binary, so Authenticode on the bootstrap EXE alone would NOT vouch
+for the _internal/ payload that actually runs. Instead the whole ZIP's SHA-256 is checked against the
+release's published checksums.txt (fetched over HTTPS) - i.e. the download is exactly as trustworthy as
+fetching that ZIP yourself from the release page. On a match it's extracted and staged in the user's
+Downloads for them to copy over their folder. Settings live in %APPDATA%, so a folder replace never
+touches them. (Installer-grade signing of the portable bundle is a tracked hardening follow-up.)
 """
 from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 import urllib.request
+import zipfile
 from typing import Callable, Optional
 
 from PyQt6.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt6.QtWidgets import QMessageBox, QProgressDialog, QWidget
 
+from netspeedtray import constants
 from netspeedtray.utils.signature_verifier import verify_file
 
 logger = logging.getLogger("NetSpeedTray.UpdateInstaller")
@@ -82,16 +95,126 @@ def launch_installer(path: str) -> None:
     subprocess.Popen([path], close_fds=True)
 
 
+def _safe_extract(zip_path: str, dest_dir: str) -> None:
+    """
+    Extract ``zip_path`` into ``dest_dir``, refusing any member that would escape it (zip-slip).
+
+    The download host is untrusted - the Authenticode gate on the *extracted* EXE is what authorizes
+    the update - so a hostile archive must not be able to write a single byte outside the private temp
+    directory during extraction.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_root = os.path.realpath(dest_dir)
+    with zipfile.ZipFile(zip_path) as zf:
+        for member in zf.namelist():
+            target = os.path.realpath(os.path.join(dest_dir, member))
+            if target != dest_root and not target.startswith(dest_root + os.sep):
+                raise RuntimeError(f"unsafe path in archive: {member!r}")
+        zf.extractall(dest_dir)
+
+
+def _locate_portable_exe(root: str) -> str:
+    """Return the path to the bundled ``<APP_NAME>.exe`` inside an extracted portable tree (raises if
+    absent - a portable archive without the app EXE is not something we hand to the user)."""
+    wanted = f"{constants.app.APP_NAME}.exe".lower()
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            if name.lower() == wanted:
+                return os.path.join(dirpath, name)
+    raise RuntimeError(f"no {constants.app.APP_NAME}.exe in the portable archive")
+
+
+def _downloads_dir() -> str:
+    """The user's Downloads folder if it exists, else their home directory - a persistent, findable
+    place to stage the verified new version (the temp dir gets swept on the next launch)."""
+    home = os.path.expanduser("~")
+    downloads = os.path.join(home, "Downloads")
+    return downloads if os.path.isdir(downloads) else home
+
+
+def _sha256_file(path: str) -> str:
+    """Streaming SHA-256 of a file, as lowercase hex."""
+    import hashlib
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest().lower()
+
+
+def _fetch_checksums(url: str) -> str:
+    """Download the release's checksums.txt over HTTPS (small; capped)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read(1_000_000).decode("utf-8", "replace")
+
+
+def _expected_hash_for(checksums_text: str, filename: str) -> Optional[str]:
+    """
+    Return the lowercase SHA-256 listed for ``filename`` in a checksums.txt, or None if absent.
+
+    The release publishes ``<HASH> <FILENAME>`` lines (uppercase hex from PowerShell Get-FileHash);
+    match the filename case-insensitively and normalize the hash to lowercase.
+    """
+    fn = filename.lower()
+    for line in checksums_text.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        token, name = parts[0].lower(), " ".join(parts[1:]).lower()
+        if name == fn and len(token) == 64 and all(c in "0123456789abcdef" for c in token):
+            return token
+    return None
+
+
+def _unique_dir(path: str) -> str:
+    """
+    Return a directory path that does not currently exist, so a subsequent ``shutil.move`` renames the
+    source *to* it rather than nesting *inside* a surviving directory.
+
+    Tries to clear ``path`` first (a stale staging folder from a previous run); if a locked file leaves
+    it partly present, falls back to ``path-2``, ``path-3``, ... so we never move into a mixed folder.
+    """
+    if not os.path.exists(path):
+        return path
+    shutil.rmtree(path, ignore_errors=True)
+    if not os.path.exists(path):
+        return path
+    i = 2
+    while os.path.exists(f"{path}-{i}"):
+        i += 1
+    return f"{path}-{i}"
+
+
 class _DownloadWorker(QObject):
-    """Downloads, THEN verifies - both on the worker thread so the UI never blocks."""
+    """
+    Downloads, THEN verifies - ALL heavy I/O on the worker thread so the UI never blocks or freezes.
+
+    Installer mode: the downloaded Setup.exe is Authenticode-verified (publisher-pinned) and the emitted
+    path is that EXE; the caller launches it.
+
+    Portable mode: a PyInstaller onedir ZIP is not one signed file, so instead of Authenticode the whole
+    ZIP's SHA-256 is checked against the release's published checksums.txt - i.e. the download is exactly
+    as trustworthy as fetching that ZIP yourself from the release page (#195). On a match the archive is
+    extracted and the app folder is staged (moved) to its final Downloads location *here*, off the UI
+    thread, and ``staged`` carries that final path; the caller only reveals it and shows instructions.
+    """
     progress = pyqtSignal(int)
-    verified = pyqtSignal(str, bool, str)  # path, trusted, reason
+    verified = pyqtSignal(str, bool, str)  # installer path, trusted, reason
+    staged = pyqtSignal(str)               # portable: final staged folder in Downloads
     failed = pyqtSignal(str)
 
-    def __init__(self, url: str, dest: str) -> None:
+    def __init__(self, url: str, dest: str, *, portable: bool = False,
+                 extract_dir: Optional[str] = None, checksums_url: str = "",
+                 expected_name: str = "", ready_target: str = "") -> None:
         super().__init__()
         self._url = url
         self._dest = dest
+        self._portable = portable
+        self._extract_dir = extract_dir
+        self._checksums_url = checksums_url
+        self._expected_name = expected_name
+        self._ready_target = ready_target
         self._cancelled = False
 
     def cancel(self) -> None:
@@ -108,9 +231,34 @@ class _DownloadWorker(QObject):
         if self._cancelled:
             self.failed.emit("cancelled")
             return
-        # Verify on THIS (worker) thread - WinVerifyTrust can block on revocation I/O.
-        result = verify_file(self._dest)
-        self.verified.emit(self._dest, result.trusted, result.reason)
+        try:
+            if self._portable:
+                self._run_portable()
+            else:
+                # Verify on THIS (worker) thread - WinVerifyTrust can block on revocation I/O.
+                result = verify_file(self._dest)
+                self.verified.emit(self._dest, result.trusted, result.reason)
+        except Exception as e:  # noqa: BLE001
+            self.failed.emit(str(e))
+
+    def _run_portable(self) -> None:
+        """Checksum-verify the whole ZIP against the release, then extract + stage. Runs on the worker
+        thread; any problem raises and run() routes it to the browser fallback."""
+        self.progress.emit(-1)  # flip the dialog to a busy indicator during verify/extract/stage
+        if not self._checksums_url or not self._expected_name or not self._ready_target:
+            raise RuntimeError("missing checksums reference for the portable update")
+        checksums = _fetch_checksums(self._checksums_url)
+        expected = _expected_hash_for(checksums, self._expected_name)
+        if not expected:
+            raise RuntimeError("no published checksum for the portable build")
+        actual = _sha256_file(self._dest)
+        if actual != expected:
+            raise RuntimeError("checksum mismatch - the download may be corrupt or tampered")
+        _safe_extract(self._dest, self._extract_dir or "")
+        app_folder = os.path.dirname(_locate_portable_exe(self._extract_dir or ""))
+        ready = _unique_dir(self._ready_target)
+        shutil.move(app_folder, ready)   # move the verified tree out of the temp dir, off the UI thread
+        self.staged.emit(ready)
 
 
 class SecureUpdater(QObject):
@@ -122,16 +270,21 @@ class SecureUpdater(QObject):
     """
     launching = pyqtSignal()
 
-    def __init__(self, parent_widget: QWidget, installer_url: str, release_url: str, i18n) -> None:
+    def __init__(self, parent_widget: QWidget, installer_url: str, release_url: str, i18n,
+                 *, portable: bool = False, portable_url: str = "", latest_version: str = "") -> None:
         super().__init__(parent_widget)
         self._parent = parent_widget
         self._installer_url = installer_url
+        self._portable = portable
+        self._portable_url = portable_url
+        self._latest_version = latest_version
         self._release_url = release_url
         self.i18n = i18n
         self._thread: Optional[QThread] = None
         self._worker: Optional[_DownloadWorker] = None
         self._dest: Optional[str] = None
         self._tmpdir: Optional[str] = None
+        self._extract_dir: Optional[str] = None
         self._progress: Optional[QProgressDialog] = None
         self._active = False
         self._user_cancelled = False
@@ -142,8 +295,10 @@ class SecureUpdater(QObject):
     def start(self) -> None:
         if self._active:  # in-flight guard: no concurrent downloads
             return
-        if not self._installer_url:
-            self._fallback("no installer asset in the release")
+        url = self._portable_url if self._portable else self._installer_url
+        if not url:
+            self._fallback("no portable asset in the release" if self._portable
+                           else "no installer asset in the release")
             return
         try:
             # Download into a private per-run directory. mkdtemp creates it 0700
@@ -152,7 +307,11 @@ class SecureUpdater(QObject):
             # (TOCTOU hardening - H5).
             sweep_stale_update_dirs()   # clear any orphaned dir from a previous successful update first
             self._tmpdir = tempfile.mkdtemp(prefix="NetSpeedTray-update-")
-            self._dest = os.path.join(self._tmpdir, "NetSpeedTray-Setup.exe")
+            if self._portable:
+                self._dest = os.path.join(self._tmpdir, "NetSpeedTray-Portable.zip")
+                self._extract_dir = os.path.join(self._tmpdir, "extracted")
+            else:
+                self._dest = os.path.join(self._tmpdir, "NetSpeedTray-Setup.exe")
         except Exception as e:
             self._fallback(f"could not create a temp directory: {e}")
             return
@@ -168,12 +327,26 @@ class SecureUpdater(QObject):
         self._progress.setAutoReset(False)
         self._progress.canceled.connect(self._on_cancel)
 
+        checksums_url = expected_name = ready_target = ""
+        if self._portable:
+            # checksums.txt is published next to the portable ZIP in the same release-download folder;
+            # the expected filename is the ZIP's own basename as listed there.
+            base, _, fname = self._portable_url.rpartition("/")
+            checksums_url = f"{base}/checksums.txt" if base else ""
+            expected_name = fname
+            name = (f"{constants.app.APP_NAME}-{self._latest_version}"
+                    if self._latest_version else f"{constants.app.APP_NAME}-update")
+            ready_target = os.path.join(_downloads_dir(), name)
+
         self._thread = QThread(self)
-        self._worker = _DownloadWorker(self._installer_url, self._dest)
+        self._worker = _DownloadWorker(url, self._dest, portable=self._portable,
+                                       extract_dir=self._extract_dir, checksums_url=checksums_url,
+                                       expected_name=expected_name, ready_target=ready_target)
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.run)
         self._worker.progress.connect(self._on_progress)
         self._worker.verified.connect(self._on_verified)
+        self._worker.staged.connect(self._on_staged)
         self._worker.failed.connect(self._on_failed)
         self._thread.start()
         self._progress.show()
@@ -212,6 +385,46 @@ class SecureUpdater(QObject):
             logger.error("Could not launch installer: %s", e, exc_info=True)
             self._cleanup_file()
             self._fallback(f"could not start the installer: {e}")
+
+    def _on_staged(self, ready: str) -> None:
+        """
+        Portable update: the ZIP's SHA-256 matched the release's checksums.txt and the new version was
+        extracted + staged to ``ready`` (in Downloads) on the worker thread. Reveal it and tell the user
+        to copy it over their current folder. Settings live in ``%APPDATA%``, not the app folder, so
+        replacing the folder never touches them (#195).
+        """
+        self._teardown_thread()
+        self._close_progress()
+        self._cleanup_file()   # drop the temp zip + now-empty extract dir; `ready` is outside it
+        if self._user_cancelled:
+            # Staging already finished before the cancel landed; don't leave a surprise folder behind.
+            try:
+                shutil.rmtree(ready, ignore_errors=True)
+            except Exception:
+                pass
+            self._finish()
+            return
+        try:
+            os.startfile(ready)   # type: ignore[attr-defined]  # reveal in Explorer (Windows)
+        except Exception:
+            pass
+        try:
+            app_dir = os.path.dirname(os.path.abspath(sys.executable))
+        except Exception:
+            app_dir = ""
+        try:
+            title = getattr(self.i18n, "UPDATE_PORTABLE_READY_TITLE", "Update ready to install")
+            msg = getattr(
+                self.i18n, "UPDATE_PORTABLE_READY_MESSAGE",
+                "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\n"
+                "To finish updating: close NetSpeedTray, then copy everything from that folder into "
+                "your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.")
+            QMessageBox.information(
+                self._parent, title,
+                msg.format(version=self._latest_version or "", ready=ready, app_dir=app_dir))
+        except Exception:
+            pass
+        self._finish()
 
     def _on_failed(self, reason: str) -> None:
         self._teardown_thread()

--- a/src/netspeedtray/tests/unit/test_update_checker.py
+++ b/src/netspeedtray/tests/unit/test_update_checker.py
@@ -20,7 +20,7 @@ and pre-release tags being truncated rather than ordered).
 """
 import pytest
 
-from netspeedtray.core.update_checker import _parse_version, is_newer
+from netspeedtray.core.update_checker import _parse_version, is_newer, select_release_assets
 
 
 # --- _parse_version: normalization -------------------------------------------
@@ -156,3 +156,24 @@ def test_prerelease_compares_older_than_final_by_accident():
 )
 def test_successive_prereleases_are_ordered():
     assert is_newer("1.4.0-beta2", "1.4.0-beta1") is True
+
+
+# --- release-asset selection (installer + portable) --------------------------
+
+def test_select_release_assets_picks_installer_and_portable():
+    """Both URLs must be surfaced so the updater can pick the portable ZIP for a portable run (#195)."""
+    assets = [
+        {"name": "checksums.txt", "browser_download_url": "https://x/sums"},
+        {"name": "NetSpeedTray-2.1.0-x64-Setup.exe", "browser_download_url": "https://x/setup"},
+        {"name": "NetSpeedTray-Portable-2.1.0.zip", "browser_download_url": "https://x/portable"},
+    ]
+    installer, portable = select_release_assets(assets)
+    assert installer == "https://x/setup"
+    assert portable == "https://x/portable"
+
+
+def test_select_release_assets_missing_are_empty():
+    installer, portable = select_release_assets([{"name": "notes.md", "browser_download_url": "https://x/n"}])
+    assert installer == ""
+    assert portable == ""
+

--- a/src/netspeedtray/tests/unit/test_update_installer.py
+++ b/src/netspeedtray/tests/unit/test_update_installer.py
@@ -4,10 +4,14 @@ The Qt thread/dialog orchestration in SecureUpdater is glue over download_to +
 verify_file, both covered on their own.
 """
 import io
+import sys
+import zipfile
 
 import pytest
 
+from netspeedtray import constants
 from netspeedtray.core import update_installer as ui
+from netspeedtray.utils.helpers import is_portable_install
 
 
 class _FakeResp:
@@ -58,3 +62,123 @@ def test_download_to_enforces_size_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(ui.urllib.request, "urlopen", lambda req, timeout=30: _FakeResp(data, len(data)))
     with pytest.raises(RuntimeError):
         ui.download_to("https://e/x", str(dest))
+
+
+# --- #195 portable guided update: pure logic -------------------------------------
+
+def test_safe_extract_writes_members(tmp_path):
+    z = tmp_path / "portable.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("NetSpeedTray/NetSpeedTray.exe", b"exe-bytes")
+        zf.writestr("NetSpeedTray/_internal/x.dll", b"dll-bytes")
+    dest = tmp_path / "out"
+    ui._safe_extract(str(z), str(dest))
+    assert (dest / "NetSpeedTray" / "NetSpeedTray.exe").read_bytes() == b"exe-bytes"
+    assert (dest / "NetSpeedTray" / "_internal" / "x.dll").read_bytes() == b"dll-bytes"
+
+
+def test_safe_extract_rejects_zip_slip(tmp_path):
+    # A malicious archive that tries to escape the extraction dir must be refused, and nothing
+    # may be written outside dest (the download host is untrusted until the inner EXE verifies).
+    z = tmp_path / "evil.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("../escaped.txt", b"pwned")
+    dest = tmp_path / "out"
+    with pytest.raises(RuntimeError):
+        ui._safe_extract(str(z), str(dest))
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_locate_portable_exe_finds_nested_exe(tmp_path):
+    appdir = tmp_path / "NetSpeedTray"
+    appdir.mkdir()
+    exe = appdir / "NetSpeedTray.exe"
+    exe.write_bytes(b"")
+    assert ui._locate_portable_exe(str(tmp_path)) == str(exe)
+
+
+def test_locate_portable_exe_raises_when_absent(tmp_path):
+    (tmp_path / "readme.txt").write_text("no exe here")
+    with pytest.raises(RuntimeError):
+        ui._locate_portable_exe(str(tmp_path))
+
+
+def test_downloads_dir_prefers_downloads(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui.os.path, "expanduser", lambda p: str(tmp_path))
+    (tmp_path / "Downloads").mkdir()
+    assert ui._downloads_dir() == str(tmp_path / "Downloads")
+
+
+def test_downloads_dir_falls_back_to_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui.os.path, "expanduser", lambda p: str(tmp_path))  # no Downloads subdir
+    assert ui._downloads_dir() == str(tmp_path)
+
+
+def test_is_portable_install_true_with_marker(tmp_path, monkeypatch):
+    (tmp_path / "NetSpeedTray.exe").write_bytes(b"")
+    (tmp_path / constants.app.PORTABLE_MARKER_FILENAME).write_text("portable")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "NetSpeedTray.exe"))
+    assert is_portable_install() is True
+
+
+def test_is_portable_install_false_without_marker(tmp_path, monkeypatch):
+    (tmp_path / "NetSpeedTray.exe").write_bytes(b"")  # installed layout: no marker
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "NetSpeedTray.exe"))
+    assert is_portable_install() is False
+
+
+def test_is_portable_install_false_when_not_frozen(tmp_path, monkeypatch):
+    (tmp_path / constants.app.PORTABLE_MARKER_FILENAME).write_text("portable")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "NetSpeedTray.exe"))
+    assert is_portable_install() is False
+
+
+# --- #195 whole-ZIP checksum verification (the portable trust anchor) ------------
+
+def test_sha256_file_matches_hashlib(tmp_path):
+    import hashlib
+    p = tmp_path / "portable.zip"
+    data = b"NetSpeedTray portable payload " * 1000
+    p.write_bytes(data)
+    assert ui._sha256_file(str(p)) == hashlib.sha256(data).hexdigest()
+
+
+def test_expected_hash_for_matches_case_insensitively():
+    # Published format is "<UPPERHASH> <filename>" (PowerShell Get-FileHash).
+    text = f"{'A' * 64} NetSpeedTray-Portable-2.1.0.zip\n{'B' * 64} NetSpeedTray-2.1.0-x64-Setup.exe\n"
+    assert ui._expected_hash_for(text, "netspeedtray-portable-2.1.0.zip") == "a" * 64
+    assert ui._expected_hash_for(text, "NetSpeedTray-2.1.0-x64-Setup.exe") == "b" * 64
+
+
+def test_expected_hash_for_absent_returns_none():
+    text = f"{'C' * 64} some-other-file.zip\n"
+    assert ui._expected_hash_for(text, "NetSpeedTray-Portable-2.1.0.zip") is None
+
+
+def test_expected_hash_for_rejects_malformed_hash():
+    text = "not-a-real-sha NetSpeedTray-Portable-2.1.0.zip\n"
+    assert ui._expected_hash_for(text, "NetSpeedTray-Portable-2.1.0.zip") is None
+
+
+def test_unique_dir_returns_same_when_absent(tmp_path):
+    target = tmp_path / "NetSpeedTray-2.1.0"
+    assert ui._unique_dir(str(target)) == str(target)
+
+
+def test_unique_dir_clears_removable_stale(tmp_path):
+    target = tmp_path / "NetSpeedTray-2.1.0"
+    target.mkdir()
+    (target / "old.txt").write_text("stale from a prior run")
+    assert ui._unique_dir(str(target)) == str(target)
+    assert not target.exists()
+
+
+def test_unique_dir_suffixes_when_stale_cannot_be_removed(tmp_path, monkeypatch):
+    # A locked file leaves the stale dir present after rmtree -> we must NOT move into it (nesting bug).
+    target = tmp_path / "NetSpeedTray-2.1.0"
+    target.mkdir()
+    monkeypatch.setattr(ui.shutil, "rmtree", lambda *a, **k: None)  # simulate a surviving locked dir
+    assert ui._unique_dir(str(target)) == str(tmp_path / "NetSpeedTray-2.1.0-2")

--- a/src/netspeedtray/utils/helpers.py
+++ b/src/netspeedtray/utils/helpers.py
@@ -77,6 +77,25 @@ def get_app_data_path() -> Path:
         raise OSError(f"Error with app data directory: {path}. Check disk space or path validity.") from e
 
 
+def is_portable_install() -> bool:
+    """
+    True when the app is running as the portable ZIP build.
+
+    The portable ZIP ships a ``portable.marker`` file next to the executable (added at package time -
+    see build.bat); the Inno installer build never contains it. A non-frozen (development) run is not
+    "portable". Used by the updater to pick the guided folder-copy update flow instead of launching the
+    installer, which can't update a portable folder in place (#195).
+    """
+    import sys
+    if not getattr(sys, "frozen", False):
+        return False
+    try:
+        app_dir = os.path.dirname(os.path.abspath(sys.executable))
+        return os.path.isfile(os.path.join(app_dir, constants.app.PORTABLE_MARKER_FILENAME))
+    except Exception:
+        return False
+
+
 def get_machine_id() -> str:
     """
     A stable per-install identifier for exported stats (so an MSP can tell two machines' CSVs apart).

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -1362,12 +1362,12 @@ class NetworkSpeedWidget(QWidget):
     def _on_update_available(self, latest_version: str, release_url: str, body: str = "",
                              installer_url: str = "", portable_url: str = "") -> None:
         """Handle update available from automatic startup check."""
-        self._show_update_dialog(latest_version, release_url, body, installer_url)
+        self._show_update_dialog(latest_version, release_url, body, installer_url, portable_url)
 
     def _on_update_available_manual(self, latest_version: str, release_url: str, body: str = "",
                                     installer_url: str = "", portable_url: str = "") -> None:
         """Handle update available from manual menu check."""
-        self._show_update_dialog(latest_version, release_url, body, installer_url)
+        self._show_update_dialog(latest_version, release_url, body, installer_url, portable_url)
 
     def _on_up_to_date_manual(self) -> None:
         """Show up-to-date message for manual check."""
@@ -1381,7 +1381,7 @@ class NetworkSpeedWidget(QWidget):
         QMessageBox.warning(self, self.i18n.UPDATE_CHECK_TITLE, self.i18n.UPDATE_CHECK_FAILED_TEXT)
 
     def _show_update_dialog(self, latest_version: str, release_url: str, body: str = "",
-                            installer_url: str = "") -> None:
+                            installer_url: str = "", portable_url: str = "") -> None:
         """Show the update-available dialog: version delta + inert release notes,
         with Download / Skip / Not Now."""
         from netspeedtray.views.update_dialog import UpdateDialog
@@ -1390,25 +1390,35 @@ class NetworkSpeedWidget(QWidget):
         dlg.exec()
 
         if dlg.action == UpdateDialog.ACTION_DOWNLOAD:
-            self._start_secure_update(installer_url, release_url)
+            self._start_secure_update(installer_url, release_url,
+                                      portable_url=portable_url, latest_version=latest)
         elif dlg.action == UpdateDialog.ACTION_SKIP:
             self.config["skipped_version"] = latest
             self.update_config({"skipped_version": latest})
 
-    def _start_secure_update(self, installer_url: str, release_url: str) -> None:
+    def _start_secure_update(self, installer_url: str, release_url: str,
+                             *, portable_url: str = "", latest_version: str = "") -> None:
         """
         One-click update: download the signed installer, verify it (Authenticode +
         SignPath pin), and run it. Any failure falls back to opening the release page
         in the browser (the old behavior), so the worst case is never worse than before.
+
+        On the portable build (detected via the packaged marker file) the installer can't update the
+        unzipped folder in place, so this runs the guided portable flow instead: download + verify the
+        portable ZIP and stage it for the user to copy over (#195).
         """
         try:
             from netspeedtray.core.update_installer import SecureUpdater
+            from netspeedtray.utils.helpers import is_portable_install
             # In-flight guard: don't start a second download over a running one.
             existing = getattr(self, "_secure_updater", None)
             if existing is not None and existing.is_running():
                 return
+            portable = is_portable_install()
             # Parented to self (not GC'd); it self-destructs via deleteLater when done.
-            self._secure_updater = SecureUpdater(self, installer_url, release_url, self.i18n)
+            self._secure_updater = SecureUpdater(
+                self, installer_url, release_url, self.i18n,
+                portable=portable, portable_url=portable_url, latest_version=latest_version)
             self._secure_updater.launching.connect(self._quit_for_update)
             self._secure_updater.start()
         except Exception as e:


### PR DESCRIPTION
## What

Fixes #195: the portable ZIP build could download an update but never install it. The one-click updater was installer-only - it launched the Program-Files `Setup.exe`, which can't update the folder a portable user unzipped, so nothing changed.

## The fix - a guided, checksum-verified portable update

- **Detection:** `is_portable_install()` checks for a `portable.marker` file next to the EXE. `build.bat` writes that marker into the ZIP **after** the installer is built, so it's portable-only; the installed one-click flow is byte-for-byte unchanged.
- **Flow (portable):** download the portable ZIP → verify the **whole download's SHA-256** against the release's published `checksums.txt` → extract (zip-slip guarded) → stage the new version in the user's Downloads → reveal it, with a "close NetSpeedTray and copy this over your folder; your settings are kept" message. Any failure falls back to the release page, exactly like the installer path. All heavy I/O runs on the worker thread, so a cross-drive Downloads move never freezes the UI.
- **Settings safe:** config lives in `%APPDATA%`, not the app folder, so a folder-copy never touches it.

## Security note (please read)

A PyInstaller **onedir** portable ZIP is many files (a signed bootstrap `NetSpeedTray.exe` + an `_internal/` payload of DLLs and bytecode), not one signed binary. An earlier draft verified only the bootstrap's Authenticode signature - an adversarial review caught that this leaves `_internal/` unverified (**RCE under a MITM / hostile mirror**, since the design treats the download host as untrusted). This PR instead verifies the **whole ZIP's checksum** against the release's `checksums.txt`, fetched over HTTPS from the same origin - i.e. **as trustworthy as downloading the ZIP yourself from the release page**. It does **not** claim the installer's code-signature gate, and the user-facing message makes no false "signature verified" claim.

**Follow-up (tracked):** installer-grade, MITM-resistant portable verification (a SignPath-signed checksums/manifest the app verifies against the pinned publisher key). Chosen to keep 2.1 shipping; this PR is a strict improvement over the broken status quo.

## Note for existing users

Today's 2.0.0 portable users need **one** manual update to reach 2.1 (the broken 2.0.0 code can't self-fix); auto-update works from 2.1 onward.

## Tests & review

- **+18 unit tests:** whole-ZIP SHA-256, `checksums.txt` parsing (case-insensitive, malformed-hash rejection, missing-entry), zip-slip refusal, inner-EXE location, portable detection (marker present/absent, not-frozen), collision-free staging, Downloads fallback, installer+portable asset selection.
- **Full suite: 826 passed, 2 xfailed.**
- **Two adversarial review passes** (security + correctness, each finding independently verified): the first pass found 1 critical (inner-EXE-only) + 2 mediums (UI-thread move, stale-dir nesting); all fixed. The re-review confirms all three **CLOSED** with **zero** new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
