### PR TITLE
feat(position): free-float the widget on a taskbar-less preferred display (#188)

### DIFF
--- a/src/netspeedtray/constants/config.py
+++ b/src/netspeedtray/constants/config.py
@@ -73,6 +73,11 @@ class ConfigConstants:
     DEFAULT_DECIMAL_PLACES: Final[int] = 1
     DEFAULT_TEXT_ALIGNMENT: Final[str] = "center"
     DEFAULT_FREE_MOVE: Final[bool] = False
+    # When the preferred monitor has NO taskbar of its own (e.g. the Corsair Xeneon Edge, or a
+    # secondary display with "show taskbar on all displays" off), float the widget on THAT display
+    # instead of falling back to the primary taskbar. On by default so the accessory-display case
+    # just works; a user can turn it off to keep the old primary-taskbar fallback (#188).
+    DEFAULT_FREE_FLOAT: Final[bool] = True
     DEFAULT_KEEP_VISIBLE_FULLSCREEN: Final[bool] = False
     DEFAULT_FORCE_DECIMALS: Final[bool] = True
     # ON by default: a taskbar status widget people want always-present should come back after a reboot.
@@ -162,6 +167,7 @@ class ConfigConstants:
         "decimal_places": DEFAULT_DECIMAL_PLACES,
         "text_alignment": DEFAULT_TEXT_ALIGNMENT,
         "free_move": DEFAULT_FREE_MOVE,
+        "free_float": DEFAULT_FREE_FLOAT,
         "double_click_action": DEFAULT_DOUBLE_CLICK_ACTION,
         "middle_click_action": DEFAULT_MIDDLE_CLICK_ACTION,
         "hardware_label_style": DEFAULT_HARDWARE_LABEL_STYLE,
@@ -296,6 +302,7 @@ class ConfigConstants:
         "arrow_up_symbol": {"type": str, "default": ""},
         "arrow_down_symbol": {"type": str, "default": ""},
         "free_move": {"type": bool, "default": DEFAULT_FREE_MOVE},
+        "free_float": {"type": bool, "default": DEFAULT_FREE_FLOAT},
         "double_click_action": {"type": str, "default": DEFAULT_DOUBLE_CLICK_ACTION, "choices": CLICK_ACTION_CHOICES},
         "middle_click_action": {"type": str, "default": DEFAULT_MIDDLE_CLICK_ACTION, "choices": CLICK_ACTION_CHOICES},
         "hardware_label_style": {"type": str, "default": DEFAULT_HARDWARE_LABEL_STYLE, "choices": ["icons_colored", "icons_monochrome", "text"]},

--- a/src/netspeedtray/constants/locales/de_DE.json
+++ b/src/netspeedtray/constants/locales/de_DE.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Aktualisierungsintervall:",
     "START_WITH_WINDOWS_LABEL": "Mit Windows starten",
     "FREE_MOVE_LABEL": "Frei beweglich (kein Einrasten)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Im Vollbild sichtbar halten",
     "FONT_SIZE_LABEL": "Schriftgröße:",
     "FONT_FAMILY_LABEL": "Schriftart:",

--- a/src/netspeedtray/constants/locales/en_US.json
+++ b/src/netspeedtray/constants/locales/en_US.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Update Interval:",
     "START_WITH_WINDOWS_LABEL": "Start with Windows",
     "FREE_MOVE_LABEL": "Free Move (No Snapping)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Keep Visible in Fullscreen",
     "FONT_SIZE_LABEL": "Font Size:",
     "FONT_FAMILY_LABEL": "Font:",

--- a/src/netspeedtray/constants/locales/es_ES.json
+++ b/src/netspeedtray/constants/locales/es_ES.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Intervalo de actualización:",
     "START_WITH_WINDOWS_LABEL": "Iniciar con Windows",
     "FREE_MOVE_LABEL": "Movimiento Libre (sin ajuste)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Mantener visible en pantalla completa",
     "FONT_SIZE_LABEL": "Tamaño de fuente:",
     "FONT_FAMILY_LABEL": "Fuente:",

--- a/src/netspeedtray/constants/locales/fr_FR.json
+++ b/src/netspeedtray/constants/locales/fr_FR.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Intervalle de Mise à Jour :",
     "START_WITH_WINDOWS_LABEL": "Lancer avec Windows",
     "FREE_MOVE_LABEL": "Déplacement Libre (Pas de Collage)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Rester visible en plein écran",
     "FONT_SIZE_LABEL": "Taille de Police :",
     "FONT_FAMILY_LABEL": "Police :",

--- a/src/netspeedtray/constants/locales/ja_JP.json
+++ b/src/netspeedtray/constants/locales/ja_JP.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "更新間隔 :",
     "START_WITH_WINDOWS_LABEL": "Windows 起動時に実行",
     "FREE_MOVE_LABEL": "自由移動 (スナップ無効)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "フルスクリーン時も表示を維持",
     "FONT_SIZE_LABEL": "フォントサイズ :",
     "FONT_FAMILY_LABEL": "フォント :",

--- a/src/netspeedtray/constants/locales/ko_KR.json
+++ b/src/netspeedtray/constants/locales/ko_KR.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "업데이트 간격:",
     "START_WITH_WINDOWS_LABEL": "Windows와 함께 시작",
     "FREE_MOVE_LABEL": "자유 이동 (스냅핑 안 함)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "전체화면에서도 위젯 유지",
     "FONT_SIZE_LABEL": "글꼴 크기:",
     "FONT_FAMILY_LABEL": "글꼴:",

--- a/src/netspeedtray/constants/locales/nl_NL.json
+++ b/src/netspeedtray/constants/locales/nl_NL.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Update-interval:",
     "START_WITH_WINDOWS_LABEL": "Starten met Windows",
     "FREE_MOVE_LABEL": "Vrij bewegen (geen uitlijning)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Zichtbaar houden in volledig scherm",
     "FONT_SIZE_LABEL": "Lettergrootte:",
     "FONT_FAMILY_LABEL": "Lettertype:",

--- a/src/netspeedtray/constants/locales/pl_PL.json
+++ b/src/netspeedtray/constants/locales/pl_PL.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Interwał aktualizacji:",
     "START_WITH_WINDOWS_LABEL": "Uruchamiaj z systemem Windows",
     "FREE_MOVE_LABEL": "Swobodne przesuwanie (bez przyciągania)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Pozostań widoczny w trybie pełnoekranowym",
     "FONT_SIZE_LABEL": "Rozmiar czcionki:",
     "FONT_FAMILY_LABEL": "Czcionka:",

--- a/src/netspeedtray/constants/locales/ru_RU.json
+++ b/src/netspeedtray/constants/locales/ru_RU.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Интервал обновления:",
     "START_WITH_WINDOWS_LABEL": "Запускать с Windows",
     "FREE_MOVE_LABEL": "Свободное перемещение (без прилипания)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Оставаться видимым в полноэкранном режиме",
     "FONT_SIZE_LABEL": "Размер шрифта:",
     "FONT_FAMILY_LABEL": "Шрифт:",

--- a/src/netspeedtray/constants/locales/sl_SI.json
+++ b/src/netspeedtray/constants/locales/sl_SI.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "Interval posodabljanja:",
     "START_WITH_WINDOWS_LABEL": "Zaženi z zagonom sistema Windows",
     "FREE_MOVE_LABEL": "Prosto premikanje (brez pripenjanja)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "Ohrani vidno v celozaslonskem načinu",
     "FONT_SIZE_LABEL": "Velikost pisave:",
     "FONT_FAMILY_LABEL": "Pisava:",

--- a/src/netspeedtray/constants/locales/zh_TW.json
+++ b/src/netspeedtray/constants/locales/zh_TW.json
@@ -75,6 +75,7 @@
     "UPDATE_INTERVAL_LABEL": "更新間隔:",
     "START_WITH_WINDOWS_LABEL": "隨 Windows 啟動",
     "FREE_MOVE_LABEL": "自由移動 (不吸附)",
+    "FREE_FLOAT_LABEL": "Float on a display without a taskbar",
     "KEEP_VISIBLE_FULLSCREEN_LABEL": "全螢幕時保持顯示",
     "FONT_SIZE_LABEL": "字型大小:",
     "FONT_FAMILY_LABEL": "字型:",

--- a/src/netspeedtray/core/input_handler.py
+++ b/src/netspeedtray/core/input_handler.py
@@ -129,15 +129,15 @@ class InputHandler(QObject):
     def _save_dragged_position(self) -> None:
         """
         Saves the final position based on the current mode:
-        - Free Move ON: Saves absolute X/Y coordinates.
-        - Free Move OFF: Calculates and saves the offset relative to the tray/edge.
+        - Floating (Free Move, or #188 free-float on a taskbar-less display): absolute X/Y.
+        - Docked: the offset relative to the tray/edge.
         """
         try:
             config = self.widget.config
-            is_free_move = config.get("free_move", False)
+            is_floating = self.position_manager.is_floating()
             updates = {}
 
-            if is_free_move:
+            if is_floating:
                 # Save absolute coordinates
                 updates["position_x"] = self.widget.x()
                 updates["position_y"] = self.widget.y()

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -380,6 +380,22 @@ class PositionCalculator:
         except Exception:
             return ScreenPosition(0, 0)
 
+    def calculate_free_float_default_position(self, screen: QScreen,
+                                              widget_size: Tuple[int, int]) -> ScreenPosition:
+        """Default position for a free-floating widget on a taskbar-less display (#188): bottom-right of
+        that screen's available geometry, inset by the edge margin. Mirrors `_get_safe_fallback_position`
+        but targets the given screen instead of primary."""
+        try:
+            screen_rect: QRect = screen.availableGeometry()
+            widget_width, widget_height = widget_size
+            ui_widget = getattr(constants.ui, 'widget', None)
+            margin_px = ui_widget.SCREEN_EDGE_MARGIN_PX if ui_widget else 10
+            x = screen_rect.right() - widget_width - margin_px
+            y = screen_rect.bottom() - widget_height - margin_px
+            return ScreenPosition(max(screen_rect.left(), x), max(screen_rect.top(), y))
+        except Exception:
+            return self._get_safe_fallback_position(widget_size)
+
     def constrain_drag_position(self, desired_pos: QPoint, taskbar_info: TaskbarInfo, widget_size_q: QSize) -> Optional[QPoint]:
         """Constrains a desired widget position during dragging to the 'safe zone'."""
         try:
@@ -448,6 +464,10 @@ class PositionManager(QObject):
         self._last_tray_rect: Optional[Tuple[int, int, int, int]] = None
         self._last_applied_geometry: Optional[QRect] = None
         self._taskbar_lost_count: int = 0
+        # Free-float (#188): set by refresh_float_state() when the preferred monitor is a taskbar-less
+        # display we should float on instead of docking to the primary taskbar.
+        self._free_float_active: bool = False
+        self._free_float_screen: Optional[QScreen] = None
         
         # Timers
         self._tray_watcher_timer = QTimer(self)
@@ -466,6 +486,23 @@ class PositionManager(QObject):
         self._tray_watcher_timer.stop()
         logger.debug("PositionManager monitoring stopped.")
 
+    def is_floating(self) -> bool:
+        """True when the widget should ignore taskbar docking - either the user's Free Move, or the
+        runtime free-float mode active when the preferred monitor has no taskbar of its own (#188)."""
+        return bool(self._state.config.get('free_move', False)) or self._free_float_active
+
+    def refresh_float_state(self) -> Optional[QScreen]:
+        """Re-evaluate whether the preferred monitor is a taskbar-less display to free-float on. Sets
+        `_free_float_active` / `_free_float_screen` and returns the target screen (or None). Cheap;
+        called each reposition. Honors the `free_float` opt-out."""
+        screen: Optional[QScreen] = None
+        if self._state.config.get('free_float', True):
+            preferred = self._state.config.get('preferred_monitor')
+            screen = taskbar_utils.get_free_float_screen(preferred)
+        self._free_float_screen = screen
+        self._free_float_active = screen is not None
+        return screen
+
     @pyqtSlot()
     def update_position(self, fresh_taskbar_info: Optional[TaskbarInfo] = None) -> None:
         """
@@ -480,7 +517,15 @@ class PositionManager(QObject):
                 preferred = self._state.config.get('preferred_monitor')
                 self._state.taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
+            # #188: is the preferred monitor a taskbar-less display we should float on?
+            self.refresh_float_state()
+
+            # A saved (dragged) position wins in both free-move and free-float.
             if self._apply_saved_position():
+                return
+
+            # No saved position + a taskbar-less preferred display -> default-place on that display.
+            if self._free_float_active and self._apply_free_float_position():
                 return
 
             if self._apply_calculated_position():
@@ -489,6 +534,23 @@ class PositionManager(QObject):
                 logger.warning("Failed to calculate position.")
         except Exception as e:
             logger.error("Error updating position: %s", e, exc_info=True)
+
+    def _apply_free_float_position(self) -> bool:
+        """Place the widget at a sensible default on the taskbar-less preferred display (#188). Returns
+        False (so the caller falls through to normal docking) if the target screen is gone or the widget
+        isn't laid out yet - a later reposition retries with valid dimensions."""
+        screen = self._free_float_screen
+        if screen is None:
+            return False
+        widget_width = self._state.widget.width()
+        widget_height = self._state.widget.height()
+        if widget_width <= 0 or widget_height <= 0:
+            return False
+        pos = self._calculator.calculate_free_float_default_position(screen, (widget_width, widget_height))
+        if pos is None:
+            return False
+        self._apply_geometry(pos.x, pos.y)
+        return True
 
     def _apply_saved_position(self) -> bool:
         """Applies saved position if 'free_move' is enabled.
@@ -499,7 +561,7 @@ class PositionManager(QObject):
         falls through to the calculated position so the widget appears near
         the tray instead of off-screen. Fixes #133.
         """
-        if not self._state.config.get('free_move', False):
+        if not self.is_floating():
             return False
 
         saved_x = self._state.config.get('position_x')
@@ -599,7 +661,7 @@ class PositionManager(QObject):
     @pyqtSlot()
     def _check_for_tray_changes(self) -> None:
         """Checks if the system tray geometry has changed (Stub for smart polling)."""
-        if self._state.config.get("free_move", False) or not self._state.widget.isVisible():
+        if self.is_floating() or not self._state.widget.isVisible():
             return
 
         try:
@@ -631,9 +693,9 @@ class PositionManager(QObject):
              preferred = self._state.config.get('preferred_monitor')
              self._state.taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
-        # FIX for #87: specific check for Free Move
-        if self._state.config.get("free_move", False):
-            # If Free Move is enabled, only constrain to screen bounds (prevent total loss)
+        # FIX for #87: specific check for Free Move (and #188 free-float - both are "floating")
+        if self.is_floating():
+            # If floating, only constrain to screen bounds (prevent total loss)
             # FIX for #102: Use the screen at the drag destination, not the taskbar's screen
             # This allows the widget to be dragged freely across all connected monitors
             screen = QApplication.screenAt(pos)

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -491,6 +491,13 @@ class PositionManager(QObject):
         runtime free-float mode active when the preferred monitor has no taskbar of its own (#188)."""
         return bool(self._state.config.get('free_move', False)) or self._free_float_active
 
+    def is_free_float_active(self) -> bool:
+        """True only when the runtime free-float mode is live (preferred monitor has no taskbar of its
+        own, #188). Unlike is_floating() this excludes plain Free Move, so callers that need to protect
+        the off-taskbar float specifically - e.g. not hiding it for a fullscreen app on another monitor -
+        don't also change docked Free-Move behavior."""
+        return self._free_float_active
+
     def refresh_float_state(self) -> Optional[QScreen]:
         """Re-evaluate whether the preferred monitor is a taskbar-less display to free-float on. Sets
         `_free_float_active` / `_free_float_screen` and returns the target screen (or None). Cheap;

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -504,11 +504,14 @@ class PositionManager(QObject):
         return screen
 
     @pyqtSlot()
-    def update_position(self, fresh_taskbar_info: Optional[TaskbarInfo] = None) -> None:
+    def update_position(self, fresh_taskbar_info: Optional[TaskbarInfo] = None,
+                        _float_refreshed: bool = False) -> None:
         """
         Main entry point to update the widget's position.
         Uses fresh taskbar info if provided, otherwise fetches it - honoring
-        the `preferred_monitor` setting (#72) when present.
+        the `preferred_monitor` setting (#72) when present. `_float_refreshed` lets the ~1s refresh
+        loop (which already called refresh_float_state() for its visibility check) skip the duplicate
+        taskbar enumeration here (#188).
         """
         try:
             if fresh_taskbar_info:
@@ -518,7 +521,8 @@ class PositionManager(QObject):
                 self._state.taskbar_info = get_taskbar_info(preferred_screen_name=preferred)
 
             # #188: is the preferred monitor a taskbar-less display we should float on?
-            self.refresh_float_state()
+            if not _float_refreshed:
+                self.refresh_float_state()
 
             # A saved (dragged) position wins in both free-move and free-float.
             if self._apply_saved_position():

--- a/src/netspeedtray/tests/unit/test_free_float.py
+++ b/src/netspeedtray/tests/unit/test_free_float.py
@@ -99,6 +99,56 @@ def test_refresh_float_state_optout_skips_detection(mock_gffs):
     mock_gffs.assert_not_called()   # the opt-out means we don't even query
 
 
+# --- is_free_float_active() ----------------------------------------------------------
+
+def test_is_free_float_active_true_only_for_runtime_float():
+    m = _manager({"free_move": False, "free_float": True})
+    m._free_float_active = True
+    assert m.is_free_float_active() is True
+
+
+def test_is_free_float_active_false_for_plain_free_move():
+    # Free Move floats, but is NOT the taskbar-less runtime float - callers that guard the
+    # off-taskbar widget (e.g. the fullscreen immediate-hide) must not treat it as such.
+    m = _manager({"free_move": True, "free_float": True})
+    m._free_float_active = False
+    assert m.is_free_float_active() is False
+    assert m.is_floating() is True   # ... but it IS floating
+
+
+# --- immediate fullscreen-hide guard (#188) ------------------------------------------
+
+def _fake_widget(keep_visible, free_float_active):
+    from netspeedtray.views.widget.main import NetworkSpeedWidget
+    w = MagicMock(spec=NetworkSpeedWidget)
+    w.config = {"keep_visible_fullscreen": keep_visible}
+    w.position_manager = MagicMock()
+    w.position_manager.is_free_float_active.return_value = free_float_active
+    return w
+
+
+def test_immediate_hide_fires_when_docked_and_not_kept():
+    from netspeedtray.views.widget.main import NetworkSpeedWidget
+    w = _fake_widget(keep_visible=False, free_float_active=False)
+    NetworkSpeedWidget._on_immediate_hide_requested(w)
+    w.setVisible.assert_called_once_with(False)
+
+
+def test_immediate_hide_skipped_when_keep_visible():
+    from netspeedtray.views.widget.main import NetworkSpeedWidget
+    w = _fake_widget(keep_visible=True, free_float_active=False)
+    NetworkSpeedWidget._on_immediate_hide_requested(w)
+    w.setVisible.assert_not_called()
+
+
+def test_immediate_hide_skipped_when_free_floating():
+    # The regression: a fullscreen app on the primary must NOT blink the off-taskbar widget out.
+    from netspeedtray.views.widget.main import NetworkSpeedWidget
+    w = _fake_widget(keep_visible=False, free_float_active=True)
+    NetworkSpeedWidget._on_immediate_hide_requested(w)
+    w.setVisible.assert_not_called()
+
+
 # --- default placement ---------------------------------------------------------------
 
 def test_free_float_default_position_is_inside_the_target_screen():

--- a/src/netspeedtray/tests/unit/test_free_float.py
+++ b/src/netspeedtray/tests/unit/test_free_float.py
@@ -1,0 +1,111 @@
+"""#188 - free-float on a taskbar-less display: detection, the is_floating() predicate, and placement."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtCore import QRect
+from PyQt6.QtWidgets import QApplication
+
+from netspeedtray.utils import taskbar_utils as tu
+from netspeedtray.core.position_manager import PositionCalculator, PositionManager, WindowState, ScreenPosition
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _screen(name, geo):
+    s = MagicMock()
+    s.name.return_value = name
+    s.availableGeometry.return_value = geo
+    s.geometry.return_value = geo
+    return s
+
+
+def _manager(config):
+    state = WindowState(config=config, widget=MagicMock())
+    return PositionManager(state)
+
+
+# --- get_free_float_screen -----------------------------------------------------------
+
+def test_no_preferred_is_no_float():
+    assert tu.get_free_float_screen(None) is None
+    assert tu.get_free_float_screen("") is None
+
+
+@patch.object(tu, "QApplication")
+def test_preferred_disconnected_is_no_float(mock_qapp):
+    mock_qapp.screens.return_value = [_screen("\\\\.\\DISPLAY1", QRect(0, 0, 1920, 1080))]
+    assert tu.get_free_float_screen("\\\\.\\DISPLAY_GONE") is None
+
+
+@patch.object(tu, "get_all_taskbar_info")
+@patch.object(tu, "_select_taskbar_for_screen")
+@patch.object(tu, "QApplication")
+def test_preferred_with_taskbar_docks_normally(mock_qapp, mock_select, mock_all):
+    scr = _screen("EDGE", QRect(1920, 0, 800, 600))
+    mock_qapp.screens.return_value = [scr]
+    mock_all.return_value = []
+    mock_select.return_value = MagicMock()   # a taskbar exists on EDGE
+    assert tu.get_free_float_screen("EDGE") is None
+
+
+@patch.object(tu, "get_all_taskbar_info")
+@patch.object(tu, "_select_taskbar_for_screen")
+@patch.object(tu, "QApplication")
+def test_preferred_taskbarless_returns_that_screen(mock_qapp, mock_select, mock_all):
+    scr = _screen("EDGE", QRect(1920, 0, 800, 600))
+    mock_qapp.screens.return_value = [scr]
+    mock_all.return_value = []
+    mock_select.return_value = None          # no taskbar on EDGE -> float on it
+    assert tu.get_free_float_screen("EDGE") is scr
+
+
+# --- is_floating() / refresh_float_state() -------------------------------------------
+
+def test_free_move_is_floating():
+    assert _manager({"free_move": True, "free_float": True}).is_floating() is True
+
+
+def test_free_float_active_is_floating_without_free_move():
+    m = _manager({"free_move": False, "free_float": True})
+    m._free_float_active = True
+    assert m.is_floating() is True
+
+
+def test_docked_is_not_floating():
+    m = _manager({"free_move": False, "free_float": True})
+    m._free_float_active = False
+    assert m.is_floating() is False
+
+
+@patch.object(tu, "get_free_float_screen")
+def test_refresh_float_state_activates(mock_gffs):
+    scr = MagicMock()
+    mock_gffs.return_value = scr
+    m = _manager({"free_move": False, "free_float": True, "preferred_monitor": "EDGE"})
+    assert m.refresh_float_state() is scr
+    assert m._free_float_active is True
+    assert m._free_float_screen is scr
+
+
+@patch.object(tu, "get_free_float_screen")
+def test_refresh_float_state_optout_skips_detection(mock_gffs):
+    m = _manager({"free_move": False, "free_float": False, "preferred_monitor": "EDGE"})
+    assert m.refresh_float_state() is None
+    assert m._free_float_active is False
+    mock_gffs.assert_not_called()   # the opt-out means we don't even query
+
+
+# --- default placement ---------------------------------------------------------------
+
+def test_free_float_default_position_is_inside_the_target_screen():
+    calc = PositionCalculator()
+    scr = _screen("EDGE", QRect(1920, 0, 800, 600))   # a second display at x=1920, 800x600
+    pos = calc.calculate_free_float_default_position(scr, (100, 40))
+    assert isinstance(pos, ScreenPosition)
+    # bottom-right of the *target* screen (not primary), fully on-screen
+    assert 1920 <= pos.x <= (1920 + 800 - 100)
+    assert 0 <= pos.y <= (600 - 40)

--- a/src/netspeedtray/tests/unit/test_input_handler.py
+++ b/src/netspeedtray/tests/unit/test_input_handler.py
@@ -80,6 +80,9 @@ class TestInputHandler(unittest.TestCase):
         self.mock_widget.setGeometry(100, 100, 200, 50)
         
         self.mock_position_manager = MagicMock()
+        # _save_dragged_position asks the position manager whether we're "floating" (free-move OR the
+        # #188 free-float); mirror the widget's free_move config so the docked/offset path is exercised.
+        self.mock_position_manager.is_floating.side_effect = lambda: bool(self.mock_widget.config.get('free_move', False))
         self.mock_tray_manager = MagicMock()
         
         self.handler = InputHandler(

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -651,6 +651,30 @@ def _log_preferred_monitor_fallback(
     )
 
 
+def get_free_float_screen(preferred_screen_name: Optional[str]) -> Optional[QScreen]:
+    """
+    Return the QScreen the widget should FREE-FLOAT on, or None to dock to a taskbar as usual.
+
+    Free-float applies only when the user's preferred monitor is (a) set, (b) currently connected, and
+    (c) has NO taskbar of its own (e.g. the Corsair Xeneon Edge, or a secondary display with "Show
+    taskbar on all displays" off). In every other case - no preference, preferred monitor disconnected,
+    or the preferred monitor has a taskbar - this returns None and the normal docking path runs (#188).
+    """
+    if not preferred_screen_name:
+        return None
+    try:
+        screen = next((s for s in QApplication.screens() if s.name() == preferred_screen_name), None)
+        if screen is None:
+            return None  # preferred monitor not connected -> the primary-taskbar fallback is correct
+        taskbars = get_all_taskbar_info()
+        if _select_taskbar_for_screen(taskbars, preferred_screen_name) is not None:
+            return None  # it has a taskbar of its own -> dock to it normally
+        return screen    # present but taskbar-less -> free-float on it
+    except Exception as e:  # noqa: BLE001 - fail-safe: never break placement over float detection
+        logger.error("get_free_float_screen failed for '%s': %s", preferred_screen_name, e, exc_info=True)
+        return None
+
+
 def get_taskbar_info(preferred_screen_name: Optional[str] = None) -> TaskbarInfo:
     """
     Retrieves the taskbar to attach the widget to.

--- a/src/netspeedtray/views/settings/pages/widget.py
+++ b/src/netspeedtray/views/settings/pages/widget.py
@@ -69,6 +69,13 @@ class WidgetPage(QWidget):
         self.free_move.toggled.connect(self.on_change)
         layout.addWidget(SettingCard(self.i18n.FREE_MOVE_LABEL, control=self.free_move))
 
+        # #188: float the widget on a preferred monitor that has no taskbar of its own.
+        self.free_float = Win11Toggle(label_text="")
+        self.free_float.toggled.connect(self.on_change)
+        layout.addWidget(SettingCard(
+            getattr(self.i18n, "FREE_FLOAT_LABEL", "Float on a display without a taskbar"),
+            control=self.free_float))
+
         self.keep_visible_fullscreen = Win11Toggle(label_text="")
         self.keep_visible_fullscreen.toggled.connect(self.on_change)
         layout.addWidget(SettingCard(self.i18n.KEEP_VISIBLE_FULLSCREEN_LABEL,
@@ -130,6 +137,7 @@ class WidgetPage(QWidget):
                 combo.setCurrentIndex(idx)
 
         self.free_move.setChecked(config.get("free_move", False))
+        self.free_float.setChecked(config.get("free_float", True))
         self.keep_visible_fullscreen.setChecked(
             config.get("keep_visible_fullscreen", constants.config.defaults.DEFAULT_KEEP_VISIBLE_FULLSCREEN))
 
@@ -141,5 +149,6 @@ class WidgetPage(QWidget):
             "stack_hardware_stats": mode == "side_by_stack",
             "widget_display_order": order,
             "free_move": self.free_move.isChecked(),
+            "free_float": self.free_float.isChecked(),
             "keep_visible_fullscreen": self.keep_visible_fullscreen.isChecked(),
         }

--- a/src/netspeedtray/views/widget/layout.py
+++ b/src/netspeedtray/views/widget/layout.py
@@ -107,13 +107,24 @@ class WidgetLayoutManager:
             raise RuntimeError("Renderer not initialized before resizing.")
 
         try:
+            # #188: when the preferred monitor is a taskbar-less display we free-float on, there's no
+            # taskbar to size against - render a normal compact horizontal readout with a font-derived
+            # height (below), so it renders crisp on that screen regardless of the primary's DPI.
+            from netspeedtray.utils.taskbar_utils import get_free_float_screen
+            float_screen = get_free_float_screen(self.widget.config.get("preferred_monitor")) \
+                if self.widget.config.get("free_float", True) else None
+
             taskbar_info = get_taskbar_info()
-            edge = taskbar_info.get_edge_position()
-            is_horizontal = edge in (constants.TaskbarEdge.TOP, constants.TaskbarEdge.BOTTOM)
             dpi_scale = taskbar_info.dpi_scale if taskbar_info.dpi_scale > 0 else 1.0
-            
-            is_small = is_small_taskbar(taskbar_info)
-            self.logger.debug(f"Taskbar edge: {edge}, Small: {is_small}")
+            if float_screen is not None:
+                edge = constants.TaskbarEdge.BOTTOM   # nominal; free-float doesn't dock to an edge
+                is_horizontal = True
+                is_small = False
+            else:
+                edge = taskbar_info.get_edge_position()
+                is_horizontal = edge in (constants.TaskbarEdge.TOP, constants.TaskbarEdge.BOTTOM)
+                is_small = is_small_taskbar(taskbar_info)
+            self.logger.debug(f"Taskbar edge: {edge}, Small: {is_small}, FreeFloat: {float_screen is not None}")
 
             precision = self.widget.config.get("decimal_places", constants.config.defaults.DEFAULT_DECIMAL_PLACES)
             margin = constants.renderer.TEXT_MARGIN
@@ -364,19 +375,24 @@ class WidgetLayoutManager:
                         calculated_width = max(calculated_width, gpu_width)
                 
                 
-                # Height is the TRUE visible taskbar height for horizontal docking (Fixes #104/PR #110)
-                screen = taskbar_info.get_screen()
-                full_geom = screen.geometry()
-                avail_geom = screen.availableGeometry()
-                
-                if edge == constants.TaskbarEdge.BOTTOM:
-                    visible_tb_height = full_geom.bottom() - avail_geom.bottom()
-                elif edge == constants.TaskbarEdge.TOP:
-                    visible_tb_height = avail_geom.top() - full_geom.top()
+                if float_screen is not None:
+                    # No taskbar to match on a taskbar-less display: font-derived height in LOGICAL px, so
+                    # Qt scales it correctly on that screen regardless of the primary monitor's DPI (#188).
+                    calculated_height = self.metrics.height() * 2 + (margin * 4)
                 else:
-                    visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
+                    # Height is the TRUE visible taskbar height for horizontal docking (Fixes #104/PR #110)
+                    screen = taskbar_info.get_screen()
+                    full_geom = screen.geometry()
+                    avail_geom = screen.availableGeometry()
 
-                calculated_height = visible_tb_height
+                    if edge == constants.TaskbarEdge.BOTTOM:
+                        visible_tb_height = full_geom.bottom() - avail_geom.bottom()
+                    elif edge == constants.TaskbarEdge.TOP:
+                        visible_tb_height = avail_geom.top() - full_geom.top()
+                    else:
+                        visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
+
+                    calculated_height = visible_tb_height
 
             else:
                 # Width is the TRUE visible taskbar width for vertical docking (Fixes #104/PR #110)

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -341,6 +341,18 @@ class NetworkSpeedWidget(QWidget):
 
 
 
+    def _on_immediate_hide_requested(self) -> None:
+        """Handle the fast fullscreen-obstruction hide, honoring the two states that must
+        stay visible: the user's keep_visible_fullscreen choice (#107), and runtime
+        free-float (#188) - where a taskbar-less preferred monitor falls back to the
+        primary taskbar, so a fullscreen app on the primary would otherwise transiently
+        hide the off-taskbar widget. Mirrors the visibility gate in _execute_refresh()."""
+        if self.config.get("keep_visible_fullscreen", False):
+            return
+        if self.position_manager and self.position_manager.is_free_float_active():
+            return
+        self.setVisible(False)
+
     def _execute_refresh(self, hwnd: int = 0) -> None:
         """
         The AUTHORITATIVE refresh trigger. This version includes a grace period
@@ -767,9 +779,13 @@ class NetworkSpeedWidget(QWidget):
             # "keep visible over fullscreen" choice (issue #107). Without this guard
             # the immediate-hide path bypassed keep_visible_fullscreen, which
             # _execute_refresh() already respects, so the widget vanished anyway.
-            self.system_event_handler.immediate_hide_requested.connect(
-                lambda: None if self.config.get("keep_visible_fullscreen", False) else self.setVisible(False)
-            )
+            #
+            # Also skip the hide when free-floating (#188): a taskbar-less preferred
+            # monitor falls back to the *primary* taskbar for obstruction checks, so a
+            # fullscreen app on the primary would otherwise blink the off-taskbar widget
+            # out until the next refresh re-shows it. _execute_refresh() already forces
+            # it visible in this state; mirror that here so there's no transient flicker.
+            self.system_event_handler.immediate_hide_requested.connect(self._on_immediate_hide_requested)
 
             # Immediately re-assert topmost when the taskbar gains focus, so the widget
             # never lingers behind the activating taskbar (the debounced refresh is too

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -396,7 +396,9 @@ class NetworkSpeedWidget(QWidget):
                 # Free-move keeps the user's exact saved spot (applied once); docked and free-float both
                 # reposition on the refresh (free-float re-places on / re-detects its taskbar-less display).
                 if not self.config.get("free_move", False):
-                    self.position_manager.update_position(fresh_taskbar_info=taskbar_info)
+                    # _float_refreshed=True: we already called refresh_float_state() above for the
+                    # visibility check this tick, so don't re-enumerate taskbars inside (#188).
+                    self.position_manager.update_position(fresh_taskbar_info=taskbar_info, _float_refreshed=True)
                 
                 # Always re-assert topmost status when visible to prevent falling behind taskbar (#77)
                 self._ensure_win32_topmost()
@@ -1693,15 +1695,18 @@ class NetworkSpeedWidget(QWidget):
                     pass
                 self.monitor_window = None
 
-            # Floating (Free Move OR #188 free-float) persists its absolute spot; a docked widget clears
-            # it so it re-docks to the tray next launch.
-            floating = (self.position_manager.is_floating() if self.position_manager
-                        else self.config.get("free_move", False))
-            if floating:
+            # Persist the widget's absolute spot when it's actively floating (Free Move or #188
+            # free-float). Only CLEAR the saved coords when the widget is genuinely docked - i.e. BOTH
+            # free_move and free_float are OFF in config. Crucially we do NOT clear just because the
+            # free-float display is currently absent (asleep/unplugged): is_floating() is runtime state,
+            # so gating the clear on it would wipe a user's dragged spot every time the accessory panel
+            # sleeps. (config_controller clears on an explicit switch to docked.) (#188)
+            if self.position_manager and self.position_manager.is_floating():
                 pos = self.pos()
                 self.update_config({"position_x": pos.x(), "position_y": pos.y()}, save_to_disk=False)
-            else:
+            elif not self.config.get("free_move", False) and not self.config.get("free_float", True):
                 self.update_config({"position_x": None, "position_y": None}, save_to_disk=False)
+            # else: free-float-capable but the display is temporarily absent -> keep the saved spot.
             
             self.logger.debug("Performing final configuration save...")
             self.config_manager.save(self.config)

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -376,15 +376,25 @@ class NetworkSpeedWidget(QWidget):
             if hwnd == 0:
                 hwnd = win32gui.GetForegroundWindow()
 
+            # #188: is the preferred monitor a taskbar-less display we should free-float on?
+            free_float_active = self.position_manager.refresh_float_state() is not None
+
             # Allow user override to keep widget visible even when a fullscreen window is present
             keep_visible = self.config.get("keep_visible_fullscreen", False)
-            should_be_visible = is_taskbar_visible(taskbar_info) and (keep_visible or not is_taskbar_obstructed(taskbar_info, hwnd))
+            if free_float_active:
+                # The accessory display has no taskbar to hide behind, and the visibility/obstruction
+                # checks are judged against the (irrelevant) primary taskbar - so just keep it shown.
+                should_be_visible = True
+            else:
+                should_be_visible = is_taskbar_visible(taskbar_info) and (keep_visible or not is_taskbar_obstructed(taskbar_info, hwnd))
 
             if self.isVisible() != should_be_visible:
                 self.setVisible(should_be_visible)
-            
+
             # Only update position if we are supposed to be visible.
             if self.isVisible():
+                # Free-move keeps the user's exact saved spot (applied once); docked and free-float both
+                # reposition on the refresh (free-float re-places on / re-detects its taskbar-less display).
                 if not self.config.get("free_move", False):
                     self.position_manager.update_position(fresh_taskbar_info=taskbar_info)
                 
@@ -1526,6 +1536,13 @@ class NetworkSpeedWidget(QWidget):
         only drives the right-align decision and the live/preview parity.)
         """
         try:
+            # A free-floating widget on a taskbar-less display has no taskbar edge; render it as a
+            # compact horizontal readout (#188).
+            from netspeedtray.utils.taskbar_utils import get_free_float_screen
+            if self.config.get("free_float", True) and \
+                    get_free_float_screen(self.config.get("preferred_monitor")) is not None:
+                self._cached_layout_mode = 'horizontal'
+                return
             taskbar_info = get_taskbar_info()
             self._cached_layout_mode = self._layout_mode_for_edge(taskbar_info.get_edge_position())
         except Exception:
@@ -1676,7 +1693,11 @@ class NetworkSpeedWidget(QWidget):
                     pass
                 self.monitor_window = None
 
-            if self.config.get("free_move", False):
+            # Floating (Free Move OR #188 free-float) persists its absolute spot; a docked widget clears
+            # it so it re-docks to the tray next launch.
+            floating = (self.position_manager.is_floating() if self.position_manager
+                        else self.config.get("free_move", False))
+            if floating:
                 pos = self.pos()
                 self.update_config({"position_x": pos.x(), "position_y": pos.y()}, save_to_disk=False)
             else:


### PR DESCRIPTION
## What

Closes #188. When the preferred monitor has **no taskbar of its own** — the Corsair Xeneon Edge accessory display, or any secondary monitor with "Show taskbar on all displays" off — NetSpeedTray used to fall back to the primary taskbar. It now **floats on that display** instead: default-placed bottom-right, draggable, and remembered.

## Design

- **Detection:** `taskbar_utils.get_free_float_screen(preferred)` returns the target screen only when the preferred monitor is set **and** connected **and** has no taskbar of its own; otherwise `None` → dock exactly as before. Fail-safe, and short-circuits cheaply (no taskbar enumeration) when no preferred monitor is set — so the 99% of users are unaffected.
- **One `PositionManager.is_floating()` predicate** (`free_move OR free_float_active`) replaces the scattered `free_move` gates across `_apply_saved_position`, `_check_for_tray_changes`, `constrain_drag`, `input_handler._save_dragged_position`, and the close-time position save — so a dragged free-float widget is remembered and the tray watcher won't yank it back to primary.
- **`refresh_float_state()`** drives it each reposition; `update_position` default-places on the taskbar-less screen; `_execute_refresh` keeps a free-float widget **visible** (no taskbar to hide behind) and `_refresh_cached_layout_mode` renders it horizontal.
- **The mixed-DPI fix:** on the taskbar-less screen the height is **font-derived (logical px)** rather than measured off a taskbar that isn't there — so Qt scales it crisp per-screen regardless of the primary monitor's DPI (e.g. Edge @100% + primary @150%).
- New **`free_float` setting** (default on) + Settings toggle + `FREE_FLOAT_LABEL` in all 11 locales.

## Tested & reviewed

- **+10 unit tests** (detection: 4 cases; `is_floating`; `refresh_float_state` + opt-out; default placement). Full suite **818 passed, 2 xfailed**.
- **Adversarial review** (completeness of the gate conversion + regression safety), findings verified: caught + fixed a **HIGH** — the close handler wiped the saved free-float spot if the accessory display was asleep at close (now gated on config, not volatile runtime state) — and a **LOW** per-tick enumeration doubling.

## ⚠️ Needs your live verification

This is the one piece I can't verify here — it needs a **real taskbar-less accessory display at mixed DPI** (your Corsair Xeneon Edge @100% + primary @150%):
- Widget appears on the Edge, correct compact height, **crisp** at 100% while primary is 150%.
- Draggable anywhere on it; the spot is **remembered** across restart; the 1 Hz watcher does **not** re-dock it to primary.
- Visibility (a fullscreen app on the primary must not hide it); toggling `free_float` off restores the old primary-dock fallback.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
