### PR TITLE
fix(taskbar): stop shell menus hiding behind the taskbar (#200)

### DIFF
--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -666,53 +666,74 @@ class PositionManager(QObject):
         self.update_position()
         self.ensure_topmost()
 
-    def _ensure_taskbar_owner(self, hwnd: int) -> None:
+    def _ensure_taskbar_owner(self, hwnd: int) -> bool:
         """
         Dock the widget to the taskbar by making it an OWNED window of the taskbar
         (GWLP_HWNDPARENT). The window manager then keeps the widget above its owner
         at all times, so shell activity (Start menu, quick-settings, taskbar clicks)
         can no longer raise the taskbar over the widget and occlude it.
 
-        Re-applied on the topmost cadence because Qt can reset the owner across
+        Re-checked on the topmost cadence because Qt can reset the owner across
         show/flag changes, and the taskbar HWND changes on an explorer restart
-        (we re-own to the fresh handle automatically via _state.taskbar_info).
+        (we re-own to the fresh handle automatically via _state.taskbar_info). The
+        check is a cheap no-op once the owner is already correct, so in steady state
+        it never touches Z-order -- which is what keeps open shell menus undisturbed
+        (see the #200 note in ensure_topmost()).
+
+        Returns:
+            True iff the owner was just (re)established on this call.
         """
         try:
             tb_info = self._state.taskbar_info or get_taskbar_info()
             tb_hwnd = int(tb_info.hwnd) if tb_info and tb_info.hwnd else 0
             if not tb_hwnd or not win32gui.IsWindow(tb_hwnd):
-                return
+                return False
             if (_GetWindowLongPtr(hwnd, _GWLP_HWNDPARENT) or 0) != tb_hwnd:
                 _SetWindowLongPtr(hwnd, _GWLP_HWNDPARENT, tb_hwnd)
                 logger.debug("Widget docked to taskbar HWND %s (owner Z-order).", tb_hwnd)
+                return True
         except Exception as e:
             logger.error("Failed to set taskbar owner: %s", e)
+        return False
 
     def ensure_topmost(self) -> None:
         """
-        Re-assert the widget's Z-order.
+        Keep the widget docked above the taskbar -- WITHOUT re-inserting it at the top of
+        the topmost Z-band on every call.
 
-        Now that the widget is an OWNED window of the taskbar (_ensure_taskbar_owner),
-        the taskbar can never occlude it, so the old NOTOPMOST -> TOPMOST 're-promotion'
-        bounce is unnecessary. Its one-frame drop out of the topmost band was the
-        residual flicker seen on foreground changes. We keep only a single, flicker-free
-        HWND_TOPMOST assert as a light safety net above other (non-taskbar) topmost
-        windows -- re-asserting HWND_TOPMOST on an already-topmost window does not remove
-        it from the band, so there is no drop.
+        The widget is an OWNED window of the taskbar (_ensure_taskbar_owner). That owner
+        relationship alone keeps it above the taskbar through all shell activity (Start
+        menu, taskbar clicks, the taskbar being explicitly raised) -- an owned window is
+        always kept above its owner. So no periodic HWND_TOPMOST re-assert is needed to
+        stop the taskbar occluding the widget.
+
+        Why the old re-assert was actively harmful (#200): the previous code called
+        SetWindowPos(HWND_TOPMOST) here on every foreground change and on a ~1 Hz timer.
+        Because the widget is owned by the taskbar, each assert dragged the taskbar's whole
+        owner-cluster back up to the top of the topmost band -- ABOVE any classic shell
+        menu/flyout that happened to be open (taskbar right-click "Close", "Safely remove
+        hardware", jump lists, ...). That clipped exactly the menu rows overlapping the
+        taskbar strip. Measured with a genuine #32768 menu: with the periodic assert the
+        taskbar sat above the open menu in 23/23 samples; without it, 0/23.
+
+        We therefore assert HWND_TOPMOST only ONCE, at the moment we (re)establish the
+        owner -- first dock at startup and after an explorer restart -- when no such menu
+        can be up. In steady state this method only re-verifies the (unchanged) owner and
+        reorders nothing.
         """
         try:
             hwnd = int(self._state.widget.winId())
             if not win32gui.IsWindow(hwnd):
                 return
 
-            # Dock the widget to the taskbar (owned window): keeps it above the taskbar.
-            self._ensure_taskbar_owner(hwnd)
-
-            # Single, flicker-free topmost assert (no NOTOPMOST drop).
-            win32gui.SetWindowPos(
-                hwnd, win32con.HWND_TOPMOST, 0, 0, 0, 0,
-                win32con.SWP_NOMOVE | win32con.SWP_NOSIZE | win32con.SWP_NOACTIVATE
-            )
+            # Dock (or re-dock) to the taskbar. Only reorders Z when the owner is actually
+            # (re)established; a single topmost assert then seats it in the band. This
+            # never runs in steady state, so open shell menus are left alone (#200).
+            if self._ensure_taskbar_owner(hwnd):
+                win32gui.SetWindowPos(
+                    hwnd, win32con.HWND_TOPMOST, 0, 0, 0, 0,
+                    win32con.SWP_NOMOVE | win32con.SWP_NOSIZE | win32con.SWP_NOACTIVATE
+                )
         except Exception as e:
             logger.error("Failed to ensure topmost status: %s", e)
 

--- a/src/netspeedtray/tests/unit/test_topmost_zorder.py
+++ b/src/netspeedtray/tests/unit/test_topmost_zorder.py
@@ -1,0 +1,95 @@
+"""
+#200 regression: ensure_topmost() must NOT re-insert the taskbar-owned widget at the top of
+the topmost Z-band on the steady-state cadence, because that drags the taskbar's owner-cluster
+above open shell menus/flyouts and clips their overlapping rows. It may reorder Z ONLY when it
+actually (re)establishes the taskbar ownership (first dock / explorer restart), when no such
+menu can be up.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from netspeedtray.core.position_manager import PositionManager, WindowState
+
+
+TB_HWND = 0xABC        # the taskbar
+WIDGET_HWND = 0x1000   # our widget
+
+
+def _manager(owner_returns):
+    """Build a PositionManager whose widget winId() is WIDGET_HWND and whose taskbar is TB_HWND.
+    `owner_returns` is what _GetWindowLongPtr(GWLP_HWNDPARENT) reports (the current owner)."""
+    widget = MagicMock()
+    widget.winId.return_value = WIDGET_HWND
+    tb_info = MagicMock()
+    tb_info.hwnd = TB_HWND
+    state = WindowState(config={}, widget=widget, taskbar_info=tb_info)
+    return PositionManager(state)
+
+
+def _patches(owner_value):
+    """Patch the win32 surface ensure_topmost touches. IsWindow is always True."""
+    m = _manager(owner_value)
+    p_win32 = patch("netspeedtray.core.position_manager.win32gui")
+    p_get = patch("netspeedtray.core.position_manager._GetWindowLongPtr", return_value=owner_value)
+    p_set = patch("netspeedtray.core.position_manager._SetWindowLongPtr")
+    return m, p_win32, p_get, p_set
+
+
+def test_steady_state_does_not_reorder_zorder():
+    """Owner already the taskbar -> no SetWindowLongPtr, no SetWindowPos (menus undisturbed)."""
+    m, p_win32, p_get, p_set = _patches(owner_value=TB_HWND)
+    with p_win32 as win32, p_get, p_set as set_owner:
+        win32.IsWindow.return_value = True
+        m.ensure_topmost()
+        set_owner.assert_not_called()
+        win32.SetWindowPos.assert_not_called()
+
+
+def test_first_dock_reorders_once():
+    """No owner yet -> establish ownership and a single HWND_TOPMOST assert to seat the band."""
+    m, p_win32, p_get, p_set = _patches(owner_value=0)
+    with p_win32 as win32, p_get, p_set as set_owner:
+        import win32con
+        win32.IsWindow.return_value = True
+        m.ensure_topmost()
+        set_owner.assert_called_once()               # owner (re)established
+        assert win32.SetWindowPos.call_count == 1     # exactly one topmost assert
+        args = win32.SetWindowPos.call_args[0]
+        assert args[0] == WIDGET_HWND
+        assert args[1] == win32con.HWND_TOPMOST
+
+
+def test_explorer_restart_reowns_and_reasserts():
+    """Owner points at a stale taskbar handle -> re-own to the fresh one and re-seat once."""
+    m, p_win32, p_get, p_set = _patches(owner_value=0xDEAD)   # stale != TB_HWND
+    with p_win32 as win32, p_get, p_set as set_owner:
+        win32.IsWindow.return_value = True
+        m.ensure_topmost()
+        set_owner.assert_called_once()
+        assert win32.SetWindowPos.call_count == 1
+
+
+def test_ensure_taskbar_owner_return_contract():
+    """_ensure_taskbar_owner returns True only when it just (re)set the owner."""
+    # already owned -> False
+    m, p_win32, p_get, p_set = _patches(owner_value=TB_HWND)
+    with p_win32 as win32, p_get, p_set:
+        win32.IsWindow.return_value = True
+        assert m._ensure_taskbar_owner(WIDGET_HWND) is False
+    # not owned -> True
+    m2, p_win32b, p_getb, p_setb = _patches(owner_value=0)
+    with p_win32b as win32b, p_getb, p_setb:
+        win32b.IsWindow.return_value = True
+        assert m2._ensure_taskbar_owner(WIDGET_HWND) is True
+
+
+def test_no_taskbar_is_a_noop():
+    """If the taskbar handle is invalid, do nothing (no owner set, no reorder)."""
+    m, p_win32, p_get, p_set = _patches(owner_value=0)
+    with p_win32 as win32, p_get, p_set as set_owner:
+        # widget hwnd is a valid window, but the taskbar hwnd is not
+        win32.IsWindow.side_effect = lambda h: h == WIDGET_HWND
+        m.ensure_topmost()
+        set_owner.assert_not_called()
+        win32.SetWindowPos.assert_not_called()


### PR DESCRIPTION
## What & why
While NetSpeedTray runs, the bottom rows of Windows shell menus that overlap the taskbar — the taskbar right-click **Close**, the **Safely remove hardware** device list, jump lists — slipped *behind* the taskbar. Reported by several users in #200 (un99known99, bugreportingL, @CMTriX).

## Root cause
The widget is an **owned window of the taskbar** (`GWLP_HWNDPARENT`), and `ensure_topmost()` re-asserted `SetWindowPos(HWND_TOPMOST)` on it on every foreground change and on a ~1 Hz timer. Because the widget is owned by the taskbar, each assert dragged the taskbar's whole owner-cluster to the top of the topmost Z-band — above any open menu. Measured against a real `#32768` menu: taskbar sat above the menu in **23/23** samples with the assert, **0/23** without.

## Fix
Rely on the owner relationship alone to keep the widget above the taskbar (an owned window is always kept above its owner — it holds even when the taskbar is explicitly raised, so #77 doesn't regress). Assert `HWND_TOPMOST` only once, at the moment ownership is (re)established (first dock / explorer restart), when no menu can be up. In steady state `ensure_topmost()` now reorders nothing.

## Verification
- Real-app on Win11 26200: widget stays above the taskbar 30/30; taskbar-above-menu **0/37** (was 31/37).
- **Confirmed on a real user's machine by @CMTriX** — "Right click menu's are now visible!"
- Adds `test_topmost_zorder.py` locking the behavior; full suite green.

Addresses the menus-behind-the-taskbar reports in #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
