### PR TITLE
fix(startup): don't crash on launch under read-only Program Files (#210)

### DIFF
--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -24,8 +24,26 @@ except ImportError:
     win32pdh = None
 
 try:
+    import win32com
+    # A frozen install under read-only Program Files makes win32com's default gen_py cache
+    # dir (inside the bundle, `_internal\win32com\gen_py`) unwritable. Importing win32com.client
+    # then crashes while (re)building its COM cache there -- and it raises FileNotFoundError,
+    # NOT ImportError, so the old guard let it through and the app failed to start (#210).
+    # Point the generated-code cache at a writable per-user temp dir BEFORE importing
+    # win32com.client. (We only ever use late-bound GetObject("winmgmts:...") for WMI, which
+    # doesn't need this cache at all; the redirect just keeps the import from crashing.)
+    import os as _os, tempfile as _tempfile
+    try:
+        _gen_dir = _os.path.join(_tempfile.gettempdir(), "netspeedtray_win32com_gen")
+        _os.makedirs(_gen_dir, exist_ok=True)
+        win32com.__gen_path__ = _gen_dir
+    except OSError:
+        pass
     import win32com.client
-except ImportError:
+except (ImportError, OSError):
+    # win32com is a bundled dependency, so the package import above effectively always
+    # succeeds; on the off chance win32com.client still can't load, degrade gracefully
+    # (WMI hardware monitoring disabled) instead of crashing the app.
     win32com.client = None
 
 import subprocess


### PR DESCRIPTION
## What & why
The **installed** build (Setup → `C:\Program Files\NetSpeedTray`) crashed on launch with a `win32com` gencache `FileNotFoundError`. Found by @CMTriX during 2.1 test-build testing (#200).

## Root cause
The 2.1 network-identity feature imports `win32com.client`; on import, `gencache` tries to (re)build its COM cache in win32com's default `gen_py` dir, which in a frozen build lives inside the **read-only** `_internal` folder under Program Files. It raises `FileNotFoundError` (not `ImportError`), so the existing `except ImportError` guard didn't catch it. Portable / single-exe builds extract to a writable temp dir, so they were unaffected.

## Fix
Redirect `win32com.__gen_path__` to a writable per-user temp dir before importing `win32com.client`, and widen the guard to `(ImportError, OSError)` so any residual failure degrades gracefully (WMI hardware monitoring off) instead of crashing. We only use late-bound `GetObject("winmgmts:…")` for WMI, which never needs the generated cache.

## Verification
- Reproduced: unfixed onedir with `_internal\win32com` denied write → never starts.
- Fixed: same condition → starts cleanly. 808 tests pass.
- **Confirmed on an installed build by @CMTriX** — "Installation works now!"

Fixes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
