### PR TITLE
fix(layout): widget text cropped top & bottom when work area isn't taskbar-inset (#221)

### DIFF
--- a/src/netspeedtray/tests/unit/test_widget_layout_height.py
+++ b/src/netspeedtray/tests/unit/test_widget_layout_height.py
@@ -1,0 +1,89 @@
+"""#221 - the docked widget height must never collapse below the two-row readout.
+
+When Windows does not inset the work area for the taskbar (some Win11 26200 single-monitor
+setups report ``QScreen.availableGeometry() == geometry()``), the old height calc derived 0 from
+the work-area diff and clamped to a 20px floor, while the renderer always draws a ~33px two-row
+stack - so the text was cropped equally top and bottom. ``WidgetLayoutManager._horizontal_dock_height``
+now (A) falls back to the real taskbar height when the diff is non-positive and (B) floors to the
+two-row content so text can never crop.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtCore import QRect
+from PyQt6.QtGui import QFont, QFontMetrics
+from PyQt6.QtWidgets import QApplication
+
+from netspeedtray import constants
+from netspeedtray.views.widget.layout import WidgetLayoutManager
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _screen(geo: QRect, avail: QRect):
+    s = MagicMock()
+    s.geometry.return_value = geo
+    s.availableGeometry.return_value = avail
+    return s
+
+
+def _taskbar(screen, *, height: int, rect=(0, 1392, 2560, 1440), dpi_scale=1.0):
+    tb = MagicMock()
+    tb.get_screen.return_value = screen
+    tb.height = height
+    tb.rect = rect
+    tb.dpi_scale = dpi_scale
+    return tb
+
+
+def _lm(font_size: int = 9) -> WidgetLayoutManager:
+    lm = WidgetLayoutManager(MagicMock())
+    lm.metrics = QFontMetrics(QFont("Segoe UI", font_size))
+    return lm
+
+
+def _two_row_min(lm: WidgetLayoutManager) -> int:
+    """The renderer's two-row content height (draw_network_speeds: 2*line_height + 1)."""
+    return lm.metrics.height() * 2 + 1
+
+
+def test_bug221_workarea_not_inset_falls_back_to_taskbar_height():
+    # The #221 condition: availableGeometry == geometry, so the work-area diff is 0.
+    # Old code returned 0 here -> clamped to a 20px box -> the two-row readout cropped top & bottom.
+    full = QRect(0, 0, 2560, 1440)
+    lm = _lm()
+    tb = _taskbar(_screen(full, full), height=48)
+    h = lm._horizontal_dock_height(constants.TaskbarEdge.BOTTOM, tb, 1.0)
+    assert h == 48                      # Part A: real taskbar height, not the 20px floor
+    assert h >= _two_row_min(lm)        # both rows fit -> no crop
+
+
+def test_normal_bottom_taskbar_uses_work_area_inset_unchanged():
+    # availableGeometry inset by a 48px bottom taskbar: diff is used as-is (no regression to #104/#110).
+    full = QRect(0, 0, 2560, 1440)
+    avail = QRect(0, 0, 2560, 1392)     # 48px shorter
+    lm = _lm()
+    tb = _taskbar(_screen(full, avail), height=48)
+    assert lm._horizontal_dock_height(constants.TaskbarEdge.BOTTOM, tb, 1.0) == 48
+
+
+def test_top_taskbar_workarea_not_inset_falls_back():
+    full = QRect(0, 0, 2560, 1440)
+    lm = _lm()
+    tb = _taskbar(_screen(full, full), height=44)
+    h = lm._horizontal_dock_height(constants.TaskbarEdge.TOP, tb, 1.0)
+    assert h == 44
+    assert h >= _two_row_min(lm)
+
+
+def test_small_taskbar_floored_to_two_row_content():
+    # A genuinely small taskbar (below the two-row content) must still not crop: Part B floor.
+    full = QRect(0, 0, 1920, 1080)
+    avail = QRect(0, 0, 1920, 1058)     # ~22px taskbar, positive so Part A does not fire
+    lm = _lm()
+    tb = _taskbar(_screen(full, avail), height=22)
+    assert lm._horizontal_dock_height(constants.TaskbarEdge.BOTTOM, tb, 1.0) >= _two_row_min(lm)

--- a/src/netspeedtray/views/widget/layout.py
+++ b/src/netspeedtray/views/widget/layout.py
@@ -380,19 +380,10 @@ class WidgetLayoutManager:
                     # Qt scales it correctly on that screen regardless of the primary monitor's DPI (#188).
                     calculated_height = self.metrics.height() * 2 + (margin * 4)
                 else:
-                    # Height is the TRUE visible taskbar height for horizontal docking (Fixes #104/PR #110)
-                    screen = taskbar_info.get_screen()
-                    full_geom = screen.geometry()
-                    avail_geom = screen.availableGeometry()
-
-                    if edge == constants.TaskbarEdge.BOTTOM:
-                        visible_tb_height = full_geom.bottom() - avail_geom.bottom()
-                    elif edge == constants.TaskbarEdge.TOP:
-                        visible_tb_height = avail_geom.top() - full_geom.top()
-                    else:
-                        visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
-
-                    calculated_height = visible_tb_height
+                    # Visible taskbar height for horizontal docking (#104/PR #110), with a #221
+                    # fallback + two-row floor so a work area Windows doesn't inset for the taskbar
+                    # (availableGeometry() == geometry()) can't collapse the widget below the readout.
+                    calculated_height = self._horizontal_dock_height(edge, taskbar_info, dpi_scale)
 
             else:
                 # Width is the TRUE visible taskbar width for vertical docking (Fixes #104/PR #110)
@@ -424,3 +415,37 @@ class WidgetLayoutManager:
             self.logger.error(f"Failed to resize widget: {e}", exc_info=True)
             self.widget.setFixedSize(150, 40)
             self.logger.warning("Applied fallback widget size: 150x40px")
+
+    def _horizontal_dock_height(self, edge: "constants.TaskbarEdge", taskbar_info: Any, dpi_scale: float) -> float:
+        """Visible taskbar height (logical px) to size a horizontal-taskbar widget to.
+
+        Normally this is the work-area inset - the slice of the screen the taskbar covers, i.e.
+        ``screen.geometry()`` minus ``screen.availableGeometry()`` (the "TRUE visible" height from
+        #104/PR #110). Two robustness guards were added for #221 (text cropped top and bottom):
+
+        - Part A (fallback): Windows does not always inset the work area for the taskbar - on some
+          Win11 26200 setups ``availableGeometry() == geometry()``, so the diff is 0 and the widget
+          would collapse onto the ``max(..., 20)`` floor. Fall back to the validated LOGICAL taskbar
+          height (``TaskbarInfo.height``, > 0 for a real taskbar) - the value ``is_small_taskbar()``
+          trusts, and the same ``<= 0`` guard ``position_manager`` already uses to POSITION the
+          widget. This only brings the sizing into line with the positioning already happening.
+        - Part B (floor): the renderer always stacks two rows (``draw_network_speeds``:
+          ``total_height = 2*line_height + 1``), so any docked height below that crops the glyphs.
+          Floor to the two-row content (+1px for the ``int()`` rounding in ``top_y``) so text can
+          never crop, without the generous margin pad the free-float/side branches use.
+        """
+        screen = taskbar_info.get_screen()
+        full_geom = screen.geometry()
+        avail_geom = screen.availableGeometry()
+
+        if edge == constants.TaskbarEdge.BOTTOM:
+            visible_tb_height = full_geom.bottom() - avail_geom.bottom()
+        elif edge == constants.TaskbarEdge.TOP:
+            visible_tb_height = avail_geom.top() - full_geom.top()
+        else:
+            visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
+
+        if visible_tb_height <= 0:                      # Part A (#221)
+            visible_tb_height = taskbar_info.height
+
+        return max(visible_tb_height, self.metrics.height() * 2 + 2)   # Part B (#221)


### PR DESCRIPTION
Fixes #221 — widget text "cropped from top and bottom" (reported on Win11 26200, single 2560×1440 @ 100%).

## Root cause

`WidgetLayoutManager.resize_widget_for_font()` derived the docked widget height from the work-area inset:

```python
visible_tb_height = full_geom.bottom() - avail_geom.bottom()   # bottom taskbar
calculated_height = visible_tb_height                          # then max(.., 20)
```

On the reporter's machine the support bundle shows `available 2560x1440 logical` — i.e. `QScreen.availableGeometry() == geometry()`: Windows isn't insetting the work area for the taskbar (auto-hide / a Win11 26200 work-area quirk). So the diff is `bottom − bottom = 0`, and the height clamps to the **20px floor**.

The renderer always stacks two rows and centers them:

```python
total_height = line_height * 2 + 1                             # ~33px at Segoe UI 9
top_y = int((height - total_height) / 2 + ascent)
```

With `height = 20 < 33`, `(height − total_height)/2` is negative, so the block is centered on the too-short box and overflows **equally top and bottom** — exactly the reported symptom. (Verified numerically: at H=20 it clips for every font size; at the true H=48 it fits.)

Notably, `position_manager` **already** falls back to the real taskbar rect height under the identical `<= 0` guard when it *positions* the widget — so the widget was a 20px box centered inside a 48px taskbar slot. The sizing code just never got the same treatment.

## Fix

The height calc is extracted into `_horizontal_dock_height()` with two guards:

- **(A) fallback** — when the work-area diff is `<= 0`, use the validated logical taskbar height `TaskbarInfo.height` (the value `is_small_taskbar()` already trusts, and the same guard `position_manager` uses). This yields the true ~48px → no clip, docks flush.
- **(B) two-row floor** — `max(height, metrics.height()*2 + 2)` so text can never crop even on a genuinely small taskbar whose own height is below the two-row content.

Part A fires only when the diff is already degenerate, so the deliberate "true visible height" behavior from #104/PR #110 is preserved for any positive diff; Part B only ever *raises* height. The `#188` free-float path takes the font-derived branch and never reaches this code.

## Testing

- New `test_widget_layout_height.py` (4 cases): the no-inset fallback (the #221 repro), the normal inset (unchanged), the TOP edge, and the small-taskbar floor.
- Full suite green: **859 passed, 2 xfailed**.

## Follow-ups (not in this PR)

- The **vertical** (left/right) taskbar branch has the same fragility for *width* (`right − right == 0`) — a parallel latent issue worth a separate fix.
- Re-sizing on `WM_SETTINGCHANGE` / work-area-change would be the more complete long-term fix for the underlying availableGeometry quirk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
