### PR TITLE
docs(readme): fix the star-history chart (sealed-token embed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,9 +391,17 @@ Every release you download from this repo is signed end-to-end - no SmartScreen 
 
 ---
 
+## Star History
+
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=erez-c137/NetSpeedTray&type=Date)](https://star-history.com/#erez-c137/NetSpeedTray&Date)
+<a href="https://www.star-history.com/?type=date&repos=erez-c137%2FNetSpeedTray">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&theme=dark&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
+  </picture>
+</a>
 
 </div>
 


### PR DESCRIPTION
Fixes the broken star-history chart at the bottom of the README.

**Why it broke:** GitHub restricted access to star-timestamp data on 2026-06-30 to a repo's own admins/collaborators, so star-history's servers can no longer fetch it for third-party repos — every live `/svg` embed went dead (404/503) and the site started prompting for a token.

**Fix:** star-history's new sealed-token approach — a fine-grained `Metadata: read-only` token, encrypted server-side into a `sealed_token`, on the `/chart` endpoint. Also upgrades to a `<picture>` element with dark/light variants and adds a "Star History" heading.

Verified: the `sealed_token` chart URL returns HTTP 200 with a real plotted SVG (no token/rate-limit error).

Note: the token has an expiry — the chart will need re-generating when it lapses.
