### PR TITLE
fix(position): stop the widget jumping on auto-hide taskbars + drop win32evtlog (#135)

### DIFF
--- a/build/netspeedtray.spec
+++ b/build/netspeedtray.spec
@@ -117,6 +117,15 @@ my_excludes = [
     'win32ui',
     'win32uiole',
 
+    # Windows Event Log bindings. Pulled in transitively (the only stdlib
+    # consumer is logging.handlers.NTEventLogHandler, which we don't use — we
+    # log to a file). Nothing in src/ imports win32evtlog. Excluding it drops
+    # win32\win32evtlog.pyd, which some heuristic AVs (e.g. Webroot) flag as a
+    # false positive on the frozen build (#135). Verify the EXE still launches
+    # and file logging works after changing this.
+    'win32evtlog',
+    'win32evtlogutil',
+
     # PIL plugins for image formats we never load. matplotlib's PIL usage
     # is only for PNG figure backing — these niche codecs are dead weight.
     # Drops PIL\_avif.cp311.pyd (~7.5 MB uncompressed) plus minor formats.

--- a/build/netspeedtray.spec
+++ b/build/netspeedtray.spec
@@ -118,7 +118,7 @@ my_excludes = [
     'win32uiole',
 
     # Windows Event Log bindings. Pulled in transitively (the only stdlib
-    # consumer is logging.handlers.NTEventLogHandler, which we don't use — we
+    # consumer is logging.handlers.NTEventLogHandler, which we don't use - we
     # log to a file). Nothing in src/ imports win32evtlog. Excluding it drops
     # win32\win32evtlog.pyd, which some heuristic AVs (e.g. Webroot) flag as a
     # false positive on the frozen build (#135). Verify the EXE still launches

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -253,15 +253,24 @@ class PositionCalculator:
             visible_tb_height = full_geom.bottom() - avail_geom.bottom()
             y_origin = avail_geom.bottom() + 1
             if visible_tb_height <= 0:
+                # Work area isn't inset for the taskbar (auto-hide, or the Win11 26200 quirk
+                # where availableGeometry() == geometry() - see #221). Take the band height
+                # from the taskbar rect, but anchor Y to the STABLE screen edge, NOT
+                # taskbar_info.rect[1]: an auto-hide taskbar's rect top slides during the
+                # show/hide animation, and reading it here made the widget chase the slide
+                # up and down every refresh tick (#135). A docked bottom taskbar always
+                # occupies the bottom `visible_tb_height` band of the screen.
                 visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
-                y_origin = taskbar_info.rect[1] / dpi_scale
+                y_origin = (full_geom.bottom() + 1) - visible_tb_height
         elif edge == constants.taskbar.edge.TOP:
             # Visible taskbar is the space above available geometry
             visible_tb_height = avail_geom.top() - full_geom.top()
             y_origin = full_geom.top()
             if visible_tb_height <= 0:
+                # See the BOTTOM note (#135/#221). Anchor to the screen's top edge, which is
+                # stable; the rect top slides off-screen while an auto-hide taskbar animates.
                 visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale
-                y_origin = taskbar_info.rect[1] / dpi_scale
+                y_origin = full_geom.top()
         else:
             # Fallback to rect-based if we're not sure
             visible_tb_height = (taskbar_info.rect[3] - taskbar_info.rect[1]) / dpi_scale

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -343,15 +343,21 @@ class PositionCalculator:
             visible_tb_width = full_geom.right() - avail_geom.right()
             x_origin = avail_geom.right() + 1
             if visible_tb_width <= 0:
+                # No work-area inset (auto-hide, or the #221 quirk). Anchor X to the STABLE
+                # screen edge, not taskbar_info.rect[0] which slides during the auto-hide
+                # animation (the vertical-taskbar analogue of the #135 bottom/top jump). A
+                # docked right taskbar always occupies the right `visible_tb_width` band.
                 visible_tb_width = (taskbar_info.rect[2] - taskbar_info.rect[0]) / dpi_scale
-                x_origin = taskbar_info.rect[0] / dpi_scale
+                x_origin = (full_geom.right() + 1) - visible_tb_width
         else: # LEFT
             # Visible taskbar is the space to the left of available geometry
             visible_tb_width = avail_geom.left() - full_geom.left()
             x_origin = full_geom.left()
             if visible_tb_width <= 0:
+                # See the RIGHT note (#135/#221). Anchor to the screen's left edge, which is
+                # stable; the rect left slides off-screen while a left auto-hide bar animates.
                 visible_tb_width = (taskbar_info.rect[2] - taskbar_info.rect[0]) / dpi_scale
-                x_origin = taskbar_info.rect[0] / dpi_scale
+                x_origin = full_geom.left()
             
         # Calculate X: center widget horizontally in taskbar gap
         x_center = x_origin + (visible_tb_width - widget_width) / 2.0

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -41,6 +41,41 @@ class TestPositionCalculator(unittest.TestCase):
         self.assertEqual(pos.x, 1590)
         self.assertEqual(pos.y, 1040)
 
+    def test_autohide_bottom_y_anchored_to_screen_not_sliding_rect(self):
+        """#135: an auto-hide taskbar reserves no work area (availableGeometry() ==
+        geometry()), so _calculate_horizontal_position falls into the rect-based fallback.
+        Y must anchor to the stable screen edge, NOT the live taskbar rect top - which slides
+        during the show/hide animation and made the widget chase it (jump up/down) every
+        refresh tick. The raw computed Y must be identical whether the taskbar rect is fully
+        shown or caught mid-slide.
+
+        This exercises the calculator directly, before validate_position() clamps the widget
+        on-screen - the clamp would otherwise mask an off-screen mid-slide Y and hide the bug.
+        """
+        screen = MagicMock()
+        screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        screen.availableGeometry.return_value = QRect(0, 0, 1920, 1080)  # auto-hide: NO inset
+
+        def _tb(rect_top: int):
+            tb = MagicMock(spec=TaskbarInfo)
+            tb.rect = (0, rect_top, 1920, rect_top + 40)  # 40px-tall taskbar
+            tb.tasklist_rect = None
+            tb.get_tray_rect.return_value = (1700, rect_top, 1920, rect_top + 40)
+            tb.get_edge_position.return_value = constants.taskbar.edge.BOTTOM
+            tb.dpi_scale = 1.0
+            tb.get_screen.return_value = screen
+            return tb
+
+        widget_size = (100, 40)
+        config = {'tray_offset_x': 10}
+
+        _, y_shown = self.calculator._calculate_horizontal_position(_tb(1040), widget_size, config, 1.0)  # fully shown
+        _, y_slide = self.calculator._calculate_horizontal_position(_tb(1060), widget_size, config, 1.0)  # mid-slide
+
+        self.assertEqual(y_shown, y_slide)   # anchored -> no jump as the taskbar animates
+        # Band = bottom 40px of the screen: y_origin = (1079+1 - 40) = 1040, centered (equal h) = 1040.
+        self.assertEqual(y_shown, 1040)
+
     def test_tray_edge_min_gap_floor(self):
         """#161 pt1: a below-floor tray offset (incl. 0) is raised to TRAY_EDGE_MIN_GAP_PX so the
         widget never abuts the '^' chevron; a larger user offset is preserved."""

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -76,6 +76,36 @@ class TestPositionCalculator(unittest.TestCase):
         # Band = bottom 40px of the screen: y_origin = (1079+1 - 40) = 1040, centered (equal h) = 1040.
         self.assertEqual(y_shown, 1040)
 
+    def test_autohide_right_x_anchored_to_screen_not_sliding_rect(self):
+        """#135 vertical-taskbar analogue: a RIGHT auto-hide taskbar reserves no work area, so
+        _calculate_vertical_position falls into the rect-based fallback. X must anchor to the
+        stable screen edge, NOT the live taskbar rect left - which slides during the show/hide
+        animation and would make the widget chase it sideways. Raw computed X must be identical
+        whether the taskbar rect is fully shown or caught mid-slide."""
+        screen = MagicMock()
+        screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        screen.availableGeometry.return_value = QRect(0, 0, 1920, 1080)  # auto-hide: NO inset
+
+        def _tb(rect_left: int):
+            tb = MagicMock(spec=TaskbarInfo)
+            tb.rect = (rect_left, 0, rect_left + 40, 1080)  # 40px-wide right taskbar
+            tb.tasklist_rect = None
+            tb.get_tray_rect.return_value = (rect_left, 900, rect_left + 40, 1080)
+            tb.get_edge_position.return_value = constants.taskbar.edge.RIGHT
+            tb.dpi_scale = 1.0
+            tb.get_screen.return_value = screen
+            return tb
+
+        widget_size = (100, 40)
+        config = {'tray_offset_y': 5}
+
+        x_shown, _ = self.calculator._calculate_vertical_position(_tb(1880), widget_size, config, 1.0)  # fully shown
+        x_slide, _ = self.calculator._calculate_vertical_position(_tb(1900), widget_size, config, 1.0)  # mid-slide
+
+        self.assertEqual(x_shown, x_slide)   # anchored -> no jump as the taskbar animates
+        # Band = right 40px: x_origin = (1919+1 - 40) = 1880, centered = 1880 + (40-100)/2 = 1850.
+        self.assertEqual(x_shown, 1850)
+
     def test_tray_edge_min_gap_floor(self):
         """#161 pt1: a below-floor tray offset (incl. 0) is raised to TRAY_EDGE_MIN_GAP_PX so the
         widget never abuts the '^' chevron; a larger user offset is preserved."""

--- a/src/netspeedtray/tests/unit/test_position_manager.py
+++ b/src/netspeedtray/tests/unit/test_position_manager.py
@@ -106,6 +106,66 @@ class TestPositionCalculator(unittest.TestCase):
         # Band = right 40px: x_origin = (1919+1 - 40) = 1880, centered = 1880 + (40-100)/2 = 1850.
         self.assertEqual(x_shown, 1850)
 
+    def test_autohide_top_y_anchored_to_screen_not_sliding_rect(self):
+        """#135 top-taskbar analogue: a TOP auto-hide taskbar reserves no work area, so
+        _calculate_horizontal_position falls into the rect-based fallback. Y must anchor to
+        the stable screen top edge, NOT the live taskbar rect top - which slides off-screen
+        (rect top goes negative) as the bar hides and shows. Raw computed Y must be identical
+        whether the taskbar rect is fully shown or caught mid-slide."""
+        screen = MagicMock()
+        screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        screen.availableGeometry.return_value = QRect(0, 0, 1920, 1080)  # auto-hide: NO inset
+
+        def _tb(rect_top: int):
+            tb = MagicMock(spec=TaskbarInfo)
+            tb.rect = (0, rect_top, 1920, rect_top + 40)  # 40px-tall top taskbar
+            tb.tasklist_rect = None
+            tb.get_tray_rect.return_value = (1700, rect_top, 1920, rect_top + 40)
+            tb.get_edge_position.return_value = constants.taskbar.edge.TOP
+            tb.dpi_scale = 1.0
+            tb.get_screen.return_value = screen
+            return tb
+
+        widget_size = (100, 40)
+        config = {'tray_offset_x': 10}
+
+        _, y_shown = self.calculator._calculate_horizontal_position(_tb(0), widget_size, config, 1.0)    # fully shown
+        _, y_slide = self.calculator._calculate_horizontal_position(_tb(-20), widget_size, config, 1.0)  # mid-slide (hiding up)
+
+        self.assertEqual(y_shown, y_slide)   # anchored -> no jump as the taskbar animates
+        # Band = top 40px of the screen: y_origin = full_geom.top() = 0, centered (equal h) = 0.
+        self.assertEqual(y_shown, 0)
+
+    def test_autohide_left_x_anchored_to_screen_not_sliding_rect(self):
+        """#135 left-taskbar analogue: a LEFT auto-hide taskbar reserves no work area, so
+        _calculate_vertical_position falls into the rect-based fallback. X must anchor to the
+        stable screen left edge, NOT the live taskbar rect left - which slides off-screen
+        (rect left goes negative) as the bar hides and shows. Raw computed X must be identical
+        whether the taskbar rect is fully shown or caught mid-slide."""
+        screen = MagicMock()
+        screen.geometry.return_value = QRect(0, 0, 1920, 1080)
+        screen.availableGeometry.return_value = QRect(0, 0, 1920, 1080)  # auto-hide: NO inset
+
+        def _tb(rect_left: int):
+            tb = MagicMock(spec=TaskbarInfo)
+            tb.rect = (rect_left, 0, rect_left + 40, 1080)  # 40px-wide left taskbar
+            tb.tasklist_rect = None
+            tb.get_tray_rect.return_value = (rect_left, 900, rect_left + 40, 1080)
+            tb.get_edge_position.return_value = constants.taskbar.edge.LEFT
+            tb.dpi_scale = 1.0
+            tb.get_screen.return_value = screen
+            return tb
+
+        widget_size = (100, 40)
+        config = {'tray_offset_y': 5}
+
+        x_shown, _ = self.calculator._calculate_vertical_position(_tb(0), widget_size, config, 1.0)    # fully shown
+        x_slide, _ = self.calculator._calculate_vertical_position(_tb(-20), widget_size, config, 1.0)  # mid-slide (hiding left)
+
+        self.assertEqual(x_shown, x_slide)   # anchored -> no jump as the taskbar animates
+        # Band = left 40px: x_origin = full_geom.left() = 0, centered = 0 + (40-100)/2 = -30 (raw, pre-clamp).
+        self.assertEqual(x_shown, -30)
+
     def test_tray_edge_min_gap_floor(self):
         """#161 pt1: a below-floor tray offset (incl. 0) is raised to TRAY_EDGE_MIN_GAP_PX so the
         widget never abuts the '^' chevron; a larger user offset is preserved."""


### PR DESCRIPTION
Fixes the four things Johnnym3334's 2.1.0 Support Bundle surfaced on an auto-hide taskbar (#135):

- **Jumping** - the widget chased the taskbar's sliding rect frame-by-frame. Now anchors Y/X to the stable screen edge instead of `taskbar_info.rect`, for all four taskbar edges (horizontal in `ec60ac0`, vertical in `81118ab`).
- **Text clipped top/bottom** - covered by #225 (already on main); this branch adds the position half.
- **Webroot AV false-positive** - excludes the unused `win32evtlog`/`win32evtlogutil` from the PyInstaller spec (`dcaf3e2`). Verified absent from the built portable zip.
- **Drag-to-move discoverability** - docs FAQ (already on main).

**Tests:** new fail-without/pass-with regression tests for auto-hide anchor stability on all four edges (bottom/top Y, left/right X). Full suite: 863 passed, 2 xfailed. Adversarial 3-lens review: all HOLD.

Ships in v2.1.1.