### PR TITLE
ci: bump GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -48,14 +48,14 @@ jobs:
 
       - name: Upload Unsigned Installer
         id: upload_installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installer-unsigned
           path: dist/NetSpeedTray-*/NetSpeedTray-*-Setup.exe
 
       - name: Upload Unsigned Portable Zip
         id: upload_portable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: portable-unsigned
           path: dist/NetSpeedTray-*/NetSpeedTray-Portable-*.zip
@@ -100,7 +100,7 @@ jobs:
         shell: pwsh
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             signed-installer/**/*


### PR DESCRIPTION
Kills the "Node.js 20 is deprecated ... forced to run on Node.js 24" warning by moving to the current Node-24-native action majors:

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v7 |
| softprops/action-gh-release | v1 | v3 |

Verified compatible: `upload-artifact@v7` still exposes the `artifact-id` output the SignPath step reads; `action-gh-release@v3` is `using: node24` and keeps the `files` input + `GITHUB_TOKEN` env. `signpath@v2` / `winget-releaser@v2` weren't flagged, left as-is. This CI run itself exercises checkout@v7 + setup-python@v6.