### PR TITLE
fix(update): single dialog on a manual 'Check for updates' + 2.1.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [2.1.2] - July 15, 2026
+
+A small patch fixing the in-app updater.
+
+### Fixed
+- **"Check for updates" opened the update window twice.** Choosing *Check for updates* from the tray menu showed the update dialog, and after you clicked **Download** a second copy of the dialog popped up over the download - which could also keep the downloaded installer from launching. The menu now shows a single update dialog, and the download and install proceed cleanly. (The automatic daily update check was never affected by this.)
+
+---
+
 ## [2.1.1] - July 15, 2026
 
 A patch release. It makes the widget behave correctly on **auto-hide taskbars**, fixes a flat CPU-temperature reading, clears an antivirus false-positive, and folds in the latest community translation updates.

--- a/src/netspeedtray/__init__.py
+++ b/src/netspeedtray/__init__.py
@@ -4,4 +4,4 @@ NetSpeedTray package initialization.
 A system tray application for monitoring network speed on Windows.
 """
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/netspeedtray/tests/unit/test_update_manual_check_wiring.py
+++ b/src/netspeedtray/tests/unit/test_update_manual_check_wiring.py
@@ -1,0 +1,48 @@
+"""
+Regression: a manual "Check for updates" must not double-wire the update dialog.
+
+The bug: `update_available` is wired to `_on_update_available` once at widget
+construction (persistent). `check_for_updates` (the tray-menu path) *also* connected a
+second, identical handler (`_on_update_available_manual`), so a manual check fired both
+and the dialog appeared twice - the first started the download, the second "popped back
+up" over it and raced the install/quit so the installer never visibly ran.
+
+This drives the REAL `NetworkSpeedWidget.check_for_updates` against a minimal fake `self`
+(no heavy widget construction) with mock signals, and asserts the manual path does NOT
+add a second `update_available` receiver - it only wires the manual-only up-to-date /
+failed messages that the silent automatic check omits.
+"""
+import types
+from unittest.mock import MagicMock
+
+from netspeedtray.views.widget.main import NetworkSpeedWidget
+
+
+def _fake_widget():
+    return types.SimpleNamespace(
+        update_checker=MagicMock(),
+        _on_up_to_date_manual=lambda: None,
+        _on_check_failed_manual=lambda e: None,
+    )
+
+
+def test_manual_check_does_not_reconnect_update_available():
+    fake = _fake_widget()
+    uc = fake.update_checker
+
+    NetworkSpeedWidget.check_for_updates(fake)
+
+    # The regression: the manual path must NOT re-connect update_available (that second,
+    # identical handler is what showed the dialog twice). The persistent connection made
+    # once at construction is the only one.
+    uc.update_available.connect.assert_not_called()
+    # It DOES wire the manual-only messages, and kicks off the check.
+    uc.up_to_date.connect.assert_called_once()
+    uc.check_failed.connect.assert_called_once()
+    uc.check_now.assert_called_once()
+
+
+def test_manual_check_no_op_without_checker():
+    """Guard: no update_checker (feature off / not yet built) is a safe no-op."""
+    fake = types.SimpleNamespace(update_checker=None)
+    NetworkSpeedWidget.check_for_updates(fake)  # must not raise

--- a/src/netspeedtray/views/widget/main.py
+++ b/src/netspeedtray/views/widget/main.py
@@ -1386,19 +1386,20 @@ class NetworkSpeedWidget(QWidget):
     def check_for_updates(self) -> None:
         """Manually trigger an update check (from menu)."""
         if self.update_checker:
-            self.update_checker.update_available.connect(self._on_update_available_manual, Qt.ConnectionType.SingleShotConnection)
+            # update_available is already wired to _on_update_available at construction
+            # (persistent, see __init__). Do NOT connect a second handler here: on a manual
+            # check both would fire and the update dialog shows twice - the first starts the
+            # download, the second "pops back up" over it and races the install/quit, so the
+            # installer never visibly runs. Only the up-to-date / failed messages are manual-
+            # only (the automatic startup check stays silent on those).
             self.update_checker.up_to_date.connect(self._on_up_to_date_manual, Qt.ConnectionType.SingleShotConnection)
             self.update_checker.check_failed.connect(self._on_check_failed_manual, Qt.ConnectionType.SingleShotConnection)
             self.update_checker.check_now()
 
     def _on_update_available(self, latest_version: str, release_url: str, body: str = "",
                              installer_url: str = "", portable_url: str = "") -> None:
-        """Handle update available from automatic startup check."""
-        self._show_update_dialog(latest_version, release_url, body, installer_url, portable_url)
-
-    def _on_update_available_manual(self, latest_version: str, release_url: str, body: str = "",
-                                    installer_url: str = "", portable_url: str = "") -> None:
-        """Handle update available from manual menu check."""
+        """Handle update available - from either the automatic startup check or a manual
+        menu check (both use this single persistent handler; see check_for_updates)."""
         self._show_update_dialog(latest_version, release_url, body, installer_url, portable_url)
 
     def _on_up_to_date_manual(self) -> None:


### PR DESCRIPTION
Fixes the in-app updater double-dialog and cuts 2.1.2.

**Bug:** `update_available` is wired to `_on_update_available` once at construction (persistent). The manual menu path (`check_for_updates`) connected a second, identical handler, so a manual *Check for updates* fired both -> two dialogs. Dialog 1's Download started the download; dialog 2 popped up over it and raced the download-complete -> launch-installer -> quit path, so the installer never visibly ran. The automatic startup check had only the one handler and was unaffected.

**Fix:** drop the redundant manual connection; remove the dead duplicate handler. New regression test asserts the manual path adds no second `update_available` receiver. 865 tests pass; local build.bat smoke clean.

Also bumps `__version__` to 2.1.2 + changelog entry.