### PR TITLE
docs(readme): drop the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,22 +391,6 @@ Every release you download from this repo is signed end-to-end - no SmartScreen 
 
 ---
 
-## Star History
-
-<div align="center">
-
-<a href="https://www.star-history.com/?type=date&repos=erez-c137%2FNetSpeedTray">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&theme=dark&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=erez-c137/NetSpeedTray&type=date&legend=top-left&sealed_token=g6Vso18jKEaxFTNmiO_SQiH6FghFMJaYtQcfxlf_CkBRG9L0_5qPpfLnJv3TjDWWyW2AgEjzknIhRo104R-2gP7mZ3Unw7GVSwKOZLGNqmPk8vWnVeRy0l0W4X0_4qSD_N4by_q87KMvWN4s8-_zY4wCQYUv0ICzhIrJpSE1dVvEczpbFC7Z9dIeON4M" />
-  </picture>
-</a>
-
-</div>
-
----
-
 ## License
 
 NetSpeedTray is licensed under the [GNU GPL v3.0](LICENSE).


### PR DESCRIPTION
GitHub [restricted the stargazers API](https://www.star-history.com/blog/github-stargazer-api-restriction) on 2026-06-30 to a repo's own admins and collaborators, so star-history.com can't read star data for visitors any more.

**It didn't fail loudly.** The embed returned HTTP 200 and a valid 60 KB SVG — whose text content read *"GitHub restricted access to star data"*. So it rendered as a chart-shaped notice, which looks like a neglected page rather than an upstream outage. Camo, `<picture>`/`srcset` and the URL casing were all fine; the markup was never the problem.

**The documented fix didn't work.** A scoped owner token sealed into the README failed across two attempts with a fine-grained PAT. That's consistent with [star-history/star-history#542](https://github.com/star-history/star-history/issues/542), where the maintainer writes *"it's unlikely I can fully restore the previous star history experience"*, GraphQL was restricted too on 2026-07-17, and several users have moved to self-hosted renderers.

**Self-hosting is viable but out of scope.** The owner's own token can still read stargazers *with* `starred_at` timestamps (verified — 684 stars over 83 pages), so a nightly Action could render and commit the SVG with no third party. That's a build, not a README fix.

Removing rather than leaving a notice that reads as neglect. GitHub has told star-history they're "actively working on it to restore the behavior" — if that lands, this is a one-line revert. The full diagnosis is recorded in project memory so nobody re-derives it.