### PR TITLE
build(deps): bump Pillow to 12.3.0 (clears all 26 Dependabot alerts)

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -8,7 +8,7 @@ pytest-cov
 freezegun
 pip-tools
 wheel>=0.46.2  # Explicitly added to enforce Security CVE fix
-pillow>=12.2.0  # Security: ensure patched Pillow (FITS GZIP decompression bomb)
+pillow>=12.3.0  # Security: 13 CVEs fixed in 12.3.0 (see dependabot)
 pytest>=9.0.3   # Security: vulnerable tmpdir handling fix
 parameterized
 pytest-qt       # GUI interaction tests (qtbot) for the PyQt6 dialogs, run headless via offscreen

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -50,7 +50,7 @@ parameterized==0.9.0
     # via -r dev-requirements.in
 pefile==2024.8.26
     # via pyinstaller
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -r dev-requirements.in
     #   -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,5 @@ matplotlib
 numpy
 wmi
 fonttools>=4.61.0   # Explicitly added to enforce Security CVE fix
-pillow>=12.2.0      # Security: ensure patched Pillow (FITS GZIP decompression bomb)
+pillow>=12.3.0      # Security: 13 CVEs fixed in 12.3.0 (see dependabot)
 python-bidi          # RTL (Hebrew) bidi reshaping for matplotlib graph labels (item 6)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ numpy==2.3.2
     #   matplotlib
 packaging==25.0
     # via matplotlib
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -r requirements.in
     #   matplotlib


### PR DESCRIPTION
All 26 open Dependabot alerts are the same package: **13 CVEs against Pillow, counted once per manifest** (`requirements.txt` + `dev-requirements.txt`). Every one is fixed in **12.3.0**, so one patch-level bump closes the entire set.

### Exposure

Low, and worth saying plainly rather than overselling:

- We never `import PIL` directly and never open an image. Pillow arrives via matplotlib.
- Our only image path is `figure.savefig()` in [`utils/exporters.py`](src/netspeedtray/utils/exporters.py) - writing a PNG of a graph we drew ourselves.
- The CVEs are decoder/parser bugs reached by loading **attacker-supplied** images or fonts (PCF, BDF, GD, TGA, EPS, JPEG2000, PDF), plus an OS command injection in `WindowsViewer.get_command()` that requires `Image.show()`, which we never call.

So this is hygiene, not an incident. Doing it anyway because it is free, it keeps things honest for anyone running from source, and a clean security tab means the *next* real alert is visible instead of buried under 26 of these.

### Why hand-pinned instead of pip-compile

The lockfiles were compiled on Python 3.14; this machine is 3.11, so `pip-compile` would rewrite the header and churn every unrelated pin days before a release. Pillow 12.3.0 has **no runtime dependencies** and the same `>=3.10` floor, so the bump is genuinely drop-in and a surgical edit is the lower-risk change. Both `.in` floors and both `.txt` pins were updated together, so the next real recompile stays consistent.

### Verification

- 1061 tests pass on 12.3.0
- matplotlib imports and renders a PNG correctly
- Checked the `PIL.*` excludes in `build.spec`: all still resolve except `PIL.HeifImagePlugin`, which no longer exists upstream. A PyInstaller exclude for a missing module is a no-op, so the list is left alone.

Targeting 2.1.3.