### PR TITLE
docs: credit the translators the README has been missing since 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ You probably grabbed an unsigned dev build. The official releases ([Setup.exe / 
 - **Support Bundle** - one-click sanitized zip of logs + config + system info for bug reports
 
 ### Localization
-- **10 languages:** English, Korean, French, German, Russian, Spanish, Dutch, Polish, Slovenian, Japanese
+- **14 languages:** English, Korean, French, German, Russian, Spanish, Dutch, Polish, Slovenian, Japanese, Simplified Chinese, Traditional Chinese, Hebrew (RTL), Turkish
 - 100% key parity across all locales
 
 </details>
@@ -296,13 +296,13 @@ I'm not doing this for the money - but I'd be lying if I said a little support d
 
 - ⭐ **Star the repo** - one click, and it genuinely helps others find the project.
 - 🐛 **File a good bug report** - use the [template](https://github.com/erez-c137/NetSpeedTray/issues/new?template=bug_report.yml) and attach a Support Bundle; it saves me real triage time.
-- 🌍 **Improve a translation** - German and Spanish especially could use a native-speaker review. See [TRANSLATORS.md](TRANSLATORS.md).
+- 🌍 **Improve a translation** - German, Spanish and Hebrew especially could use a native-speaker review. See [TRANSLATORS.md](TRANSLATORS.md).
 
 ---
 
 ## Translators
 
-NetSpeedTray's UI lives in 10 languages thanks to the people below. Each translation is real time and care - if you use NetSpeedTray in your language, please give them a star and a thank-you.
+NetSpeedTray's UI lives in 14 languages thanks to the people below. Each translation is real time and care - if you use NetSpeedTray in your language, please give them a star and a thank-you.
 
 | Language | Locale | Translator |
 |---|---|---|
@@ -313,6 +313,10 @@ NetSpeedTray's UI lives in 10 languages thanks to the people below. Each transla
 | 🇵🇱 Polish | `pl_PL` | FadeMind |
 | 🇫🇷 French | `fr_FR` | [@logounet](https://github.com/logounet) |
 | 🇯🇵 Japanese | `ja_JP` | [@coolvitto](https://github.com/coolvitto) |
+| 🇨🇳 Simplified Chinese | `zh_CN` | [@RainThings](https://github.com/RainThings) |
+| 🇹🇼 Traditional Chinese | `zh_TW` | [@raylolhue](https://github.com/raylolhue), [@in2002-tw](https://github.com/in2002-tw), [@tony8077616](https://github.com/tony8077616) |
+| 🇹🇷 Turkish | `tr_TR` | [@lezgintekay](https://github.com/lezgintekay) |
+| 🇮🇱 Hebrew (RTL) | `he_IL` | [@rami123](https://github.com/rami123) - **native-speaker review welcome** |
 | 🇩🇪 German | `de_DE` | Maintainer - **native-speaker review welcome** |
 | 🇪🇸 Spanish | `es_ES` | Maintainer - **native-speaker review welcome** |
 

--- a/TRANSLATORS.md
+++ b/TRANSLATORS.md
@@ -1,6 +1,6 @@
 # Translators
 
-NetSpeedTray's UI is available in 13 languages - including Hebrew, its first right-to-left locale - thanks to the community contributors below. Each name represents real time and care invested in making the app feel native to its users - thank you.
+NetSpeedTray's UI is available in 14 languages - including Hebrew, its first right-to-left locale - thanks to the community contributors below. Each name represents real time and care invested in making the app feel native to its users - thank you.
 
 If you'd like to contribute a translation or improve an existing one, see the locale files in [`src/netspeedtray/constants/locales/`](src/netspeedtray/constants/locales/) and open a pull request. The `en_US.json` file is the source of truth - all other locales must keep key parity with it (enforced by [`test_locales_parity.py`](src/netspeedtray/tests/unit/test_locales_parity.py)).
 
@@ -15,6 +15,7 @@ If you'd like to contribute a translation or improve an existing one, see the lo
 | Polish | `pl_PL` | FadeMind | [#39](https://github.com/erez-c137/NetSpeedTray/pull/39) |
 | French | `fr_FR` | [@logounet](https://github.com/logounet) | #94 |
 | Japanese | `ja_JP` | [@coolvitto](https://github.com/coolvitto) | [#155](https://github.com/erez-c137/NetSpeedTray/pull/155) |
+| Turkish | `tr_TR` | [@lezgintekay](https://github.com/lezgintekay) | [#249](https://github.com/erez-c137/NetSpeedTray/pull/249) |
 | Simplified Chinese | `zh_CN` | [@RainThings](https://github.com/RainThings) | [#209](https://github.com/erez-c137/NetSpeedTray/pull/209) |
 | Traditional Chinese (Taiwan) | `zh_TW` | [@raylolhue](https://github.com/raylolhue), with terminology improvements from [@in2002-tw](https://github.com/in2002-tw) and native polish from [@tony8077616](https://github.com/tony8077616) | [#199](https://github.com/erez-c137/NetSpeedTray/pull/199), [#215](https://github.com/erez-c137/NetSpeedTray/pull/215) |
 | Hebrew (RTL) | `he_IL` | [@rami123](https://github.com/rami123) (initiated the locale) — remaining strings AI-assisted, **pending native review** | [#165](https://github.com/erez-c137/NetSpeedTray/pull/165) |


### PR DESCRIPTION
The README has said **"10 languages"** since 2.0, listing the 2.0 set. Chinese (Simplified and Traditional) and Hebrew all shipped in **2.1.0** and were added to `TRANSLATORS.md` at the time - but the README table was never updated alongside it.

The result is that five people who did real translation work have been uncredited on the page most visitors actually read: [@RainThings](https://github.com/RainThings), [@raylolhue](https://github.com/raylolhue), [@in2002-tw](https://github.com/in2002-tw), [@tony8077616](https://github.com/tony8077616) and [@rami123](https://github.com/rami123). That is worth fixing on its own, separately from any release.

### Changes

- README: `10 languages` -> `14`, in both the feature list and the Translators heading
- README: added Simplified Chinese, Traditional Chinese, Hebrew (RTL) and Turkish to the table
- README: the "improve a translation" ask now names Hebrew alongside German and Spanish - past the ~74 strings @rami123 seeded, `he_IL` is AI-assisted and genuinely wants a native pass
- `TRANSLATORS.md`: 13 -> 14 languages, Turkish row added

Turkish comes from #249, so merge that first. Docs only - no code touched.