### PR TITLE
docs: finish the 2.1.3 changelog entry + add a Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Alerts alone were enough to accumulate 26 open advisories against a single package before anyone
+# looked (all Pillow, all cleared by one patch bump in #252). These keep the pins moving on their own.
+#
+# Grouped and capped deliberately: this is a solo-maintained project, and a stream of one-PR-per-pin
+# is noise that gets ignored, which is the failure mode this is meant to prevent. Security updates
+# are ungrouped so they arrive on their own and stay visible.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      # Runtime pins move together; a bump here needs a real smoke test either way.
+      runtime:
+        patterns: ["*"]
+        exclude-patterns: ["pyinstaller*", "pytest*", "pip-tools", "wheel", "build", "coverage*", "freezegun", "parameterized"]
+        update-types: ["minor", "patch"]
+      # Build and test tooling never ships to a user, so these can land with just CI green.
+      dev-tooling:
+        patterns: ["pyinstaller*", "pytest*", "pip-tools", "wheel", "build", "coverage*", "freezegun", "parameterized"]
+    commit-message:
+      prefix: "build(deps)"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(deps)"
+    labels: ["dependencies", "ci"]

--- a/changelog.md
+++ b/changelog.md
@@ -107,13 +107,23 @@ Fixes from a month of bug reports, including one that has been in every release 
 - **VRAM no longer reads 0.0 GB after sleep.** It stayed there until you opened Settings and clicked Save. ([#237])
 - **The taskbar and the Monitor window now agree on the temperature.** One rounded and the other cut the decimal off, so 27.9 °C showed as both "27" and "28". ([#237])
 - **Dragging the widget more than ~500 px from the tray no longer snaps it back** on the next launch. ([#234])
-- **The language list shows all 13 languages.** Three sat below the fold with no way to scroll to them. ([#237])
+- **The language list shows every language.** Three sat below the fold with no way to scroll to them, and the list has since grown to fourteen. ([#237])
+
+### Security
+
+- **Pillow updated to 12.3.0**, closing thirteen advisories in the image library matplotlib uses for the history graph. Nothing here was exploitable - NetSpeedTray never opens an image, it only writes its own graph - but the dependency is current again. ([#252])
 
 ### Localization
 
 - **Turkish - the fourteenth language**, contributed by [@lezgintekay] ([#249]).
 - Japanese ([@coolvitto]) and Russian ([@ZeoNish]) updates, a Korean review ([@VenusGirl]), and a fill-in pass across the remaining languages. Several strings that were still English - the free-float label and the portable-update messages - are now translated. Native review is still welcome: [#202].
 
+### Developer notes
+
+- **Tests grew from 865 to 1135**, covering language auto-detect, the tray-menu accelerators, CPU sensor selection, the GPU wildcard counters and the arrow colours.
+- **A new locale is now checked for more than key parity.** A locale file that isn't registered in `LANGUAGE_MAP` is unreachable from the UI - Turkish arrived that way and every existing test passed, because parity only ever compares keys between files. ([#254])
+
+  *Under the hood: the new checks also pin each locale's decimal separator to CLDR and cap `DEFAULT_TEXT`, which is painted on the taskbar itself - a spelled-out phrase overflows a slot sized for "N/A".*
 
 [#168]: https://github.com/erez-c137/NetSpeedTray/issues/168
 [#187]: https://github.com/erez-c137/NetSpeedTray/issues/187
@@ -122,6 +132,8 @@ Fixes from a month of bug reports, including one that has been in every release 
 [#234]: https://github.com/erez-c137/NetSpeedTray/issues/234
 [#236]: https://github.com/erez-c137/NetSpeedTray/issues/236
 [#237]: https://github.com/erez-c137/NetSpeedTray/issues/237
+[#252]: https://github.com/erez-c137/NetSpeedTray/pull/252
+[#254]: https://github.com/erez-c137/NetSpeedTray/pull/254
 [#249]: https://github.com/erez-c137/NetSpeedTray/pull/249
 [@Aaronxiexyl]: https://github.com/Aaronxiexyl
 [@balciseri]: https://github.com/balciseri

--- a/src/netspeedtray/views/settings/pages/general.py
+++ b/src/netspeedtray/views/settings/pages/general.py
@@ -36,7 +36,7 @@ class GeneralPage(QWidget):
             getattr(self.i18n, "LANGUAGE_AUTO_DETECT", "Auto-detect (system)"), userData=None)
         for code, name in self.i18n.LANGUAGE_MAP.items():
             self.language_combo.addItem(name, userData=code)
-        # Qt defaults to 10 visible rows; we ship 13 languages plus the auto-detect row, so the
+        # Qt defaults to 10 visible rows; we ship 14 languages plus the auto-detect row, so the
         # last entries sat below the fold with no wheel scrolling in the popup (#237).
         self.language_combo.setMaxVisibleItems(self.language_combo.count())
         self.language_combo.currentIndexChanged.connect(self.on_change)


### PR DESCRIPTION
Closing the loop on the last few things this cycle left behind.

### Changelog

The 2.1.3 entry was missing two sections it earned:

- **Security** - the Pillow 12.3.0 bump (#252), written to the honesty guardrail: thirteen advisories closed, **none of them reachable here**, because the app never opens an image and only ever writes its own graph. Housekeeping, and it says so.
- **Developer notes** - 865 -> 1135 tests, and the new locale registration checks (#254).

Also fixes **"the language list shows all 13 languages"**, which Turkish made wrong the moment it merged. Reworded so it will not need editing again the next time a language lands.

Section order and reference links verified against `Docs/reference/changelog-guidelines.md` - Added / Changed / Fixed / Security / Localization / Developer notes, no undefined or orphaned link definitions.

### The stale comment in general.py

The language combo already does the right thing - `setMaxVisibleItems(self.language_combo.count())`, fed straight from `LANGUAGE_MAP` - so Turkish appeared automatically and the #237 dropdown-cap fix did **not** regress. Only the comment saying "we ship 13 languages" had aged. Worth checking rather than assuming, since a hardcoded cap there would have silently re-broken the exact bug we just fixed.

### .github/dependabot.yml

The repo never had one - alerts only, no automatic version-update PRs. That is how 26 advisories against a single package accumulated before anyone looked.

Deliberately conservative:

- **Grouped** into `runtime` and `dev-tooling`. One PR per pin is noise for a solo maintainer, and ignored noise is the exact failure mode this is meant to prevent.
- **Capped** at 5 open pip PRs, 3 for actions.
- **Security updates stay ungrouped** so they arrive on their own and stay visible.
- **`github-actions` included**, since the Node-20 deprecation bump in #232 was done by hand.

1135 tests pass.