### PR TITLE
fix(build): make the exe's version resource readable by Windows

### DIFF
--- a/build/create_version_info.py
+++ b/build/create_version_info.py
@@ -2,6 +2,20 @@
 import sys
 import os
 
+# A note on the structure below, because the wrong version of it looks right and builds fine:
+#
+# StringFileInfo must contain a StringTable keyed by "<lang><codepage>" - it is that key that ties
+# the strings to a translation. Passing the StringStructs to StringFileInfo directly (as this did
+# until 2.1.3) still produces an exe: PyInstaller accepts it, the strings really are written into
+# the resource, and nothing warns. But Windows finds no StringTable to read them from, so every
+# consumer - Explorer's Properties > Details tab, .NET's FileVersionInfo, installers, AV reputation
+# heuristics - sees a binary with no version metadata at all.
+#
+# "040904B0" is US English (0x0409) + codepage 1200 (0x04B0, Unicode), and the Translation entry
+# below must agree with it. They previously disagreed too: the key said Unicode while Translation
+# declared 1252.
+
+
 def create_version_file(version_str):
     # Ensure version has 4 parts (e.g., 1.1.8 -> 1.1.8.0)
     parts = version_str.split('.')
@@ -28,17 +42,22 @@ VSVersionInfo(
   kids=[
     StringFileInfo(
       [
-        StringStruct('CompanyName', 'Erez C137'),
-        StringStruct('FileDescription', 'NetSpeedTray'),
-        StringStruct('FileVersion', '{version_full_str}'),
-        StringStruct('InternalName', 'NetSpeedTray'),
-        StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
-        StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
-        StringStruct('ProductName', 'NetSpeedTray'),
-        StringStruct('ProductVersion', '{version_str}'),
+        StringTable(
+          '040904B0',
+          [
+            StringStruct('CompanyName', 'Erez C137'),
+            StringStruct('FileDescription', 'NetSpeedTray'),
+            StringStruct('FileVersion', '{version_full_str}'),
+            StringStruct('InternalName', 'NetSpeedTray'),
+            StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
+            StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
+            StringStruct('ProductName', 'NetSpeedTray'),
+            StringStruct('ProductVersion', '{version_str}'),
+          ]
+        )
       ]
     ),
-    VarFileInfo([VarStruct('Translation', [0x0409, 1252])])
+    VarFileInfo([VarStruct('Translation', [0x0409, 1200])])
   ]
 )
 """

--- a/build/version_info.txt
+++ b/build/version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 0, 0, 0),
-    prodvers=(2, 0, 0, 0),
+    filevers=(2, 1, 3, 0),
+    prodvers=(2, 1, 3, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -12,16 +12,21 @@ VSVersionInfo(
   kids=[
     StringFileInfo(
       [
-        StringStruct('CompanyName', 'Erez C137'),
-        StringStruct('FileDescription', 'NetSpeedTray'),
-        StringStruct('FileVersion', '2.0.0.0'),
-        StringStruct('InternalName', 'NetSpeedTray'),
-        StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
-        StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
-        StringStruct('ProductName', 'NetSpeedTray'),
-        StringStruct('ProductVersion', '2.0.0'),
+        StringTable(
+          '040904B0',
+          [
+            StringStruct('CompanyName', 'Erez C137'),
+            StringStruct('FileDescription', 'NetSpeedTray'),
+            StringStruct('FileVersion', '2.1.3.0'),
+            StringStruct('InternalName', 'NetSpeedTray'),
+            StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
+            StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
+            StringStruct('ProductName', 'NetSpeedTray'),
+            StringStruct('ProductVersion', '2.1.3'),
+          ]
+        )
       ]
     ),
-    VarFileInfo([VarStruct('Translation', [0x0409, 1252])])
+    VarFileInfo([VarStruct('Translation', [0x0409, 1200])])
   ]
 )

--- a/changelog.md
+++ b/changelog.md
@@ -107,6 +107,9 @@ Fixes from a month of bug reports, including one that has been in every release 
 - **VRAM no longer reads 0.0 GB after sleep.** It stayed there until you opened Settings and clicked Save. ([#237])
 - **The taskbar and the Monitor window now agree on the temperature.** One rounded and the other cut the decimal off, so 27.9 °C showed as both "27" and "28". ([#237])
 - **Dragging the widget more than ~500 px from the tray no longer snaps it back** on the next launch. ([#234])
+- **The app now tells Windows what version it is.** Right-clicking `NetSpeedTray.exe` and opening Properties showed a blank Details tab in every release so far - no version, no publisher, no copyright. Installers, update tooling and antivirus reputation checks all read that same metadata.
+
+  *Under the hood: the generated version resource put its `StringStruct`s straight into `StringFileInfo` with no `StringTable` wrapper, so there was no lang-codepage key for Windows to read them under. PyInstaller accepts that silently and the strings really were written into the binary - they were just unreachable. The key and the `Translation` entry also disagreed (Unicode vs 1252) and now match.*
 - **The language list shows every language.** Three sat below the fold with no way to scroll to them, and the list has since grown to fourteen. ([#237])
 
 ### Security


### PR DESCRIPTION
Found while smoke-testing the 2.1.3 build: `NetSpeedTray.exe` reports **no version metadata at all**. Right-click -> Properties -> Details is blank - no version, no publisher, no copyright. I confirmed the same on the **shipped 2.1.2 binary**, so this is longstanding, not a regression.

### Cause

`create_version_info.py` generated this:

```python
StringFileInfo([
    StringStruct("FileVersion", "2.1.3.0"),
    ...
])
```

It needs a `StringTable` in between:

```python
StringFileInfo([
    StringTable("040904B0", [
        StringStruct("FileVersion", "2.1.3.0"),
        ...
    ])
])
```

That wrapper carries the `"<lang><codepage>"` key that ties the strings to a translation. Without it Windows has nowhere to read them from.

**The failure mode is why this went unnoticed for so long:** PyInstaller accepts the malformed form without a warning, the build succeeds, and the strings really are written into the binary - I confirmed they are physically present as UTF-16 in the exe. They are just unreachable. Nothing anywhere reports a problem; the metadata is simply always empty.

The `StringTable` key and the `Translation` entry also disagreed - the key says Unicode (codepage 1200) while `Translation` declared 1252. Now consistent.

### Verified

Rebuilt and read the resource back:

| field | before | after |
|---|---|---|
| FileVersion | *(blank)* | `2.1.3.0` |
| ProductVersion | *(blank)* | `2.1.3` |
| CompanyName | *(blank)* | `Erez C137` |
| ProductName | *(blank)* | `NetSpeedTray` |
| LegalCopyright | *(blank)* | `Copyright (c) Erez C137` |
| OriginalFilename | *(blank)* | `NetSpeedTray.exe` |

### Why it is worth taking for 2.1.3

Build metadata only - no application code changes, so the risk is close to zero. Beyond the Properties dialog, installers, update tooling and **antivirus reputation heuristics** all read this, and an unsigned-looking binary with no publisher metadata is exactly the profile that trips them. This project already had a Webroot false positive to clear in 2.1.1.

Also adds a comment in the generator explaining the trap, since the broken form looks correct.