### PR TITLE
fix(monitor): draw the Hardware graph instead of an empty grid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -107,6 +107,9 @@ Fixes from a month of bug reports, including one that has been in every release 
 - **VRAM no longer reads 0.0 GB after sleep.** It stayed there until you opened Settings and clicked Save. ([#237])
 - **The taskbar and the Monitor window now agree on the temperature.** One rounded and the other cut the decimal off, so 27.9 °C showed as both "27" and "28". ([#237])
 - **Dragging the widget more than ~500 px from the tray no longer snaps it back** on the next launch. ([#234])
+- **The Monitor's Hardware graph draws again.** It had been showing an empty grid with a 0-1 scale instead of your CPU, GPU and RAM history - in 2.1.0, 2.1.1 and 2.1.2. The Network graph on the next tab was never affected.
+
+  *Under the hood: `get_hardware_history()` returns `datetime` timestamps, as its type hint says, but the hardware renderers built their arrays with `np.array(rows, dtype=float)`, which cannot convert one. The `TypeError` was caught and logged by `GraphHost._on_data_ready`, so the tab failed silently and only a log line ever said so - which is why it survived three releases. Found by opening the tab during a release smoke test.*
 - **The app now tells Windows what version it is.** Right-clicking `NetSpeedTray.exe` and opening Properties showed a blank Details tab in every release so far - no version, no publisher, no copyright. Installers, update tooling and antivirus reputation checks all read that same metadata.
 
   *Under the hood: the generated version resource put its `StringStruct`s straight into `StringFileInfo` with no `StringTable` wrapper, so there was no lang-codepage key for Windows to read them under. PyInstaller accepts that silently and the strings really were written into the binary - they were just unreachable. The key and the `Translation` entry also disagreed (Unicode vs 1252) and now match.*

--- a/src/netspeedtray/tests/unit/test_hardware_graph_timestamps.py
+++ b/src/netspeedtray/tests/unit/test_hardware_graph_timestamps.py
@@ -1,0 +1,84 @@
+"""
+The Monitor's Hardware graph must accept the timestamps its own data layer produces.
+
+`WidgetState.get_hardware_history()` is typed `List[Tuple[datetime, float]]` and really does return
+datetimes, but the hardware renderers built their arrays with `np.array(rows, dtype=float)`, which
+cannot convert a datetime. Every hardware series therefore raised
+
+    TypeError: float() argument must be a string or a real number, not 'datetime.datetime'
+
+inside `GraphRenderer.render()`. `GraphHost._on_data_ready` catches everything and logs it, so the
+Hardware tab just drew empty 0.0-1.0 axes - no error surfaced to the user. It shipped that way in
+2.1.0, 2.1.1 and 2.1.2 before a smoke test caught the log line.
+
+The speed-history path yields epoch floats instead, and both reach the same renderers, so the
+coercion has to accept either.
+"""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+
+from netspeedtray.views.graph.renderer import GraphRenderer
+
+
+_BASE = datetime(2026, 8, 22, 2, 0, 0)
+
+
+def _datetime_series(n=5):
+    """Exactly what get_hardware_history() returns."""
+    return [(_BASE + timedelta(seconds=i), float(i * 10)) for i in range(n)]
+
+
+def _epoch_series(n=5):
+    """What the speed-history path yields."""
+    return [((_BASE + timedelta(seconds=i)).timestamp(), float(i * 10)) for i in range(n)]
+
+
+def test_datetime_rows_are_accepted():
+    """The regression: this raised TypeError before the fix."""
+    arr = GraphRenderer._rows_as_floats(_datetime_series())
+    assert arr.shape == (5, 2)
+    assert arr.dtype == np.float64
+    assert arr[0, 0] == pytest.approx(_BASE.timestamp())
+    assert list(arr[:, 1]) == [0.0, 10.0, 20.0, 30.0, 40.0]
+
+
+def test_epoch_rows_still_work():
+    """The other caller must not regress."""
+    arr = GraphRenderer._rows_as_floats(_epoch_series())
+    assert arr.shape == (5, 2)
+    assert arr[0, 0] == pytest.approx(_BASE.timestamp())
+
+
+def test_both_shapes_agree():
+    """A datetime series and the same instants as epochs must produce identical arrays."""
+    np.testing.assert_allclose(
+        GraphRenderer._rows_as_floats(_datetime_series()),
+        GraphRenderer._rows_as_floats(_epoch_series()),
+    )
+
+
+def test_three_column_rows_survive():
+    """The overview network series is (ts, up, down), not (ts, value)."""
+    rows = [(_BASE + timedelta(seconds=i), float(i), float(i * 2)) for i in range(3)]
+    arr = GraphRenderer._rows_as_floats(rows)
+    assert arr.shape == (3, 3)
+    assert list(arr[:, 2]) == [0.0, 2.0, 4.0]
+
+
+def test_empty_series_is_empty_not_an_error():
+    """Callers guard with `if not series` / `len(x) > 0`; an empty input must stay falsy, not raise."""
+    arr = GraphRenderer._rows_as_floats([])
+    assert len(arr) == 0
+
+
+def test_raw_numpy_conversion_still_fails_on_datetimes():
+    """Pins WHY the helper exists.
+
+    If a future refactor drops back to `np.array(rows, dtype=float)`, this documents the failure it
+    reintroduces - the bug was invisible precisely because the exception was swallowed downstream.
+    """
+    with pytest.raises(TypeError):
+        np.array(_datetime_series(), dtype=float)

--- a/src/netspeedtray/views/graph/renderer.py
+++ b/src/netspeedtray/views/graph/renderer.py
@@ -697,6 +697,28 @@ class GraphRenderer(QObject):
         self.ax_cpu.set_ylabel(self._lbl(self.i18n.ORDER_TYPE_CPU), fontsize=8, color=text_color)
         self.ax_gpu.set_ylabel(self._lbl(self.i18n.ORDER_TYPE_GPU), fontsize=8, color=text_color)
 
+    @staticmethod
+    def _rows_as_floats(series) -> np.ndarray:
+        """(timestamp, value, ...) rows as a float array, accepting datetime OR epoch timestamps.
+
+        The two data sources disagree on the first column and both reach these renderers:
+        `get_hardware_history()` is typed - and really returns - `List[Tuple[datetime, float]]`,
+        while the speed-history path yields epoch floats. `np.array(rows, dtype=float)` cannot
+        convert a datetime, so every hardware series raised
+
+            TypeError: float() argument must be ... not 'datetime.datetime'
+
+        which `GraphHost._on_data_ready` swallowed into a log line - leaving the Monitor's Hardware
+        tab drawing empty 0.0-1.0 axes with no hint that anything had failed. Mirrors the coercion
+        the network branch of `render()` already does inline.
+        """
+        rows = []
+        for row in series:
+            ts = row[0]
+            rows.append([ts.timestamp() if isinstance(ts, datetime) else float(ts)]
+                        + [float(v) for v in row[1:]])
+        return np.array(rows, dtype=float)
+
     def _render_overview(self, data_dict, start_time, end_time, period_key: str, boot_time):
         """Internal helper for overview plotting."""
         # Clear existing artists so live refresh doesn't keep stacking lines.
@@ -716,14 +738,14 @@ class GraphRenderer(QObject):
             self.ax_upload.set_ylim(bottom=0, top=max(up)*1.2 if max(up)>0 else 1)
 
         # Plot CPU
-        cpu = np.array(data_dict.get("cpu", []), dtype=float)
+        cpu = self._rows_as_floats(data_dict.get("cpu", []))
         if len(cpu) > 0:
             ts = [datetime.fromtimestamp(t) for t in cpu[:, 0]]
             self.ax_cpu.plot(ts, cpu[:, 1], color=constants.graph.CPU_LINE_COLOR, linewidth=1)
             self.ax_cpu.set_ylim(0, 100)
 
         # Plot GPU
-        gpu = np.array(data_dict.get("gpu", []), dtype=float)
+        gpu = self._rows_as_floats(data_dict.get("gpu", []))
         if len(gpu) > 0:
             ts = [datetime.fromtimestamp(t) for t in gpu[:, 0]]
             self.ax_gpu.plot(ts, gpu[:, 1], color=constants.graph.GPU_LINE_COLOR, linewidth=1)
@@ -823,7 +845,7 @@ class GraphRenderer(QObject):
             series = data_dict.get(role) or []
             if not series:
                 continue
-            arr = np.array([(float(item[0]), float(item[1])) for item in series], dtype=float)
+            arr = self._rows_as_floats(series)
             ts = arr[:, 0]
             dts = [datetime.fromtimestamp(t) for t in ts]
             ys = self._smooth_series(arr[:, 1], styles.get("smooth_window", 5)) if smooth else arr[:, 1]
@@ -941,7 +963,7 @@ class GraphRenderer(QObject):
             if not series:
                 self._apply_hw_ylim(ax, fixed, 0.0)
                 continue
-            arr = np.array([(float(item[0]), float(item[1])) for item in series], dtype=float)
+            arr = self._rows_as_floats(series)
             ts = arr[:, 0]
             dts = [datetime.fromtimestamp(t) for t in ts]
             ys = self._smooth_series(arr[:, 1], styles.get("smooth_window", 5)) if smooth else arr[:, 1]
@@ -974,7 +996,7 @@ class GraphRenderer(QObject):
         ax.clear()
         self._format_hardware_axes(stat_type)
 
-        raw = np.array(history_data, dtype=float)
+        raw = self._rows_as_floats(history_data)
         timestamps = raw[:, 0]
         dts = [datetime.fromtimestamp(t) for t in timestamps]
         values = raw[:, 1]


### PR DESCRIPTION
Found by actually opening the tab while smoke-testing the 2.1.3 build.

The Monitor's **Hardware tab has been drawing an empty 0.0-1.0 grid** instead of CPU/GPU/RAM history. Not a 2.1.3 regression - the log shows it first happening **2026-07-08**, so it shipped in **2.1.0, 2.1.1 and 2.1.2**. The Network tab graph was never affected.

### Cause

`WidgetState.get_hardware_history()` returns `datetime` timestamps - it is typed `List[Tuple[datetime, float]]` and really does return them. The speed-history path yields epoch floats instead. Both reach the same renderers, and the hardware ones did:

```python
arr = np.array([(float(item[0]), float(item[1])) for item in series], dtype=float)
```

`float(datetime)` raises `TypeError`. **`GraphHost._on_data_ready` catches every exception and logs it**, so nothing surfaced to the user - the tab simply drew an empty grid, forever, and only a log line ever said why. That is how it survived three releases.

The network branch of `render()` already coerced both shapes inline. This lifts that into a shared `_rows_as_floats()` helper and applies it at **all five** sites that consume a hardware series - `_render_hwcombined`, `_render_hwseparate`, `_render_hwsingle`, and overview's `cpu`/`gpu` - so the remaining latent copies cannot bite later.

### Verified end to end, not just by unit test

| | before | after |
|---|---|---|
| Hardware tab | empty grid, 0.0-1.0 axes | CPU + GPU + RAM plotted with a legend over a full week |
| log | `GraphHost render error` every ~2s | **0** render errors |

Six new tests in `test_hardware_graph_timestamps.py` cover datetime rows, epoch rows, both agreeing, 3-column overview rows, and empty input - plus one that pins *why* the helper exists by asserting the raw `np.array(..., dtype=float)` conversion still fails on datetimes, so a future refactor cannot quietly reintroduce it.

1141 tests pass.

**Timing is your call** - this is a real fix but a pre-existing bug, not a 2.1.3 regression, so it is equally defensible to hold it for 2.1.4 rather than re-test the release build.