### PR TITLE
chore: open the 2.1.4 cycle

### DIFF
--- a/src/netspeedtray/__init__.py
+++ b/src/netspeedtray/__init__.py
@@ -4,4 +4,4 @@ NetSpeedTray package initialization.
 A system tray application for monitoring network speed on Windows.
 """
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"


### PR DESCRIPTION
Bumps `__version__` to **2.1.4**, immediately after 2.1.3 shipped.

### Why now, when nothing is scoped

Leaving the version at the released value makes a build from `main` **indistinguishable from the signed release** - `--version`, the Settings title bar and support bundles all report the same string.

That is not hypothetical. During the 2.1.3 smoke test I found a NetSpeedTray running since Aug 20 and briefly took it for the release; it was a dev build, and both said `2.1.3`. `release-process.md` step 2 bumps at **cycle start** for exactly this reason.

### This is a holding pen, not a commitment

Every 2.1.4 candidate is blocked on someone else:

| # | Blocked on |
|---|---|
| #238 | the reporter answering "does it happen on hover?" - that picks between a ~3-line fix and a Win10 VM |
| #234B | @VenusGirl's clean-profile test |
| #218 | still unreproduced; reporter asked not to close |
| #202 | translators - Hebrew, German and Spanish named on release day |
| #249 | @lezgintekay confirming or replacing my `DEFAULT_TEXT` choice |

**If nothing unblocks, 2.1.4 never ships** and its content rolls into whatever comes next. That is a fine outcome, and the plan says so out loud.

2.2 stays [spike-gated](https://github.com/erez-c137/NetSpeedTray/issues) on ETW + MSIX; neither spike has been run. Per the roadmap's own principle, the 2-3 weeks after a launch are triage, not feature work.

### Not in this PR

- **No changelog entry.** Those are written at release time and dated at tag time, and this project deliberately keeps **no `[Unreleased]` section** (it caused four-way merge conflicts in the 1.3.2 cycle - see `changelog-guidelines.md`).
- Planning docs (`Docs/releases/v2.1.4/action-plan.md`, ROADMAP row, the 2.1.3 retro) are written but `Docs/` is gitignored, so they stay local by design.

One-line change. 1141 tests pass.