### PR TITLE
docs: use American English consistently in user-facing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ The widget lives on your taskbar - at its simplest, just your up &amp; down spee
   <br/>
   <div align="center">
     <img src="screenshots/settings_appearance_2.0.png" alt="NetSpeedTray Settings - Appearance page" width="780" />
-    <p><sub><b>Appearance</b> - fonts, colours, and arrow-style presets, with a live widget preview at the bottom that updates as you change things.</sub></p>
+    <p><sub><b>Appearance</b> - fonts, colors, and arrow-style presets, with a live widget preview at the bottom that updates as you change things.</sub></p>
     <br/>
     <img src="screenshots/settings_general_2.0.png" alt="NetSpeedTray Settings - General page" width="780" />
-    <p><sub><b>General</b> - language, update rate, behaviour, preferred monitor, and configurable double-/middle-click actions. Six pages in all: General · Widget · Appearance · Hardware · Network · Advanced.</sub></p>
+    <p><sub><b>General</b> - language, update rate, behavior, preferred monitor, and configurable double-/middle-click actions. Six pages in all: General · Widget · Appearance · Hardware · Network · Advanced.</sub></p>
   </div>
 </details>
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@ Downloads and signed installers: [Releases](https://github.com/erez-c137/NetSpee
 
 WHO READS THIS FILE
   Users deciding whether to upgrade, people checking if their bug got fixed,
-  and developers looking for when a behaviour changed. Write for the first two;
+  and developers looking for when a behavior changed. Write for the first two;
   the link at the end of each line serves the third.
 
 THE RULE
@@ -52,7 +52,7 @@ WHEN THE MECHANISM MATTERS
 
 SECTIONS - use only these, in this order, and omit any that are empty:
     ### Added        new features
-    ### Changed      behaviour that changed for existing users
+    ### Changed      behavior that changed for existing users
     ### Fixed        bugs
     ### Removed      features taken away
     ### Security     anything with a security impact
@@ -63,7 +63,7 @@ SECTIONS - use only these, in this order, and omit any that are empty:
 
 ALSO
   - Start each release with ONE sentence saying what it is.
-  - Anything that changes behaviour on upgrade goes in a "> **Upgrading:**"
+  - Anything that changes behavior on upgrade goes in a "> **Upgrading:**"
     callout right under that sentence, before the sections.
   - Credit inline and compactly: ([#234], thanks [@user]).
   - Link issues as ([#234]) using the reference-style links kept at the bottom
@@ -83,7 +83,7 @@ Fixes from a month of bug reports, including one that has been in every release 
 
 ### Added
 
-- **Upload and download arrows can have their own colours.** Turn on *Custom arrow colors* in **Settings → Appearance**. Off by default, so nothing moves unless you ask. ([#168], thanks [@VenusGirl])
+- **Upload and download arrows can have their own colors.** Turn on *Custom arrow colors* in **Settings → Appearance**. Off by default, so nothing moves unless you ask. ([#168], thanks [@VenusGirl])
 - **The Settings and Monitor windows can stay on top.** New toggle in **Settings → Advanced**, so the Monitor can sit over a full-screen app. ([#213], thanks [@CMTriX])
 
 ### Changed
@@ -95,7 +95,7 @@ Fixes from a month of bug reports, including one that has been in every release 
 - **The app now starts in your Windows display language.** Auto-detect never worked, so Korean, Japanese, Russian, Polish, Dutch, Slovenian, Hebrew and both Chinese variants always fell back to English - in every release ever shipped. If you found the app in English despite your system being set otherwise and assumed it simply wasn't translated: it was, and I'm sorry. The Language settings card now shows what was detected, so this can't fail quietly again, and choosing Auto-detect correctly prompts you to restart - it used to stay silent. ([#234], thanks [@VenusGirl])
 
   *Under the hood: `locale.getlocale()` returns the C-runtime name on Windows ("Korean_Korea"), not "ko_KR", so every lookup missed and fell through to English. German, Spanish and French worked only because CPython's `locale_alias` happens to carry their CRT names - which is why this survived a year on an English dev machine. Now reads `GetUserDefaultUILanguage()`.*
-- **The CPU temperature no longer shows your graphics card's.** On laptops whose CPU reports no temperature, NetSpeedTray picked up the GPU's sensor instead and labelled it CPU. ([#237], thanks [@Aaronxiexyl], whose sensor report made this visible)
+- **The CPU temperature no longer shows your graphics card's.** On laptops whose CPU reports no temperature, NetSpeedTray picked up the GPU's sensor instead and labeled it CPU. ([#237], thanks [@Aaronxiexyl], whose sensor report made this visible)
 
   *Under the hood: when nothing is named exactly "CPU Package" we fall back to matching sensor names, and one keyword was "CORE" - which matches NVIDIA's "GPU Core". The sensor identifier now decides before any name is considered.*
 - **GPU usage now counts apps you start after NetSpeedTray.** It only ever watched programs that were already running, so on laptops with two GPUs the discrete card was never measured at all. ([#236], thanks [@balciseri], who filed this as a feature request and turned out to have found a bug)
@@ -126,7 +126,7 @@ Fixes from a month of bug reports, including one that has been in every release 
 
 ### Developer notes
 
-- **Tests grew from 865 to 1135**, covering language auto-detect, the tray-menu accelerators, CPU sensor selection, the GPU wildcard counters and the arrow colours.
+- **Tests grew from 865 to 1135**, covering language auto-detect, the tray-menu accelerators, CPU sensor selection, the GPU wildcard counters and the arrow colors.
 - **A new locale is now checked for more than key parity.** A locale file that isn't registered in `LANGUAGE_MAP` is unreachable from the UI - Turkish arrived that way and every existing test passed, because parity only ever compares keys between files. ([#254])
 
   *Under the hood: the new checks also pin each locale's decimal separator to CLDR and cap `DEFAULT_TEXT`, which is painted on the taskbar itself - a spelled-out phrase overflows a slot sized for "N/A".*
@@ -166,7 +166,7 @@ One fix for the in-app updater.
 
 ## [2.1.1] - July 15, 2026
 
-Auto-hide taskbar behaviour, a flat CPU temperature, and an antivirus false positive.
+Auto-hide taskbar behavior, a flat CPU temperature, and an antivirus false positive.
 
 ### Fixed
 
@@ -270,11 +270,11 @@ Polish on top of 2.0.0: localization fixes for the history graph, a rounding fix
   *Under the hood: the formatter rounded before checking whether the value had crossed into the next unit. It now promotes after rounding.*
 - **Preferred Monitor works on multi-monitor setups.** Choosing a secondary display did nothing at all before. ([#72], thanks [@Mythos])
 
-  *Under the hood: two separate faults. Taskbar discovery required a system-tray area, which on Windows 11 only the primary taskbar has - so every secondary taskbar was silently discarded. And even once placed, the once-a-second refresh re-resolved the primary taskbar and pulled the widget back within a frame. Every repositioning path now honours the setting.*
+  *Under the hood: two separate faults. Taskbar discovery required a system-tray area, which on Windows 11 only the primary taskbar has - so every secondary taskbar was silently discarded. And even once placed, the once-a-second refresh re-resolved the primary taskbar and pulled the widget back within a frame. Every repositioning path now honors the setting.*
 - **Both arrows on the plan-speed and data-cap spinboxes now work.** The text field overlapped the up button and swallowed its clicks. ([#169])
 - **The Monitor's settings gear only appears on the Hardware tab**, where it actually does something. ([#170])
 - **The side-by-side hardware readout stays aligned and stops sliding.** The block shifted sideways whenever a percentage ticked over (9→10, 99→100), RAM and VRAM didn't line up between rows, and memory could clip to a single digit after a language change. Each field now sits in its own fixed-width column. ([#179])
-- **"Show RAM" and "Show VRAM" grey out when their monitor is off.** RAM rides on the CPU readout and VRAM on the GPU readout, so enabling either alone showed nothing.
+- **"Show RAM" and "Show VRAM" gray out when their monitor is off.** RAM rides on the CPU readout and VRAM on the GPU readout, so enabling either alone showed nothing.
 - **Honest guidance when temperature and power aren't available.** NetSpeedTray used to tell you to run LibreHardwareMonitor as Administrator, sending you after a permissions problem that doesn't exist. ([#134], thanks [@Mythos])
 
   *Under the hood: LHM removed its WMI provider in v0.9.5, so `root\LibreHardwareMonitor` no longer exists in current builds - no amount of elevation brings it back. The download link now points at v0.9.4, the last WMI-capable release.*
@@ -317,7 +317,7 @@ Polish on top of 2.0.0: localization fixes for the history graph, a rounding fix
   *Under the hood: the cap reads a dedicated monotonic counter, not the sampled history, which would under-count. Alerts are debounced and restart-safe.*
 - **Network latency and a plain-word verdict** - *Internet: Good / OK / Slow* - with milliseconds as subtext. Defaults to your gateway, so it stays on your LAN; a public host is strictly opt-in.
 - **Native Windows 11 chrome** - dark title bars that follow your theme, rounded corners, a Fluent tab strip, styled settings controls, and a rebuilt right-click menu and Support dialog. Silently does nothing on Windows 10.
-- **Live settings preview.** Settings shows an inert render of the widget on a taskbar-like strip that updates as you change font, colour, arrows, layout or mode - drawn through the same paint path as the real widget, so it matches exactly.
+- **Live settings preview.** Settings shows an inert render of the widget on a taskbar-like strip that updates as you change font, color, arrows, layout or mode - drawn through the same paint path as the real widget, so it matches exactly.
 - **Six arrow styles** plus a custom option: Classic, Solid, Compact, Outline, Outline Compact, Double.
 - **Scroll to switch metrics in Cycle mode**, instead of waiting for the rotation.
 - **Pause / Resume in the right-click menu**, and a hover card showing data used today and this month.
@@ -336,7 +336,7 @@ Polish on top of 2.0.0: localization fixes for the history graph, a rounding fix
 
   *Under the hood: two causes. A "re-assert position when the taskbar takes focus" step had been lost in an earlier refactor, and a redundant Z-order re-promotion briefly dropped the translucent widget out of the top layer - unnecessary once docked.*
 - **Fullscreen hide and show is near-instant both ways**, including apps that go fullscreen without taking focus, like double-clicking a video. It used to lag up to a second.
-- **Colour coding now follows the real speed, not the number on screen.** Thresholds are defined in Mbps but were compared against whatever was displayed, so in Kbps or MB/s mode the bands triggered at the wrong speeds - a 0.5 Mbps stream shown as "500 Kbps" counted as fast. Banding is now computed from the canonical speed.
+- **Color coding now follows the real speed, not the number on screen.** Thresholds are defined in Mbps but were compared against whatever was displayed, so in Kbps or MB/s mode the bands triggered at the wrong speeds - a 0.5 Mbps stream shown as "500 Kbps" counted as fast. Banding is now computed from the canonical speed.
 - **Log files are written reliably again.** They could previously fail silently, so Support Bundles arrived with no logs at all.
 
   *Under the hood: `config.py` imported `logging` but not `logging.handlers`, which Python does not import automatically. Depending on import order this raised `AttributeError`, fell back to console-only logging, and produced no file.*
@@ -352,7 +352,7 @@ Polish on top of 2.0.0: localization fixes for the history graph, a rounding fix
 - **The graph window no longer crashes while building a tab title.** It referenced a translation key that exists in no language file.
 
   *Under the hood: a new test now scans the code for references to nonexistent translation keys, so this class cannot come back silently.*
-- **The colour threshold boxes now follow your chosen unit.** They always read "Mbps", even when the widget was set to byte or binary units. Contributed by [@rami123] ([#165]).
+- **The color threshold boxes now follow your chosen unit.** They always read "Mbps", even when the widget was set to byte or binary units. Contributed by [@rami123] ([#165]).
 - **Dragging the widget right of the tray no longer snaps it back.** The saved offset went negative and was clamped to zero, so the next reposition pulled it left again. Contributed by [@rami123] ([#165]).
 
 ### Performance
@@ -370,7 +370,7 @@ Polish on top of 2.0.0: localization fixes for the history graph, a rounding fix
 ### Developer notes
 
 - **First CI pipeline.** The full suite now runs on every push and PR to `main`; previously tests ran only on release tags, so a regression could land unnoticed.
-- **Tests grew from 196 to 722.** Notable new coverage: the data-cap odometer and restart-safe alerts, the shared paint path and preview render-parity, the honest connection model, the recoverable circuit breaker, and the first headless GUI tests including render-pixel verification of the colour bands.
+- **Tests grew from 196 to 722.** Notable new coverage: the data-cap odometer and restart-safe alerts, the shared paint path and preview render-parity, the honest connection model, the recoverable circuit breaker, and the first headless GUI tests including render-pixel verification of the color bands.
 - **Shared widget paint path.** The widget's drawing was lifted into one pure render function driven by a metrics snapshot, so the live widget and every preview render through identical code.
 - **The Monitor reuses the existing matplotlib engine byte-for-byte** behind one lazily-loaded canvas, under an import firewall - the matplotlib-free Overview never triggers the heavy import, keeping the idle-RAM win.
 - **History is no longer silently lost on the "Keep everything" setting.** A crash in retention maintenance had been stopping all history writes - Windows raises `OSError 22` on pre-1970 `datetime.timestamp()`. Fixed with safe cutoff arithmetic.

--- a/src/netspeedtray/constants/config.py
+++ b/src/netspeedtray/constants/config.py
@@ -50,8 +50,8 @@ class ConfigConstants:
     DEFAULT_ARROW_FONT_SIZE: Final[int] = 10
     DEFAULT_ARROW_FONT_WEIGHT: Final[int] = fonts.WEIGHT_DEMIBOLD
     # Arrows share the speed text's pen by design - one setPen paints the arrow, the number and the
-    # unit, so with colour-coding on the whole line bands together. Opting in splits that into two
-    # colour languages (direction vs magnitude), which is a real design change, so it is off by
+    # unit, so with color-coding on the whole line bands together. Opting in splits that into two
+    # color languages (direction vs magnitude), which is a real design change, so it is off by
     # default and existing widgets render byte-identically after an upgrade (#168).
     DEFAULT_USE_CUSTOM_ARROW_COLORS: Final[bool] = False
     DEFAULT_ARROW_UP_COLOR: Final[str] = color.GREEN
@@ -113,7 +113,7 @@ class ConfigConstants:
         CLICK_ACTION_PAUSE,
         CLICK_ACTION_NONE,
     ]
-    # Defaults preserve existing behaviour: double-click already opened the Monitor; middle-click
+    # Defaults preserve existing behavior: double-click already opened the Monitor; middle-click
     # did nothing, so it stays "Nothing" until a user opts in.
     DEFAULT_DOUBLE_CLICK_ACTION: Final[str] = CLICK_ACTION_OPEN_MONITOR
     DEFAULT_MIDDLE_CLICK_ACTION: Final[str] = CLICK_ACTION_NONE
@@ -224,7 +224,7 @@ class ConfigConstants:
         "monitor_vram_enabled": DEFAULT_MONITOR_VRAM_ENABLED,
         "show_hardware_temps": DEFAULT_SHOW_HARDWARE_TEMPS,
         "show_hardware_power": DEFAULT_SHOW_HARDWARE_POWER,
-        # Record cheap CPU/GPU/RAM utilisation to the DB always (not just while the widget displays it),
+        # Record cheap CPU/GPU/RAM utilization to the DB always (not just while the widget displays it),
         # so the Monitor's history graphs have real data to show for past periods. Cheap (psutil +
         # one PDH read); temps/power are NOT recorded here (those stay gated/forced-only).
         "record_hardware_history": True,

--- a/src/netspeedtray/constants/styles.py
+++ b/src/netspeedtray/constants/styles.py
@@ -19,7 +19,7 @@ class UIStyleConstants:
     # --- Light Mode ---
     LIGHT_MODE_TEXT_COLOR: Final[str] = color.BLACK
     DIALOG_SIDEBAR_BG_LIGHT: Final[str] = "#f3f3f3"
-    # Light-mode counterpart: a soft grey base so the near-white #FBFBFB cards float (was #ffffff, which
+    # Light-mode counterpart: a soft gray base so the near-white #FBFBFB cards float (was #ffffff, which
     # made the cards read as slightly darker insets on white instead of floating panels).
     DIALOG_CONTENT_BG_LIGHT: Final[str] = "#f3f3f3"
     DIALOG_SECTION_BG_LIGHT: Final[str] = "#F0F0F0"

--- a/src/netspeedtray/core/database.py
+++ b/src/netspeedtray/core/database.py
@@ -803,7 +803,7 @@ class DatabaseWorker(QThread):
                 
                 return pruned_count > 0
             else:
-                self.logger.warning("Scheduled prune was due, but no pending retention period was found. Cancelling.")
+                self.logger.warning("Scheduled prune was due, but no pending retention period was found. Canceling.")
                 cursor.execute("DELETE FROM metadata WHERE key = 'prune_scheduled_at'")
                 return False
         elif new_retention_config < current_retention_db:
@@ -816,7 +816,7 @@ class DatabaseWorker(QThread):
         elif new_retention_config > current_retention_db:
             if prune_scheduled_at_ts is not None:
                 cursor.execute("DELETE FROM metadata WHERE key IN ('prune_scheduled_at', 'pending_retention_days')")
-                self.logger.info("Retention period increased. Pending data prune has been cancelled.")
+                self.logger.info("Retention period increased. Pending data prune has been canceled.")
             cursor.execute("INSERT OR REPLACE INTO metadata (key, value) VALUES ('current_retention_days', ?)", (str(new_retention_config),))
         
         cutoff = self._retention_cutoff(now, current_retention_db)

--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -881,7 +881,7 @@ class StatsMonitorThread(QThread):
         if _in_rdp:
             self.logger.info("RDP session detected - GPU monitoring will be skipped.")
 
-        # Initialise the COM apartment ONCE for this thread (H4). Was done per-poll inside
+        # Initialize the COM apartment ONCE for this thread (H4). Was done per-poll inside
         # the WMI helpers, leaking a COM ref every poll while no LHM source was connected.
         self._init_com()
 
@@ -921,7 +921,7 @@ class StatsMonitorThread(QThread):
 
                 # Monitor-window override forces hardware collection even with the widget's flags off.
                 _force_hw = self._force_hardware_collection
-                # Always-on history recording: collect cheap CPU/GPU/RAM utilisation so the Monitor's
+                # Always-on history recording: collect cheap CPU/GPU/RAM utilization so the Monitor's
                 # graphs have real past data. Temps/power stay on their own (heavier) gates below.
                 _record = self.config.get('record_hardware_history', True)
 
@@ -1036,7 +1036,7 @@ class StatsMonitorThread(QThread):
         self._wmi_ohm = None
 
     def _init_com(self) -> None:
-        """Initialise the COM apartment ONCE for this thread (WMI/LHM access)."""
+        """Initialize the COM apartment ONCE for this thread (WMI/LHM access)."""
         try:
             import pythoncom
             pythoncom.CoInitialize()
@@ -1044,7 +1044,7 @@ class StatsMonitorThread(QThread):
             pass
 
     def _cleanup_com(self) -> None:
-        """Releases COM apartment initialised for WMI access."""
+        """Releases COM apartment initialized for WMI access."""
         try:
             import pythoncom
             pythoncom.CoUninitialize()

--- a/src/netspeedtray/core/tray_manager.py
+++ b/src/netspeedtray/core/tray_manager.py
@@ -43,7 +43,7 @@ class TrayIconManager(QObject):
         # Retrieve actions for external use if needed (e.g., toggling text)
         self.pause_action: Optional[QAction] = None
         self.pause_separator: Optional[QAction] = None
-        # [(QAction, Segoe-Fluent-codepoint)] - icons are (re)tinted to the text colour on each open.
+        # [(QAction, Segoe-Fluent-codepoint)] - icons are (re)tinted to the text color on each open.
         self._menu_icon_actions: list = []
 
     def initialize(self) -> None:
@@ -131,7 +131,7 @@ class TrayIconManager(QObject):
                 exit_action.setEnabled(False)
 
             # Native Win11 menu iconography: a Segoe Fluent glyph beside each item (tinted to the text
-            # colour per theme in _apply_menu_style, which runs on every open). The pause glyph swaps
+            # color per theme in _apply_menu_style, which runs on every open). The pause glyph swaps
             # pause<->play with the action's state in _refresh_dynamic_items.
             self._menu_icon_actions = [
                 (settings_action, 0xE713),    # Settings (gear)
@@ -173,7 +173,7 @@ class TrayIconManager(QObject):
                 f" QMenu::item:selected {{ background: {c['subtle_fill']}; color: {c['text_primary']}; }}"
                 f" QMenu::item:disabled {{ color: {c['text_secondary']}; }}"
                 f" QMenu::separator {{ height: 1px; background: {c['card_stroke']}; margin: 4px 10px; }}")
-            # Tint the Fluent glyphs to the current text colour so they track the OS light/dark theme.
+            # Tint the Fluent glyphs to the current text color so they track the OS light/dark theme.
             for action, cp in self._menu_icon_actions:
                 action.setIcon(su.fluent_icon(cp, 16, c['text_primary']))
         except Exception as e:

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -62,7 +62,7 @@ def download_to(url: str, dest: str,
         read = 0
         while True:
             if is_cancelled is not None and is_cancelled():
-                raise RuntimeError("cancelled")
+                raise RuntimeError("canceled")
             chunk = resp.read(_CHUNK)
             if not chunk:
                 break
@@ -229,7 +229,7 @@ class _DownloadWorker(QObject):
             self.failed.emit(str(e))
             return
         if self._cancelled:
-            self.failed.emit("cancelled")
+            self.failed.emit("canceled")
             return
         try:
             if self._portable:
@@ -430,7 +430,7 @@ class SecureUpdater(QObject):
         self._teardown_thread()
         self._close_progress()
         self._cleanup_file()
-        if reason == "cancelled":
+        if reason == "canceled":
             self._finish()
             return
         self._fallback(reason)

--- a/src/netspeedtray/core/widget_state.py
+++ b/src/netspeedtray/core/widget_state.py
@@ -189,12 +189,12 @@ class WidgetState(QObject):
                     self._db_batch.append((timestamp, interface, min(up_speed, max_speed), min(down_speed, max_speed)))
 
 
-    # Utilisation stats are 0-100% and clamped; physical stats (power W, temperature °C, latency ms)
+    # Utilization stats are 0-100% and clamped; physical stats (power W, temperature °C, latency ms)
     # are NOT percentages and must be stored unclamped - a 200 ms ping or 180 W draw must not become 100.
     _PCT_STATS = frozenset({'cpu', 'gpu', 'ram', 'vram'})
 
     def add_hardware_stat(self, stat_type: str, value: float, now: Optional[datetime] = None) -> None:
-        """Record a hardware sample (utilisation %, power W, temperature °C, or latency ms) to the
+        """Record a hardware sample (utilization %, power W, temperature °C, or latency ms) to the
         in-memory deque (for graphed util stats) + the DB batch (for all, via the 3-tier rollups)."""
         _now = now or datetime.now()
         snapshot = HardwareStatSnapshot(value=value, timestamp=_now)
@@ -448,7 +448,7 @@ class WidgetState(QObject):
             return []
 
     # --- pro-stats: tier-aware honest window summaries (exact ≤24h raw, avg+max beyond) ----------
-    _RAW_SUMMARY_SECONDS = 24 * 3600   # the raw tier retains ~24h; windows within it summarise exactly
+    _RAW_SUMMARY_SECONDS = 24 * 3600   # the raw tier retains ~24h; windows within it summarize exactly
 
     def summarize_hardware(self, stat_type: str, start_time: datetime, end_time: datetime,
                            poll_interval: float = 1.0):

--- a/src/netspeedtray/tests/unit/test_american_english.py
+++ b/src/netspeedtray/tests/unit/test_american_english.py
@@ -1,0 +1,97 @@
+"""
+User-facing English is American English.
+
+The app's own UI strings were already consistent - `en_US.json` never drifted - but the prose around
+them had: `changelog.md` said "their own colours" in the same sentence as the real UI label "Custom
+arrow colors", and the published 2.1.3 release notes shipped the British spelling. Documentation
+that contradicts the product is worse than either choice made consistently.
+
+This guards the **English text a user actually reads**: the UI strings, the README, the changelog and
+the contributor-facing markdown. It deliberately does NOT police Python comments (not user-facing, and
+the noise would drown the signal) or other locales - `Centre` is correct French and `grau` is not our
+business.
+
+Note `analysis` is NOT in the list: only the verb differs (analyse/analyze), and the noun is spelled
+the same on both sides of the Atlantic. Same for `practice` as a noun.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parents[4]
+_LOCALES = Path(__file__).parents[3] / "netspeedtray" / "constants" / "locales"
+
+# British -> American. Only unambiguous cases; anything a US style guide also accepts is left out.
+_BRITISH = {
+    "colour": "color", "colours": "colors", "coloured": "colored", "colourful": "colorful",
+    "behaviour": "behavior", "behaviours": "behaviors",
+    "centre": "center", "centres": "centers", "centred": "centered",
+    "grey": "gray", "greyed": "grayed",
+    "licence": "license", "defence": "defense", "offence": "offense",
+    "catalogue": "catalog", "programme": "program", "artefact": "artifact",
+    "judgement": "judgment", "ageing": "aging", "fulfil": "fulfill",
+    "neighbour": "neighbor", "honour": "honor", "honours": "honors", "honoured": "honored",
+    "favour": "favor", "favours": "favors", "favoured": "favored", "favourite": "favorite",
+    "labelled": "labeled", "labelling": "labeling", "unlabelled": "unlabeled",
+    "relabelled": "relabeled", "modelled": "modeled", "modelling": "modeling",
+    "travelling": "traveling", "marvellous": "marvelous",
+    "analyse": "analyze", "analysed": "analyzed", "analysing": "analyzing",
+    "localise": "localize", "localised": "localized", "localisation": "localization",
+    "normalise": "normalize", "normalised": "normalized", "normalisation": "normalization",
+    "recognise": "recognize", "recognised": "recognized",
+    "organise": "organize", "organised": "organized", "organisation": "organization",
+    "initialise": "initialize", "initialised": "initialized",
+    "customise": "customize", "customised": "customized", "customisable": "customizable",
+    "optimise": "optimize", "optimised": "optimized", "optimisation": "optimization",
+    "summarise": "summarize", "summarised": "summarized",
+    "utilise": "utilize", "utilised": "utilized", "utilisation": "utilization",
+    "prioritise": "prioritize", "visualise": "visualize",
+    "synchronise": "synchronize", "synchronised": "synchronized",
+    "minimise": "minimize", "minimised": "minimized",
+    "maximise": "maximize", "maximised": "maximized",
+    "apologise": "apologize", "serialise": "serialize",
+    "whilst": "while", "amongst": "among",
+}
+
+_RX = re.compile(r"\b(" + "|".join(sorted(_BRITISH, key=len, reverse=True)) + r")\b", re.IGNORECASE)
+
+
+def _offenders(text):
+    """(british, american, line_no) for each hit."""
+    out = []
+    for i, line in enumerate(text.splitlines(), 1):
+        for m in _RX.finditer(line):
+            w = m.group(0)
+            out.append((w, _BRITISH[w.lower()], i))
+    return out
+
+
+def test_ui_strings_are_american():
+    """en_US.json is what users read inside the app - the highest-stakes file here."""
+    data = json.loads((_LOCALES / "en_US.json").read_text(encoding="utf-8"))
+    problems = []
+    for key, value in data.items():
+        if not isinstance(value, str):
+            continue
+        for brit, amer, _ in _offenders(value):
+            problems.append(f"{key}: {value!r} uses {brit!r}, should be {amer!r}")
+    assert not problems, "British spelling in en_US.json:\n  " + "\n  ".join(problems)
+
+
+@pytest.mark.parametrize("name", ["changelog.md", "README.md", "TRANSLATORS.md", "privacy.md"])
+def test_public_markdown_is_american(name):
+    path = _ROOT / name
+    if not path.exists():
+        pytest.skip(f"{name} not present")
+    problems = [f"line {n}: {b!r} -> {a!r}" for b, a, n in _offenders(path.read_text(encoding="utf-8"))]
+    assert not problems, f"British spelling in {name}:\n  " + "\n  ".join(problems)
+
+
+def test_the_word_list_itself_is_sane():
+    """Every mapping must actually change the word, and never map to another British spelling."""
+    for brit, amer in _BRITISH.items():
+        assert brit != amer, f"{brit!r} maps to itself"
+        assert amer not in _BRITISH, f"{brit!r} -> {amer!r}, which is itself flagged as British"

--- a/src/netspeedtray/tests/unit/test_arrow_colors.py
+++ b/src/netspeedtray/tests/unit/test_arrow_colors.py
@@ -1,13 +1,13 @@
 """
-Per-direction arrow colours (#168).
+Per-direction arrow colors (#168).
 
-The arrows share the speed text's pen by design: `_draw_speed_line` sets ONE pen - the colour-coding
-band, or the default - and that same pen paints the arrow, the number and the unit. So with colour
+The arrows share the speed text's pen by design: `_draw_speed_line` sets ONE pen - the color-coding
+band, or the default - and that same pen paints the arrow, the number and the unit. So with color
 coding on, the whole line lights up together as a single signal. That is a defensible design, not an
-oversight, which is why this ships opt-in and defaults to the old behaviour.
+oversight, which is why this ships opt-in and defaults to the old behavior.
 
 The trap these tests exist for: overriding the pen to draw the arrow and forgetting to restore it
-leaves the NUMBER wearing the arrow's colour, which reads as a colour-coding regression (cf. #153).
+leaves the NUMBER wearing the arrow's color, which reads as a color-coding regression (cf. #153).
 """
 
 import pytest
@@ -31,7 +31,7 @@ def _cfg(**over):
 
 
 def _render(cfg, up_mbps=5.0, down_mbps=5.0) -> set:
-    """Render one frame and return the set of distinct opaque RGB colours drawn."""
+    """Render one frame and return the set of distinct opaque RGB colors drawn."""
     img = QImage(W, H, QImage.Format.Format_ARGB32)
     img.fill(QColor(0, 0, 0, 0))
     renderer = WidgetRenderer(cfg, I18nStrings("en_US"))
@@ -58,7 +58,7 @@ class TestDefaultIsUnchanged:
         assert constants.config.defaults.DEFAULT_CONFIG["use_custom_arrow_colors"] is False
 
     def test_disabled_renders_identically_to_before(self, q_app):
-        """Nobody's widget may shift on upgrade. With the toggle off, the arrow colour keys must
+        """Nobody's widget may shift on upgrade. With the toggle off, the arrow color keys must
         make no difference at all - even when they hold wild values."""
         base = _render(_cfg())
         with_unused_colors = _render(_cfg(arrow_up_color="#FF00FF", arrow_down_color="#00FFFF"))
@@ -70,27 +70,27 @@ class TestEnabledColorsTheArrowsOnly:
     def test_both_arrow_colors_are_painted(self, q_app):
         colors = _render(_cfg(use_custom_arrow_colors=True,
                               arrow_up_color="#FF0000", arrow_down_color="#0000FF"))
-        assert _rgb("#FF0000") in colors, "upload arrow colour was not painted"
-        assert _rgb("#0000FF") in colors, "download arrow colour was not painted"
+        assert _rgb("#FF0000") in colors, "upload arrow color was not painted"
+        assert _rgb("#0000FF") in colors, "download arrow color was not painted"
 
     def test_the_number_keeps_the_default_pen(self, q_app):
-        """THE trap. If the arrow's pen is not restored, the number inherits it and the arrow colour
-        silently becomes the whole line's colour."""
+        """THE trap. If the arrow's pen is not restored, the number inherits it and the arrow color
+        silently becomes the whole line's color."""
         default_color = constants.config.defaults.DEFAULT_CONFIG["default_color"]
         colors = _render(_cfg(use_custom_arrow_colors=True, color_coding=False,
                               arrow_up_color="#FF0000", arrow_down_color="#0000FF"))
         assert _rgb(default_color) in colors, \
-            "the speed text lost its own colour - the arrow pen was not restored"
+            "the speed text lost its own color - the arrow pen was not restored"
 
     def test_the_number_keeps_its_color_coding_band(self, q_app):
-        """Same trap, with colour coding on: the number must still band by speed while the arrows
-        hold their fixed colours."""
+        """Same trap, with color coding on: the number must still band by speed while the arrows
+        hold their fixed colors."""
         cfg = _cfg(use_custom_arrow_colors=True, color_coding=True,
                    arrow_up_color="#FF0000", arrow_down_color="#0000FF",
                    high_speed_threshold=1.0, low_speed_threshold=0.1,
                    high_speed_color="#00FF00")
         colors = _render(cfg, up_mbps=500.0, down_mbps=500.0)
-        assert _rgb("#00FF00") in colors, "the number lost its high-speed band colour"
+        assert _rgb("#00FF00") in colors, "the number lost its high-speed band color"
         assert _rgb("#FF0000") in colors and _rgb("#0000FF") in colors
 
     def test_hidden_arrows_are_unaffected(self, q_app):

--- a/src/netspeedtray/tests/unit/test_database_worker_queue.py
+++ b/src/netspeedtray/tests/unit/test_database_worker_queue.py
@@ -23,7 +23,7 @@ def test_running_worker_drains_queue_and_fires_barrier(tmp_path, qtbot=None):
     worker = DatabaseWorker(tmp_path / "hist.db")
     worker.start()
     try:
-        # Give the worker a moment to initialise its connection/schema.
+        # Give the worker a moment to initialize its connection/schema.
         ready = threading.Event()
         # The barrier proves the worker reached and processed an enqueued task in order.
         barrier = threading.Event()
@@ -85,7 +85,7 @@ def test_maintenance_survives_keep_forever_and_keeps_writing(tmp_path):
     try:
         done = threading.Event()
         worker.enqueue_task("__signal__", done)
-        assert done.wait(5.0), "worker failed to initialise"
+        assert done.wait(5.0), "worker failed to initialize"
         worker.enqueue_task("maintenance", {"keep_data": 36500})    # would crash the thread pre-fix
         worker.enqueue_task("persist_hardware", [(int(time.time()), "ram", 47.5)])
         flushed = threading.Event()

--- a/src/netspeedtray/tests/unit/test_hardware_list.py
+++ b/src/netspeedtray/tests/unit/test_hardware_list.py
@@ -1,6 +1,6 @@
 """
 HardwareActivityWorker + HardwareBarList - the Monitor Hardware tab. Verifies per-process CPU is
-normalised to total-CPU and the idle process is excluded, GPU% is summed per PID from PDH instance
+normalized to total-CPU and the idle process is excluded, GPU% is summed per PID from PDH instance
 names, and the bar list builds/updates/sorts + handles empty/RDP states.
 """
 import types

--- a/src/netspeedtray/tests/unit/test_hardware_vendors.py
+++ b/src/netspeedtray/tests/unit/test_hardware_vendors.py
@@ -52,7 +52,7 @@ def test_gpu_color_is_theme_aware_cpu_is_not():
 
 def test_hybrid_gpu_returns_neutral(monkeypatch):
     """A discrete GPU + an Intel iGPU (hybrid laptop) must NOT assert the discrete brand - the graphed
-    util is max-across-adapters, so colour/legend stay neutral."""
+    util is max-across-adapters, so color/legend stay neutral."""
     try:
         hv.gpu_vendor.cache_clear()
         monkeypatch.setattr(hv, "_enumerate_gpu_adapters", lambda: ["intel", "nvidia"])

--- a/src/netspeedtray/tests/unit/test_i18n_autodetect.py
+++ b/src/netspeedtray/tests/unit/test_i18n_autodetect.py
@@ -158,7 +158,7 @@ class TestDisplayLanguageVersusRegionalFormat:
         ("de_DE", "de_DE"), ("es_ES", "es_ES"), ("fr_FR", "fr_FR"),
     ])
     def test_english_display_falls_back_to_a_supported_regional_format(self, format_locale, expected):
-        """The behaviour this fix must NOT take away: English-language Windows with a German,
+        """The behavior this fix must NOT take away: English-language Windows with a German,
         Spanish or French regional format is common across Europe, and those users got a localized
         app in 2.1.2. CPython's locale_alias resolves exactly these three CRT names."""
         with patch("ctypes.windll", self._windll(1033), create=True), \

--- a/src/netspeedtray/tests/unit/test_menu_accelerators.py
+++ b/src/netspeedtray/tests/unit/test_menu_accelerators.py
@@ -33,7 +33,7 @@ _TRAY_MENU_KEYS = [
     "EXIT_MENU_ITEM",
 ]
 
-# Pause and Resume are the same QAction, relabelled - they can never be on screen together
+# Pause and Resume are the same QAction, relabeled - they can never be on screen together
 # (tray_manager.update_pause_action), so they are allowed to share a letter.
 _MUTUALLY_EXCLUSIVE = [{"PAUSE_MENU_ITEM", "RESUME_MENU_ITEM"}]
 

--- a/src/netspeedtray/tests/unit/test_monitor_a11y.py
+++ b/src/netspeedtray/tests/unit/test_monitor_a11y.py
@@ -116,7 +116,7 @@ def test_timeline_selector_is_focusable_and_named(q_app):
 
 
 def test_subtle_dark_text_meets_wcag_aa_on_the_card(q_app):
-    """The app-wide caption colour must clear WCAG AA (4.5:1) on the dark card - regression for #808080."""
+    """The app-wide caption color must clear WCAG AA (4.5:1) on the dark card - regression for #808080."""
     from netspeedtray.constants.styles import styles as S
 
     def _lin(c):

--- a/src/netspeedtray/tests/unit/test_monitor_graph_theme.py
+++ b/src/netspeedtray/tests/unit/test_monitor_graph_theme.py
@@ -24,7 +24,7 @@ def test_hw_styles_follow_os_theme_not_config(q_app, monkeypatch):
     host = GH.GraphHost(MagicMock(), cfg, I18nStrings("en_US"))
     monkeypatch.setattr(GH.su, "is_dark_mode", lambda: False)   # ...but the OS is in light mode
     styles = host._hw_styles()
-    # The RAM line colour is derived from the theme; light mode -> #388E3C, dark -> #4CAF50.
+    # The RAM line color is derived from the theme; light mode -> #388E3C, dark -> #4CAF50.
     assert styles["ram"][0] == "#388E3C", "graph theme ignored the OS (light) theme and used config"
 
     monkeypatch.setattr(GH.su, "is_dark_mode", lambda: True)

--- a/src/netspeedtray/tests/unit/test_native_event_resume.py
+++ b/src/netspeedtray/tests/unit/test_native_event_resume.py
@@ -63,7 +63,7 @@ def test_resume_message_schedules_reassert(monkeypatch):
 
 
 def test_resume_suspend_flag_also_reasserts(monkeypatch):
-    """The other resume flag (PBT_APMRESUMESUSPEND) is honoured too."""
+    """The other resume flag (PBT_APMRESUMESUSPEND) is honored too."""
     scheduled = []
     monkeypatch.setattr(
         "netspeedtray.views.widget.main.QTimer.singleShot",

--- a/src/netspeedtray/tests/unit/test_renderer_logic.py
+++ b/src/netspeedtray/tests/unit/test_renderer_logic.py
@@ -180,10 +180,10 @@ def test_apply_hw_ylim_fixed_vs_auto():
     ax.set_ylim.assert_called_with(0, 10.0)
 
 
-# --- 6.2b review fix: toggle (single-stat) mode must honour hw_styles -------------
+# --- 6.2b review fix: toggle (single-stat) mode must honor hw_styles -------------
 # Regression guard for the adversarial-review finding: the Monitor's "toggle" layout renders one
 # CPU/GPU line via render(stat_type="cpu"/"gpu", hw_styles=...). That path must route through the
-# hw-aware _render_hwsingle (configured colour + Smooth + fixed/auto axis), while the standalone
+# hw-aware _render_hwsingle (configured color + Smooth + fixed/auto axis), while the standalone
 # GraphWindow (hw_styles=None) must keep the legacy _plot_high_res path. Mock-based to avoid a real
 # canvas.draw() (which hangs under pytest-qt); the visual integration is covered by the render smoke.
 
@@ -216,7 +216,7 @@ def test_toggle_mode_dispatches_to_hwsingle_with_styles():
     r.render(data, datetime.fromtimestamp(now - 60), datetime.fromtimestamp(now),
              "TIMELINE_60_MINUTES", stat_type="cpu", hw_styles=hw, force_rebuild=True)
     r._render_hwsingle.assert_called_once()
-    assert r._render_hwsingle.call_args[0][-1] is hw     # the colour/smooth/axis styles reach the renderer
+    assert r._render_hwsingle.call_args[0][-1] is hw     # the color/smooth/axis styles reach the renderer
     r._plot_high_res.assert_not_called()                 # not the legacy path
 
 

--- a/src/netspeedtray/tests/unit/test_settings_pages.py
+++ b/src/netspeedtray/tests/unit/test_settings_pages.py
@@ -438,7 +438,7 @@ def test_arrow_colors_round_trip(q_app, mock_i18n, mock_callback):
     assert out["arrow_up_color"] == "#123456"
     assert out["arrow_down_color"] == "#654321"
 
-    # Off hides the swatches but must still round-trip the stored colours.
+    # Off hides the swatches but must still round-trip the stored colors.
     page.load_settings({"use_custom_arrow_colors": False,
                         "arrow_up_color": "#ABCDEF",
                         "arrow_down_color": "#FEDCBA"})
@@ -449,9 +449,9 @@ def test_arrow_colors_round_trip(q_app, mock_i18n, mock_callback):
 
 
 def test_arrow_color_widgets_follow_the_dialog_naming_convention(q_app, mock_i18n, mock_callback):
-    """SettingsDialog routes every non-threshold colour back through set_color_input by the
+    """SettingsDialog routes every non-threshold color back through set_color_input by the
     "{key}_color_button" / "{key}_color_input" attribute convention. Naming them anything else
-    silently breaks the colour picker with no test to catch it."""
+    silently breaks the color picker with no test to catch it."""
     page = AppearancePage(mock_i18n, mock_callback, MagicMock(), MagicMock())
     for key in ("arrow_up", "arrow_down"):
         assert hasattr(page, f"{key}_color_button")

--- a/src/netspeedtray/tests/unit/test_settings_reshuffle.py
+++ b/src/netspeedtray/tests/unit/test_settings_reshuffle.py
@@ -7,7 +7,7 @@ control can return the wrong value (corrupt mapping). This test pins both:
 
   * COVERAGE - every mutable key the dialog manages today is still present in get_settings().
   * ROUND-TRIP - loading a config with the high-risk keys (the moved ones + the segmented enums +
-    the colours) and reading it straight back returns the same values.
+    the colors) and reading it straight back returns the same values.
 
 It is deliberately structure-agnostic: it drives the public SettingsDialog API only, so it holds
 identically before and after the page reshuffle. A red here means the reshuffle dropped/corrupted a
@@ -27,10 +27,10 @@ from netspeedtray.views.settings.dialog import SettingsDialog
 MANAGED_KEYS = {
     # General
     "language", "update_rate", "start_with_windows", "check_for_updates", "preferred_monitor",
-    # Widget (layout + on-taskbar behaviour)
+    # Widget (layout + on-taskbar behavior)
     "free_move", "keep_visible_fullscreen",
     "widget_display_mode", "stack_hardware_stats", "widget_display_order",
-    # Appearance - font / colour / arrows / background
+    # Appearance - font / color / arrows / background
     "font_family", "font_size", "font_weight", "default_color",
     "background_color", "background_opacity",
     "use_separate_arrow_font", "arrow_font_family", "arrow_font_size",
@@ -39,7 +39,7 @@ MANAGED_KEYS = {
     # Appearance - units / format (was the Display page)
     "unit_type", "speed_display_mode", "decimal_places", "text_alignment",
     "swap_upload_download", "hide_arrows", "hide_unit_suffix", "short_unit_labels",
-    # Appearance - colour coding (was the Color Coding page)
+    # Appearance - color coding (was the Color Coding page)
     "color_coding", "high_speed_threshold", "low_speed_threshold",
     "high_speed_color", "low_speed_color",
     # Hardware
@@ -60,7 +60,7 @@ MANAGED_KEYS = {
 }
 
 # High-risk keys for the reshuffle: the ones that MOVE pages, the segmented enums (int/string
-# userData mappings that silently corrupt if mis-wired), and the colours. Mapped to a valid
+# userData mappings that silently corrupt if mis-wired), and the colors. Mapped to a valid
 # non-default value we can prove round-trips.
 ROUNDTRIP = {
     "free_move": True,
@@ -108,7 +108,7 @@ def test_no_managed_key_is_dropped(qtbot):
 
 
 def test_highrisk_keys_round_trip(qtbot):
-    """Load a config with the moved + segmented + colour keys at non-defaults; read them straight
+    """Load a config with the moved + segmented + color keys at non-defaults; read them straight
     back. A corrupt mapping (e.g. a segmented control losing its userData) returns the wrong value."""
     cfg = dict(constants.config.defaults.DEFAULT_CONFIG)
     cfg.update(ROUNDTRIP)
@@ -145,8 +145,8 @@ def test_unmanaged_keys_are_preserved_through_get_settings(qtbot):
 # --- integration tests for the cross-page wiring the UI/UX audit flagged as untested -----------------
 
 def test_color_picker_routes_to_the_right_embedded_section(qtbot, monkeypatch):
-    """Appearance embeds the old Colors page as colors_section. The dialog's colour picker must route
-    high/low-speed colours to that section and default/background to Appearance itself - a mis-wired
+    """Appearance embeds the old Colors page as colors_section. The dialog's color picker must route
+    high/low-speed colors to that section and default/background to Appearance itself - a mis-wired
     branch would silently paint the wrong swatch."""
     from PyQt6.QtGui import QColor
     from PyQt6.QtWidgets import QColorDialog
@@ -183,8 +183,8 @@ def test_enabling_a_hardware_monitor_switches_widget_out_of_network_only(qtbot):
 
 
 def test_color_is_automatic_flips_false_after_user_picks_default_colour(qtbot, monkeypatch):
-    """Picking an explicit default colour must clear the implicit color_is_automatic flag, so the text
-    colour stops auto-tracking the theme."""
+    """Picking an explicit default color must clear the implicit color_is_automatic flag, so the text
+    color stops auto-tracking the theme."""
     from PyQt6.QtGui import QColor
     from PyQt6.QtWidgets import QColorDialog
     cfg = dict(constants.config.defaults.DEFAULT_CONFIG)

--- a/src/netspeedtray/tests/unit/test_settings_widget.py
+++ b/src/netspeedtray/tests/unit/test_settings_widget.py
@@ -1,4 +1,4 @@
-"""Widget settings page (2.0 IA) - the controls that moved here from General (behaviour) and Hardware
+"""Widget settings page (2.0 IA) - the controls that moved here from General (behavior) and Hardware
 (layout) must round-trip, and the hardware auto-switch convenience must survive the move."""
 import pytest
 

--- a/src/netspeedtray/tests/unit/test_widget_state.py
+++ b/src/netspeedtray/tests/unit/test_widget_state.py
@@ -735,7 +735,7 @@ def test_hardware_history_raw_fallback_for_recent_long_window(managed_widget_sta
 
 
 def test_add_hardware_stat_clamps_pct_not_physical(managed_widget_state):
-    """Utilisation stats clamp 0-100; physical stats (power W / temp °C / latency ms) store unclamped
+    """Utilization stats clamp 0-100; physical stats (power W / temp °C / latency ms) store unclamped
     so a 180 W draw or 200 ms ping isn't corrupted to 100."""
     state, _ = managed_widget_state
     state._hw_batch.clear()

--- a/src/netspeedtray/utils/components.py
+++ b/src/netspeedtray/utils/components.py
@@ -73,7 +73,7 @@ class Win11ComboBox(QComboBox):
     for the native rounded drop-shadow). Under our dark theme the styled item-view didn't actually
     cover that container on screen, so the open list rendered see-through over whatever it overlapped -
     unreadable. We force both the container window and its viewport opaque each time the pop-up opens
-    (the container is created lazily on the first show and then reused). Colours still come from the
+    (the container is created lazily on the first show and then reused). Colors still come from the
     QSS (``QComboBox QAbstractItemView``); this only removes the transparency. Use everywhere a
     settings combo is needed, exactly like a plain QComboBox."""
 
@@ -235,7 +235,7 @@ class Win11Toggle(QWidget):
             return
         self.thumb_animation.stop()
         if animate and prefers_reduced_motion():
-            animate = False   # honour Windows "Animation effects" off - snap instead of slide
+            animate = False   # honor Windows "Animation effects" off - snap instead of slide
         if animate:
             self.thumb_animation.setStartValue(current_pos)
             self.thumb_animation.setEndValue(end_pos)

--- a/src/netspeedtray/utils/hardware_vendors.py
+++ b/src/netspeedtray/utils/hardware_vendors.py
@@ -4,19 +4,19 @@ Hardware vendor detection + the Monitor's vendor-aware graph palette.
 CPU vendor comes from the registry (CentralProcessor\\0\\VendorIdentifier), GPU vendor from the
 display-adapter DriverDesc - both no-admin, cached for the process. (CPU silicon never changes at
 runtime; GPU is cached too - a Thunderbolt eGPU hot-plug or a driver TDR/reinstall mid-session is
-knowingly NOT re-detected until restart, which at worst means a slightly-off line colour.)
+knowingly NOT re-detected until restart, which at worst means a slightly-off line color.)
 
 The palette solves the brand-collision problem: AMD ships red for both Ryzen and Radeon, Intel ships
-blue for both Core and Arc/iGPU - so CPU and GPU would draw the same colour on a same-vendor box (the
+blue for both Core and Arc/iGPU - so CPU and GPU would draw the same color on a same-vendor box (the
 Intel-CPU + Intel-iGPU case is very common). We separate them on TWO channels: the GPU always gets a
-distinct sibling SHADE *and* a dashed line. Hue + lightness + dash survives even red/green colour-
+distinct sibling SHADE *and* a dashed line. Hue + lightness + dash survives even red/green color-
 blindness. The GPU shades are theme-aware (the dark hues fail WCAG contrast on the light graph
-background, so light mode gets darker siblings). Smart defaults only - Monitor settings expose colour
+background, so light mode gets darker siblings). Smart defaults only - Monitor settings expose color
 pickers that override.
 
 On a HYBRID laptop (Intel iGPU + a discrete Nvidia/AMD) the graphed value is max-across-adapters
 (usually the idle-busy iGPU), so asserting the discrete brand would be a lie - we return 'unknown'
-(neutral) in that case so colour + legend never claim a GPU the data isn't about.
+(neutral) in that case so color + legend never claim a GPU the data isn't about.
 """
 from __future__ import annotations
 
@@ -74,7 +74,7 @@ def gpu_vendor() -> str:
     discrete = sorted({v for v in adapters if v in ("nvidia", "amd")})
     has_intel = "intel" in adapters
     if discrete and has_intel:
-        _logger.debug("Hybrid GPU detected (%s + intel) - using neutral colour.", discrete)
+        _logger.debug("Hybrid GPU detected (%s + intel) - using neutral color.", discrete)
         return "unknown"
     if discrete:
         if len(discrete) > 1:
@@ -136,7 +136,7 @@ def _classify_gpu(desc: str) -> str:
 def graph_line_style(role: str, override_color: Optional[str] = None,
                      is_dark: bool = True) -> Tuple[str, object]:
     """(color, linestyle) for 'cpu' or 'gpu'. ``override_color`` (Monitor settings) wins; the GPU
-    colour is theme-aware so it stays legible on the light graph background."""
+    color is theme-aware so it stays legible on the light graph background."""
     if role == "gpu":
         table = _GPU_COLORS_DARK if is_dark else _GPU_COLORS_LIGHT
         color = override_color or table.get(gpu_vendor(), table["unknown"])
@@ -146,7 +146,7 @@ def graph_line_style(role: str, override_color: Optional[str] = None,
 
 
 def default_color(role: str, is_dark: bool = True) -> str:
-    """The vendor-default hex for 'cpu' / 'gpu' (for pre-filling the settings colour pickers)."""
+    """The vendor-default hex for 'cpu' / 'gpu' (for pre-filling the settings color pickers)."""
     if role == "gpu":
         table = _GPU_COLORS_DARK if is_dark else _GPU_COLORS_LIGHT
         return table.get(gpu_vendor(), table["unknown"])

--- a/src/netspeedtray/utils/styles.py
+++ b/src/netspeedtray/utils/styles.py
@@ -47,7 +47,7 @@ def combo_chevron_url(color_hex: str) -> str:
 
     Qt drops a combo's native arrow as soon as ``::drop-down`` is QSS-styled, which left every styled
     dropdown looking like a bare box. Supplying our own themed glyph restores the affordance with the
-    native Win11 chevron. Rendered at 2× then scaled by QSS for crispness; cached per colour so it's
+    native Win11 chevron. Rendered at 2× then scaled by QSS for crispness; cached per color so it's
     written once. Degrades to no-arrow (empty string) if the app-data dir can't be written.
     """
     try:
@@ -413,7 +413,7 @@ def sidebar_style() -> str:
     sidebar_bg = style_constants.DIALOG_SIDEBAR_BG_DARK if dark_mode_active else style_constants.DIALOG_SIDEBAR_BG_LIGHT
     text_color = style_constants.DARK_MODE_TEXT_COLOR if dark_mode_active else style_constants.LIGHT_MODE_TEXT_COLOR
     # Win11 NavigationView selection: a subtle fill + a short accent indicator bar, NOT a saturated
-    # full-bleed accent block; hover is the same subtle fill (not an opaque grey).
+    # full-bleed accent block; hover is the same subtle fill (not an opaque gray).
     subtle_fill = style_constants.SUBTLE_FILL_DARK if dark_mode_active else style_constants.SUBTLE_FILL_LIGHT
     # The selected nav row uses the SAME fill as the cards so the whole UI reads as exactly two tones:
     # a dark base (window + sidebar) and a lighter surface (cards + the selected row).
@@ -673,7 +673,7 @@ def timeline_pills_style() -> str:
 def segmented_pills_style(dark: bool) -> str:
     """Theme-aware variant of timeline_pills_style() for the Monitor's period control.
 
-    timeline_pills_style() is hardcoded for the graph window's dark canvas (light-grey glyphs on a
+    timeline_pills_style() is hardcoded for the graph window's dark canvas (light-gray glyphs on a
     translucent-white fill); on the Monitor's theme-aware surface that's invisible in light mode. This
     keeps the exact geometry + accent checked-state but flips the unchecked fill/text/border by theme.
     """
@@ -799,7 +799,7 @@ def slider_style() -> str:
         handle_hover_border_color_str = "#606060"
         handle_pressed_border_color_str = "#303030"
     else:
-        # Light mode: Darker grey border
+        # Light mode: Darker gray border
         handle_border_color_str = "#cccccc"
         handle_hover_border_color_str = "#bbbbbb"
         handle_pressed_border_color_str = "#999999"

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -113,7 +113,7 @@ def find_tasklist_rect(taskbar_hwnd: int) -> Optional[Tuple[int, int, int, int]]
 # nvidia-smi etc.), match the STABLE AutomationId 'WidgetsButton' (never the Name - it's localized and
 # embeds live weather text), and return the VISIBLE CONTENT extent (min-left..max-right of its child
 # icon/text), not the padded button box - so an overlap test reflects what's actually shown, not the
-# element's dead space. Depending on taskbar alignment it sits far-left (centred) or just left of the
+# element's dead space. Depending on taskbar alignment it sits far-left (centered) or just left of the
 # tray (edge-aligned - the case that can overlap the widget). ~200ms, so it's cached + refreshed on a
 # background thread; callers get the last-known rect instantly and never block. Fail-safe: any error /
 # Widgets disabled / future-build rename -> None. Used only to nudge the user (never to auto-move).

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -300,7 +300,7 @@ class WidgetRenderer:
         """Draws current upload and download speeds.
 
         identity_text: optional network-identity band tag (e.g. "5G") drawn to the right of the unit
-        column, vertically centred. When present it participates in the block width (so side_by_side
+        column, vertically centered. When present it participates in the block width (so side_by_side
         right-align accounts for it) and the content bounds. Reserved width is the fixed worst-case
         (IDENTITY_BAND_REFERENCE), so a 2.4G<->5G change never shifts the layout.
         """
@@ -389,7 +389,7 @@ class WidgetRenderer:
             bot_raw = upload if bot_is_upload else download
             self._draw_speed_line(painter, bot_is_upload, bot_val, bot_unit, bot_raw, arrow_x, number_x, unit_x, dw_y, config, number_area_width)
 
-            # v2.1: draw the network-identity badge to the right of the unit column, vertically centred.
+            # v2.1: draw the network-identity badge to the right of the unit column, vertically centered.
             if identity_badge_w:
                 badge_x = unit_x + max_unit_width + IDENTITY_BAND_GAP_PX
                 badge_y = (height - identity_parts["h"]) / 2.0
@@ -497,14 +497,14 @@ class WidgetRenderer:
                 arrow = config.arrow_up_symbol or self.i18n.UPLOAD_ARROW
             else:
                 arrow = config.arrow_down_symbol or self.i18n.DOWNLOAD_ARROW
-            # Opt-in per-direction arrow colour (#168). Off by default, so the arrow keeps sharing
-            # the band pen set above and the whole line stays one colour signal.
+            # Opt-in per-direction arrow color (#168). Off by default, so the arrow keeps sharing
+            # the band pen set above and the whole line stays one color signal.
             if config.use_custom_arrow_colors:
                 painter.setPen(self._cached_pens['arrow_up' if is_upload else 'arrow_down'])
             painter.drawText(arrow_x, y, arrow)
             if config.use_custom_arrow_colors:
                 # Restore the band pen BEFORE the number. Forgetting this makes the value silently
-                # inherit the arrow colour, which reads as a colour-coding regression (cf. #153).
+                # inherit the arrow color, which reads as a color-coding regression (cf. #153).
                 if config.color_coding:
                     band = self._speed_band(raw_bytes, config.high_speed_threshold, config.low_speed_threshold)
                     painter.setPen(self._cached_pens[band])
@@ -784,7 +784,7 @@ class WidgetRenderer:
         if not config.graph_enabled or len(history) < constants.renderer.MIN_GRAPH_POINTS:
             return
 
-        # Honour the configured graph timespan: the series buffers more than the visible window (so a
+        # Honor the configured graph timespan: the series buffers more than the visible window (so a
         # longer timespan reveals already-recorded samples at once), so show only the last `max_samples`
         # points (= history_minutes worth). Without this the graph plotted the whole buffer and 3 min
         # looked identical to 20 min.

--- a/src/netspeedtray/views/graph/renderer.py
+++ b/src/netspeedtray/views/graph/renderer.py
@@ -620,8 +620,8 @@ class GraphRenderer(QObject):
             plotted_ts, plotted_up, plotted_down = self._plot_high_res(plot_datetimes_array, upload_mbps, download_mbps, target_end_time=end_time)
             self._configure_axes(start_time, end_time, period_key, timestamps, plotted_up, plotted_down)
         elif stat_type in ("cpu", "gpu") and hw_styles is not None:
-            # Monitor's "toggle" layout: a single CPU- or GPU-only line that must honour the same
-            # display settings as combined/separate (per-role colour, Smooth, fixed/auto y-axis). The
+            # Monitor's "toggle" layout: a single CPU- or GPU-only line that must honor the same
+            # display settings as combined/separate (per-role color, Smooth, fixed/auto y-axis). The
             # standalone GraphWindow passes no hw_styles, so it keeps the legacy path below (+ tooltips).
             self._render_hwsingle(history_data, start_time, end_time, period_key, stat_type, hw_styles)
         else:
@@ -827,7 +827,7 @@ class GraphRenderer(QObject):
                 (end_time or datetime.fromtimestamp(ts_max)))
 
     def _render_hwcombined(self, data_dict, start_time, end_time, period_key, hw_styles=None):
-        """Plots CPU + GPU on one 0-100% axis: CPU solid, GPU dashed, vendor-coloured, with a legend.
+        """Plots CPU + GPU on one 0-100% axis: CPU solid, GPU dashed, vendor-colored, with a legend.
         Two lines, no fills - overlapping gradient fills would muddy a shared axis."""
         from netspeedtray.utils import hardware_vendors as hv
         ax = self.ax_download
@@ -947,7 +947,7 @@ class GraphRenderer(QObject):
 
     def _render_hwseparate(self, data_dict, start_time, end_time, period_key, hw_styles=None):
         """CPU top, GPU middle, RAM bottom - each its own axis, so no shared-axis collision and thus
-        each vendor-coloured SOLID (no dashed sibling needed). Mirrors the combined graph's roles."""
+        each vendor-colored SOLID (no dashed sibling needed). Mirrors the combined graph's roles."""
         from netspeedtray.utils import hardware_vendors as hv
         styles = hw_styles or {}
         smooth = bool(styles.get("smoothing"))
@@ -984,8 +984,8 @@ class GraphRenderer(QObject):
         self._configure_xaxis_format(period_key, axis=self.ax_ram)
 
     def _render_hwsingle(self, history_data, start_time, end_time, period_key, stat_type, hw_styles=None):
-        """One CPU- OR GPU-only line for the Monitor's "toggle" layout. Honours the same display
-        settings as _render_hwcombined/_render_hwseparate - per-role colour (vendor default fallback),
+        """One CPU- OR GPU-only line for the Monitor's "toggle" layout. Honors the same display
+        settings as _render_hwcombined/_render_hwseparate - per-role color (vendor default fallback),
         the Smooth toggle, and the fixed-0-100 vs auto y-axis - which the legacy single-stat path
         (still used by the standalone GraphWindow, hw_styles=None) does not."""
         from netspeedtray.utils import hardware_vendors as hv

--- a/src/netspeedtray/views/graph/worker.py
+++ b/src/netspeedtray/views/graph/worker.py
@@ -83,7 +83,7 @@ class GraphDataWorker(QObject):
                 self.error.emit("Data source (WidgetState) not available.")
                 return
 
-            # The fast in-memory session path only has the ALL-interfaces aggregate, so it can't honour a
+            # The fast in-memory session path only has the ALL-interfaces aggregate, so it can't honor a
             # per-NIC filter. When the user scopes the graph to one interface, fall through to the DB path
             # (which is per-interface) even for the session range. "all"/None keeps the in-memory path.
             net_use_memory = request.is_session_view and not request.interface_name

--- a/src/netspeedtray/views/monitor/graph_host.py
+++ b/src/netspeedtray/views/monitor/graph_host.py
@@ -285,7 +285,7 @@ class GraphHost(QObject):
 
     def _hw_styles(self) -> Dict[str, Any]:
         """Vendor-aware (color, linestyle) per role for the combined CPU+GPU graph; Monitor-settings
-        colour overrides (when set) win over the auto vendor default."""
+        color overrides (when set) win over the auto vendor default."""
         from netspeedtray.utils import hardware_vendors as hv
         cpu_c = self.config.get("monitor_cpu_graph_color") or None
         gpu_c = self.config.get("monitor_gpu_graph_color") or None

--- a/src/netspeedtray/views/monitor/hardware/tab.py
+++ b/src/netspeedtray/views/monitor/hardware/tab.py
@@ -3,8 +3,8 @@ HardwareTab - the Monitor's Hardware tab: a CPU+GPU history graph over a live pe
 CPU / RAM / GPU list (vertical splitter, mirroring the Network tab).
 
 The graph is hosted by the shared GraphHost. Its layout follows the ``monitor_hw_graph_mode`` setting:
-  • combined - CPU + GPU on one 0-100% axis (CPU solid, GPU dashed), vendor-coloured.  [default]
-  • separate - CPU and GPU on two stacked axes, each vendor-coloured solid.
+  • combined - CPU + GPU on one 0-100% axis (CPU solid, GPU dashed), vendor-colored.  [default]
+  • separate - CPU and GPU on two stacked axes, each vendor-colored solid.
   • toggle   - one stat at a time (CPU **or** GPU), chosen by an in-header CPU|GPU switch.
 Smoothing and the fixed/auto y-axis are read from config by the host's ``_hw_styles``. The per-process
 list is fed by HardwareFeed. The tab imports nothing from views.graph - the graph engine enters only
@@ -52,7 +52,7 @@ class HardwareTab(QWidget):
         # Header band (control row) - FIRST, at the very top of the tab so its timeline/Live sit at the
         # exact same height + right edge as the Overview/Network bands (no jump on tab switch). The band
         # is a fixed-height shell with the shared side inset; controls are right-docked + vertically
-        # centred. It used to sit *below* the telemetry strip, which pushed it far lower than the other
+        # centered. It used to sit *below* the telemetry strip, which pushed it far lower than the other
         # tabs' controls - the visible inconsistency the owner flagged.
         self._period_key = constants.data.history_period.PERIOD_MAP.get(
             int(config.get("history_period_slider_value", 2)), "TIMELINE_24_HOURS")
@@ -108,7 +108,7 @@ class HardwareTab(QWidget):
         splitter.addWidget(self._list)
         splitter.setStretchFactor(0, 3)
         splitter.setStretchFactor(1, 2)
-        splitter.setSizes([360, 235])         # graph-favoured, fits the default 620px window
+        splitter.setSizes([360, 235])         # graph-favored, fits the default 620px window
         body.addWidget(splitter, 1)
         root.addLayout(body, 1)
 
@@ -136,7 +136,7 @@ class HardwareTab(QWidget):
 
     def _apply_graph(self, *, first_mount: bool = False) -> None:
         """Show the right stat for the current mode. On first mount we attach (reparent the shared
-        canvas); afterwards we switch in place (set_stat) or just re-render (colours/legend/smoothing)."""
+        canvas); afterwards we switch in place (set_stat) or just re-render (colors/legend/smoothing)."""
         stat = self._resolve_stat()
         self._cpu_gpu.setVisible(str(self._config.get("monitor_hw_graph_mode", "combined")) == "toggle")
         try:
@@ -156,7 +156,7 @@ class HardwareTab(QWidget):
 
     def on_settings_changed(self) -> None:
         """Called by the Monitor window when the display-settings flyout changes anything (mode,
-        colours, legend, smoothing, axis). Re-resolve the mode + re-render."""
+        colors, legend, smoothing, axis). Re-resolve the mode + re-render."""
         self._apply_graph()
 
     def _update_telemetry(self) -> None:

--- a/src/netspeedtray/views/monitor/hardware/telemetry.py
+++ b/src/netspeedtray/views/monitor/hardware/telemetry.py
@@ -1,9 +1,9 @@
 """
 TelemetryStrip - a compact band of live hardware telemetry tiles for the Monitor's Hardware tab.
 
-Surfaces the readings the stats pipeline ALREADY collects (CPU/GPU utilisation + temperature + power,
+Surfaces the readings the stats pipeline ALREADY collects (CPU/GPU utilization + temperature + power,
 RAM and VRAM used/total) but that the Monitor didn't previously show - so the Hardware tab answers
-"how hot / how loaded / how much memory" at a glance, not just the utilisation graph. It reads the
+"how hot / how loaded / how much memory" at a glance, not just the utilization graph. It reads the
 values straight off the main widget's live attributes (updated every poll by StatsController), so it
 needs no extra sampling; a tile gracefully omits a reading that's unavailable (no sensor, or the
 temp/power gate is off) rather than showing a dead "N/A".
@@ -36,7 +36,7 @@ class _TeleTile(QFrame):
         lay = QVBoxLayout(self)
         lay.setContentsMargins(12, 6, 12, 6)
         lay.setSpacing(1)
-        # Centre the caption + value: these are equal-width chips, so centred content reads as a tidy
+        # Center the caption + value: these are equal-width chips, so centered content reads as a tidy
         # row of gauges rather than left-ragged text.
         self._caption = QLabel(caption)
         self._caption.setFont(su.font(tokens.TYPE_CAPTION))

--- a/src/netspeedtray/views/monitor/hardware/worker.py
+++ b/src/netspeedtray/views/monitor/hardware/worker.py
@@ -2,7 +2,7 @@ r"""
 HardwareActivityWorker - per-process CPU / RAM / GPU sampler for the Monitor's Hardware tab.
 
 Honest, admin-free, and every number measured (not estimated):
-  * CPU%  - psutil per-process, summed across a program's PIDs, normalised to total-CPU (0-100%).
+  * CPU%  - psutil per-process, summed across a program's PIDs, normalized to total-CPU (0-100%).
   * RAM   - psutil USS (Unique Set Size = private resident memory), summed across PIDs. This is what
             Task Manager's "Memory" column shows; rss would double-count shared DLLs across a
             multi-process app and read 2-3x high. USS is heavier to read, so it's refreshed every
@@ -127,7 +127,7 @@ class HardwareActivityWorker(QObject):
                     "identity_key": key,
                     "display_name": a["display_name"],
                     "pids": sorted(a["pids"]),
-                    # Normalise summed-across-cores CPU to a 0-100% share of the whole CPU.
+                    # Normalize summed-across-cores CPU to a 0-100% share of the whole CPU.
                     "cpu_pct": min(100.0, a["cpu"] / self._cpu_count),
                     "rss_bytes": self._uss_cache.get(key, a["rss"]),  # accurate USS if cached, else rss
                     "gpu_pct": min(100.0, a["gpu"]),   # max-of-engines is already 0-100; clamp is belt-and-braces

--- a/src/netspeedtray/views/monitor/network/app_list.py
+++ b/src/netspeedtray/views/monitor/network/app_list.py
@@ -3,7 +3,7 @@ AppBarList - the per-app connection list for the Monitor's Network tab.
 
 Renders the AppActivityWorker's honest payload (live connections per app, never estimated bytes) as
 a calm bar list: one row per app, an activity bar sized (log scale) to its share of live
-connections, active apps in the accent colour and idle apps muted. Rows are keyed by app identity
+connections, active apps in the accent color and idle apps muted. Rows are keyed by app identity
 and reused across ticks (no flicker); ordering is stable (selected-first, then active-first, then by
 name), so a row only moves when its active/idle state actually flips - never because its connection
 count jittered. The selected row is pinned to the top so its highlight (and the detail panel reading
@@ -168,7 +168,7 @@ class AppRow(QFrame):
         self._name.setText(fm.elidedText(name, Qt.TextElideMode.ElideRight, _NAME_W))
         self._bar.set_value(frac, active)
         self._count.setText(str(conn))
-        # Dim idle apps so the eye lands on what's actually talking. Re-resolve colours each tick so
+        # Dim idle apps so the eye lands on what's actually talking. Re-resolve colors each tick so
         # a mid-session light/dark switch is picked up (the bar already re-reads per paint).
         c = su.semantic_colors()
         name_color = c["text_primary"] if active else c["text_secondary"]

--- a/src/netspeedtray/views/monitor/network/header.py
+++ b/src/netspeedtray/views/monitor/network/header.py
@@ -100,7 +100,7 @@ class NetworkHeader(QWidget):
         # controls - interface filter + the SAME timeline dropdown the Overview uses - given proper room
         # on the right. (Replaces the cramped six-pill strip; the dropdown also unlocks the finer ranges
         # 30m/1h/4h/8h/12h/48h the pills never had, and keeps all three tabs consistent.)
-        # Fixed height + the shared side inset so the controls sit at the SAME vertical centre + right
+        # Fixed height + the shared side inset so the controls sit at the SAME vertical center + right
         # edge as the Overview/Hardware bands - switching tabs no longer makes the dropdown jump.
         self.setFixedHeight(constants.layout.MONITOR_HEADER_BAND_HEIGHT)
         root = QHBoxLayout(self)

--- a/src/netspeedtray/views/monitor/overview/tab.py
+++ b/src/netspeedtray/views/monitor/overview/tab.py
@@ -3,7 +3,7 @@ OverviewTab - the Monitor's control center: an at-a-glance "everything that's go
 
 By contract this tab NEVER imports matplotlib (it's the default tab, so a glance-only session stays
 at the idle-RAM baseline). It leads with a NetworkHero (co-equal download + upload over a dual
-sparkline), then a row of hardware tiles (CPU / GPU / RAM / VRAM - utilisation, temperature, memory),
+sparkline), then a row of hardware tiles (CPU / GPU / RAM / VRAM - utilization, temperature, memory),
 then a Today/This-month data-usage card. The Monitor forces hardware collection while it's open, so
 the hardware tiles show real data even when the taskbar widget has hardware monitoring off.
 
@@ -29,7 +29,7 @@ from netspeedtray.utils import styles as su
 from netspeedtray.constants.styles import styles as tokens
 from netspeedtray.utils.helpers import format_speed, format_data_size, format_duration_short
 from netspeedtray.utils.widget_paint import WidgetMetrics   # reuse its Mbps→bytes/sec converter (DRY)
-# NOTE: `summaries` imports numpy at module scope. To honour the Monitor's import firewall (a glance at
+# NOTE: `summaries` imports numpy at module scope. To honor the Monitor's import firewall (a glance at
 # the default Overview must not eagerly pull the heavy compute deps), it is imported LAZILY inside
 # _reload_window - the one place it's used - NOT here. Keep it that way.
 from netspeedtray.views.monitor.overview.tiles import StatTile, UsageTile, NetworkHero, dynamic_range
@@ -39,7 +39,7 @@ from netspeedtray.views.monitor.timeline_selector import TimelineSelector
 # exports, so it is imported LAZILY in those handlers - keeping numpy off the Overview's import path.
 
 # Per-resource accent as (dark, light) pairs. Network up/down get a distinct, harmonious pair; CPU/GPU
-# echo the graph's line hues; RAM/VRAM get their own calm colours. The light variant keeps the thin
+# echo the graph's line hues; RAM/VRAM get their own calm colors. The light variant keeps the thin
 # trend line legible on the near-white light card.
 _ACCENTS = {
     # Download green / upload blue - the SAME codes as the standalone graph (color.DOWNLOAD/UPLOAD_LINE_COLOR)
@@ -433,7 +433,7 @@ class OverviewTab(QWidget):
             vu, vt = getattr(mw, "vram_used", None), getattr(mw, "vram_total", None)
             integrated = vu is None and vt is None
 
-            # Each utilisation sparkline auto-zooms to its own active band (dynamic_range), so a
+            # Each utilization sparkline auto-zooms to its own active band (dynamic_range), so a
             # low-but-varying metric (e.g. CPU mostly 5-20%) reads in detail instead of as a flat
             # squiggle against a fixed 0-100% - with a minimum span so a steady metric isn't blown up.
             cpu_series = ser.get("cpu", [])
@@ -583,7 +583,7 @@ class OverviewTab(QWidget):
         return s.replace(".", sep) if sep and sep != "." else s
 
     def _latency_html(self, mw) -> str:
-        """Latency pill: a colour-coded plain word (Good/OK/Slow - the panel insisted avg-ms is a bad
+        """Latency pill: a color-coded plain word (Good/OK/Slow - the panel insisted avg-ms is a bad
         headline) with the ms + loss% as quiet subtext. Internet (public anchor) latency wins over the
         gateway when the user opted into the public probe."""
         gw = getattr(mw, "latency_gw", None)
@@ -611,7 +611,7 @@ class OverviewTab(QWidget):
 
     def _detail_subjects(self, metric: str):
         """The subject list a card opens its Stats-detail sheet with. Hardware cards lead with their
-        utilisation and add temperature/power when a sensor reported them; network leads with both
+        utilization and add temperature/power when a sensor reported them; network leads with both
         directions plus gateway latency. (Empty secondary blocks drop out inside the sheet.)"""
         cpu = self._tr("ORDER_TYPE_CPU", "CPU")
         gpu = self._tr("ORDER_TYPE_GPU", "GPU")

--- a/src/netspeedtray/views/monitor/overview/tiles.py
+++ b/src/netspeedtray/views/monitor/overview/tiles.py
@@ -57,7 +57,7 @@ def dynamic_range(series: List[float], min_span: float = 15.0,
 
 
 class Sparkline(QWidget):
-    """A tiny trend line with a soft gradient fill, in a single accent colour."""
+    """A tiny trend line with a soft gradient fill, in a single accent color."""
 
     def __init__(self, color: str, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -329,7 +329,7 @@ class NetworkHero(ClickableCard):
         title_row.addStretch(1)
         # Latency pill (top-right) - plain word first (Good/OK/Slow), the ms as quiet subtext. Wrapped
         # in a subtle inset chip so it reads as a native Win11 status badge, not floating text (the
-        # status colour is carried by the inline text; the label hides itself when there's no reading).
+        # status color is carried by the inline text; the label hides itself when there's no reading).
         self._latency = QLabel("")
         self._latency.setFont(su.font(tokens.TYPE_CAPTION))
         self._latency.setStyleSheet(
@@ -387,7 +387,7 @@ class NetworkHero(ClickableCard):
         self._sub.setVisible(bool(sub_text))
 
     def set_latency(self, html: str) -> None:
-        """Set the top-right latency pill (rich text: a colour-coded word + quiet ms/loss subtext)."""
+        """Set the top-right latency pill (rich text: a color-coded word + quiet ms/loss subtext)."""
         self._latency.setText(html)
         self._latency.setVisible(bool(html))
 
@@ -473,7 +473,7 @@ class UsageTile(QFrame):
         return row, value
 
     def _fmt_num(self, value: float) -> str:
-        """One-decimal, honouring the locale's decimal separator (so the usage rows match the
+        """One-decimal, honoring the locale's decimal separator (so the usage rows match the
         Network tile's localized speed text in the same window - e.g. ``1,2`` on de_DE)."""
         s = f"{value:.1f}"
         sep = getattr(self._i18n, "DECIMAL_SEPARATOR", ".")

--- a/src/netspeedtray/views/monitor/settings_flyout.py
+++ b/src/netspeedtray/views/monitor/settings_flyout.py
@@ -6,7 +6,7 @@ across opens (the window caches it); ``refresh()`` re-reads the current config/t
 before each show. Changes apply LIVE - each control writes its config key (persisted via the widget's
 config_controller) and emits ``changed`` so the Monitor re-renders the active graph. Matplotlib-free.
 
-6.2a covers the combined-graph essentials (CPU/GPU line colours with a vendor "Auto" reset, and the
+6.2a covers the combined-graph essentials (CPU/GPU line colors with a vendor "Auto" reset, and the
 legend toggle). 6.2b/6.2c add the graph mode, smoothing, axis, cadence, theme and open-on-startup
 here and on a mirrored Settings → Monitor page.
 """
@@ -115,7 +115,7 @@ class MonitorSettingsFlyout(QFrame):
 
         # Don't HARD-pin the width: the 3-button Layout segmented (and longer localized labels like
         # de "Kombiniert/Umschalten") need more than 300px and Win11Segmented buttons hard-clip (no
-        # elide). A min width keeps the colour rows from looking sparse; _open_settings_flyout's
+        # elide). A min width keeps the color rows from looking sparse; _open_settings_flyout's
         # adjustSize() then grows the panel to the controls' sizeHint so no label is ever truncated.
         self.setMinimumWidth(300)
 

--- a/src/netspeedtray/views/monitor/tab_bar.py
+++ b/src/netspeedtray/views/monitor/tab_bar.py
@@ -64,7 +64,7 @@ class FlatTabBar(QWidget):
             self._buttons[self._order[0]].setChecked(True)
 
         self._apply_style()
-        # A QIcon pixmap can't be tinted by QSS, so re-render each tab's glyph in the right colour
+        # A QIcon pixmap can't be tinted by QSS, so re-render each tab's glyph in the right color
         # whenever selection moves (secondary at rest, accent when checked).
         self._group.buttonToggled.connect(lambda *_: self._update_icons())
         self._update_icons()

--- a/src/netspeedtray/views/monitor/window.py
+++ b/src/netspeedtray/views/monitor/window.py
@@ -91,7 +91,7 @@ class MonitorWindow(QWidget):
         _gear_sp.setRetainSizeWhenHidden(True)   # keep the header slot when hidden so hiding never reflows (#170)
         self._gear.setSizePolicy(_gear_sp)
         self._gear.setVisible(False)             # shown only on the Hardware tab (set in _on_tab_changed)
-        self._gear.setText(chr(0xE713))   # Segoe Fluent Icons "Settings" - monochrome, obeys QSS colour
+        self._gear.setText(chr(0xE713))   # Segoe Fluent Icons "Settings" - monochrome, obeys QSS color
         self._gear.setCursor(Qt.CursorShape.PointingHandCursor)
         self._gear.setToolTip(self._tr("MONITOR_SETTINGS_TIP", "Monitor display settings"))
         self._gear.setAccessibleName(self._tr("MONITOR_SETTINGS_TIP", "Monitor display settings"))
@@ -247,7 +247,7 @@ class MonitorWindow(QWidget):
     def _on_settings_changed(self) -> None:
         # Live-apply. The active page may need more than a re-render - a graph-mode change re-resolves
         # which stat is shown - so delegate to its on_settings_changed when it has one. Otherwise just
-        # re-render the active graph (colour/legend/smoothing/axis). No-op until a chart tab built the host.
+        # re-render the active graph (color/legend/smoothing/axis). No-op until a chart tab built the host.
         idx = self._stack.currentIndex()
         page = self._descriptors[idx].page if 0 <= idx < len(self._descriptors) else None
         if page is not None and hasattr(page, "on_settings_changed"):

--- a/src/netspeedtray/views/settings/dialog.py
+++ b/src/netspeedtray/views/settings/dialog.py
@@ -45,7 +45,7 @@ from netspeedtray.views.settings.pages.appearance import AppearancePage
 from netspeedtray.views.settings.pages.hardware import HardwarePage
 from netspeedtray.views.settings.pages.advanced import AdvancedPage
 # units.py + colors.py are now embedded inside AppearancePage (the dialog reaches them via
-# appearance_page.units_section / .colors_section for the Force-MB rule + colour-picker routing).
+# appearance_page.units_section / .colors_section for the Force-MB rule + color-picker routing).
 from netspeedtray.views.widget.preview import PreviewWidget
 from netspeedtray.constants.update_mode import UpdateMode
 
@@ -247,7 +247,7 @@ class SettingsDialog(QDialog):
                 self._open_color_dialog
             )
             # The old Color Coding + Display(Units) pages are now sections INSIDE Appearance. Keep
-            # references so the existing colour-picker routing + Force-MB rule reach the same objects.
+            # references so the existing color-picker routing + Force-MB rule reach the same objects.
             self.colors_page = self.appearance_page.colors_section
             self.units_page = self.appearance_page.units_section
 
@@ -268,7 +268,7 @@ class SettingsDialog(QDialog):
             for page in [
                 self.general_page,       # 0 - General
                 self.widget_page,        # 1 - Widget
-                self.appearance_page,    # 2 - Appearance (font/colour/units/colour-coding/graph)
+                self.appearance_page,    # 2 - Appearance (font/color/units/color-coding/graph)
                 self.hardware_page,      # 3 - Hardware
                 self.interfaces_page,    # 4 - Network
                 self.advanced_page,      # 5 - Advanced
@@ -352,7 +352,7 @@ class SettingsDialog(QDialog):
         scroll.setFrameShape(QScrollArea.Shape.NoFrame)
         scroll.setStyleSheet("QScrollArea { background: transparent; border: none; }")
         # Let the dark content background show through the scroll region so cards FLOAT on it (the page
-        # otherwise renders an opaque mid-grey that the cards blend into - the "cards section is a
+        # otherwise renders an opaque mid-gray that the cards blend into - the "cards section is a
         # different shade" bug). Mirrors how the Monitor's Overview scroll content is made transparent.
         scroll.viewport().setAutoFillBackground(False)
         page.setStyleSheet("background: transparent;")   # cards/inputs keep their own fill (more specific)
@@ -369,7 +369,7 @@ class SettingsDialog(QDialog):
         try:
             self.general_page.load_settings(self.config, self.startup_enabled_initial_state)
             self.widget_page.load_settings(self.config)
-            self.appearance_page.load_settings(self.config)   # also loads the embedded units + colours
+            self.appearance_page.load_settings(self.config)   # also loads the embedded units + colors
             self.hardware_page.load_settings(self.config)
             self.interfaces_page.load_settings(self.config)
             self.advanced_page.load_settings(self.config)
@@ -439,7 +439,7 @@ class SettingsDialog(QDialog):
             pass
 
     def _tint_sidebar_icons(self) -> None:
-        """Re-render each sidebar glyph in the right colour (a QIcon pixmap can't be tinted by QSS):
+        """Re-render each sidebar glyph in the right color (a QIcon pixmap can't be tinted by QSS):
         accent on the selected row to match the accent indicator bar, text_secondary on the rest."""
         try:
             c = style_utils.semantic_colors()
@@ -500,7 +500,7 @@ class SettingsDialog(QDialog):
             settings = self.config.copy()
             settings.update(self.general_page.get_settings())
             settings.update(self.widget_page.get_settings())
-            settings.update(self.appearance_page.get_settings())   # includes embedded units + colours
+            settings.update(self.appearance_page.get_settings())   # includes embedded units + colors
             settings.update(self.hardware_page.get_settings())
             settings.update(self.interfaces_page.get_settings())
             settings.update(self.advanced_page.get_settings())

--- a/src/netspeedtray/views/settings/pages/_fluent.py
+++ b/src/netspeedtray/views/settings/pages/_fluent.py
@@ -5,7 +5,7 @@ The 2.0 Settings pages are built from one idiom - a small section caption over a
 ``SettingCard`` rows (the native Win11 Settings layout) - instead of the old ``QGroupBox`` frames.
 This module holds the one piece that ``components.SettingCard`` doesn't: the section caption that
 groups related cards. Keeping it here means every page renders the same heading at the same size,
-colour and inset.
+color and inset.
 """
 from __future__ import annotations
 

--- a/src/netspeedtray/views/settings/pages/appearance.py
+++ b/src/netspeedtray/views/settings/pages/appearance.py
@@ -37,7 +37,7 @@ class AppearancePage(QWidget):
 
     def _setup_ui(self):
         # 2.0 IA: Win11 Settings cards under section captions (was QGroupBox frames). Compound controls
-        # (font picker button + label, colour swatch + hex) are packed into a small composite docked on
+        # (font picker button + label, color swatch + hex) are packed into a small composite docked on
         # the right of each card via _row(). All control objects + the load/get wiring are unchanged.
         layout = page_layout(self)
 
@@ -52,7 +52,7 @@ class AppearancePage(QWidget):
         layout.addWidget(SettingCard(self.i18n.FONT_FAMILY_LABEL,
                                      control=self._row(self.font_family_label, self.font_family_button)))
 
-        # Default text colour (swatch + hex).
+        # Default text color (swatch + hex).
         self.default_color_button = QPushButton()
         self.default_color_button.setObjectName("default_color")
         self.default_color_button.setFixedSize(36, 26)
@@ -111,9 +111,9 @@ class AppearancePage(QWidget):
         # Arrow Weight - REMOVED per user request (font support issues)
         layout.addWidget(self.arrow_font_container)
 
-        # Per-direction arrow colour (#168). Off by default: the arrow shares the speed text's pen,
-        # so with colour-coding on the whole line bands together as one signal. Turning this on
-        # splits it into two colour languages (direction vs magnitude) - defensible, but a real
+        # Per-direction arrow color (#168). Off by default: the arrow shares the speed text's pen,
+        # so with color-coding on the whole line bands together as one signal. Turning this on
+        # splits it into two color languages (direction vs magnitude) - defensible, but a real
         # design change, so nobody's widget shifts on upgrade.
         self.use_custom_arrow_colors = Win11Toggle(label_text="")
         self.use_custom_arrow_colors.toggled.connect(self._on_arrow_colors_toggle)
@@ -127,7 +127,7 @@ class AppearancePage(QWidget):
         for key, label in (("arrow_up", self.i18n.ARROW_UP_COLOR_LABEL),
                            ("arrow_down", self.i18n.ARROW_DOWN_COLOR_LABEL)):
             # Widget names must be "{key}_color_button" / "{key}_color_input": SettingsDialog routes
-            # every non-threshold colour back through set_color_input by that convention, so naming
+            # every non-threshold color back through set_color_input by that convention, so naming
             # them this way needs zero routing changes.
             button = QPushButton()
             button.setObjectName(f"{key}_color")
@@ -187,9 +187,9 @@ class AppearancePage(QWidget):
         self.graph_opacity.valueChanged.connect(self.on_change)
         layout.addWidget(SettingCard(self.i18n.GRAPH_OPACITY_LABEL, control=self.graph_opacity))
 
-        # --- Data format (absorbed from the old Display/Units page) + Colour coding (absorbed from the
+        # --- Data format (absorbed from the old Display/Units page) + Color coding (absorbed from the
         # old Color Coding page), 2.0 IA. Reused as-is (their own tested control groups + load/get); the
-        # dialog keeps references to them for the Force-MB rule + the high/low colour-picker routing.
+        # dialog keeps references to them for the Force-MB rule + the high/low color-picker routing.
         self.units_section = UnitsPage(self.i18n, self.on_change)
         layout.addWidget(self.units_section)
         self.colors_section = ColorsPage(self.i18n, self.on_change, self.open_color_dialog)
@@ -252,7 +252,7 @@ class AppearancePage(QWidget):
         self.history_duration.setValue(config.get("history_minutes", constants.config.defaults.DEFAULT_HISTORY_MINUTES))
         self.graph_opacity.setValue(config.get("graph_opacity", constants.config.defaults.DEFAULT_GRAPH_OPACITY))
 
-        # Absorbed sections (units / colour coding).
+        # Absorbed sections (units / color coding).
         self.units_section.load_settings(config)
         self.colors_section.load_settings(config)
 
@@ -279,7 +279,7 @@ class AppearancePage(QWidget):
             "history_minutes": self.history_duration.value(),
             "graph_opacity": self.graph_opacity.value()
         }
-        # Merge the absorbed sections' keys (units / colour coding).
+        # Merge the absorbed sections' keys (units / color coding).
         settings.update(self.units_section.get_settings())
         settings.update(self.colors_section.get_settings())
         return settings

--- a/src/netspeedtray/views/settings/pages/colors.py
+++ b/src/netspeedtray/views/settings/pages/colors.py
@@ -24,7 +24,7 @@ class ColorsPage(QWidget):
 
     def _setup_ui(self):
         # 2.0 IA: a Win11 Settings card per setting. The master toggle gates a container of
-        # threshold + swatch cards (shown only when colour coding is on). All control attribute
+        # threshold + swatch cards (shown only when color coding is on). All control attribute
         # names + the load/get wiring are unchanged.
         layout = page_layout(self)
 
@@ -38,7 +38,7 @@ class ColorsPage(QWidget):
         cc_v_layout.setContentsMargins(0, 0, 0, 0)
         cc_v_layout.setSpacing(tokens.SPACE_XS)
 
-        # Thresholds + colours, two cards each (the speed at which to switch, then the colour to use).
+        # Thresholds + colors, two cards each (the speed at which to switch, then the color to use).
         for key, t_label, c_label in [
             ("high_speed", self.i18n.HIGH_SPEED_THRESHOLD_LABEL, self.i18n.HIGH_SPEED_COLOR_LABEL),
             ("low_speed", self.i18n.LOW_SPEED_THRESHOLD_LABEL, self.i18n.LOW_SPEED_COLOR_LABEL),

--- a/src/netspeedtray/views/settings/pages/general.py
+++ b/src/netspeedtray/views/settings/pages/general.py
@@ -74,7 +74,7 @@ class GeneralPage(QWidget):
 
         # --- Behavior ---
         # NOTE (2.0 IA): free-move, keep-visible-in-fullscreen and tray-offset moved to the new Widget
-        # page (they're about the on-taskbar widget, not the app). General keeps app-level behaviour.
+        # page (they're about the on-taskbar widget, not the app). General keeps app-level behavior.
         layout.addWidget(section_header(self.i18n.BEHAVIOR_GROUP_TITLE))
         self.start_with_windows = Win11Toggle(label_text="")
         self.start_with_windows.toggled.connect(self.on_change)

--- a/src/netspeedtray/views/settings/pages/hardware.py
+++ b/src/netspeedtray/views/settings/pages/hardware.py
@@ -26,7 +26,7 @@ class HardwarePage(QWidget):
 
     def _setup_ui(self):
         # 2.0 IA: the primary monitoring toggles are Win11 Settings cards under a plain section caption;
-        # the lower-frequency groups (display mode / order / load colours) stay behind Fluent expanders.
+        # the lower-frequency groups (display mode / order / load colors) stay behind Fluent expanders.
         # All control objects + the load/get wiring are unchanged.
         layout = page_layout(self)
 
@@ -165,7 +165,7 @@ class HardwarePage(QWidget):
 
     def _set_card_enabled(self, card: SettingCard, enabled: bool) -> None:
         """Gray out a dependent card when its prerequisite is off. setEnabled alone won't visually dim
-        our fixed-colour custom toggle, so pair it with an opacity effect for the Win11 'unavailable'
+        our fixed-color custom toggle, so pair it with an opacity effect for the Win11 'unavailable'
         look (and to make the card non-interactive)."""
         card.setEnabled(enabled)
         eff = card.graphicsEffect()
@@ -175,7 +175,7 @@ class HardwarePage(QWidget):
         eff.setOpacity(1.0 if enabled else 0.4)
 
     def _sync_dependent_cards(self) -> None:
-        """Several readouts ride on the CPU/GPU utilisation lines, so gray their toggles out when there's
+        """Several readouts ride on the CPU/GPU utilization lines, so gray their toggles out when there's
         nowhere for them to render (Win11 dependent-control pattern): temperature & power need at least
         one of CPU/GPU on; RAM rides on the CPU line, and VRAM on the GPU line, so each is grayed when its
         host monitor is off - otherwise turning on RAM with CPU off promised something that never shows."""

--- a/src/netspeedtray/views/settings/pages/widget.py
+++ b/src/netspeedtray/views/settings/pages/widget.py
@@ -3,7 +3,7 @@ Widget Settings Page (2.0 IA).
 
 Everything about the on-taskbar widget itself - how its stats are laid out (display mode + order),
 and how it behaves/sits on the taskbar (free-move, keep-visible-in-fullscreen, tray offset). These
-controls used to be scattered across the General page (behaviour) and the Hardware page (layout); the
+controls used to be scattered across the General page (behavior) and the Hardware page (layout); the
 2.0 IA gathers them here so "the widget" is one place.
 
 Slider→Segmented and QListWidget upgrades are intentionally NOT done here - the controls move as-is
@@ -21,7 +21,7 @@ from netspeedtray.views.settings.pages._fluent import section_header, page_layou
 
 
 class WidgetPage(QWidget):
-    """Layout (display mode + order) and on-taskbar behaviour (free-move, fullscreen, offset)."""
+    """Layout (display mode + order) and on-taskbar behavior (free-move, fullscreen, offset)."""
 
     layout_changed = pyqtSignal()
 
@@ -63,7 +63,7 @@ class WidgetPage(QWidget):
             layout.addWidget(SettingCard(getattr(self.i18n, f"ORDER_POSITION_{i+1}"), control=combo))
             self.pos_combos.append(combo)
 
-        # --- Behaviour (was on the General page) ---
+        # --- Behavior (was on the General page) ---
         layout.addWidget(section_header(self.i18n.BEHAVIOR_GROUP_TITLE))
         self.free_move = Win11Toggle(label_text="")
         self.free_move.toggled.connect(self.on_change)
@@ -87,7 +87,7 @@ class WidgetPage(QWidget):
 
         layout.addStretch()
 
-    # --- behaviour ---------------------------------------------------------------
+    # --- behavior ---------------------------------------------------------------
     def ensure_hardware_visible(self) -> None:
         """Called by the dialog when a hardware monitor is enabled on the Hardware page: switch the
         widget out of network-only so the freshly-enabled stat is actually visible. This is the


### PR DESCRIPTION
You spotted `colour` in the 2.1.3 release notes. It was not isolated.

The app's **UI strings were already correct** - `en_US.json` never drifted - but the prose around them had. The clearest symptom, in one sentence of `changelog.md`:

> **Upload and download arrows can have their own colours.** Turn on *Custom arrow colors* in Settings → Appearance.

British in the description, American in the quoted UI label, same line. Documentation that contradicts the product is worse than either choice made consistently.

### Scope

**163 replacements across 48 files, all prose** - markdown, comments and docstrings.

Checked before applying that nothing functional was at risk:

| risk | finding |
|---|---|
| identifiers / dict keys / config keys | **none** use a British spelling |
| `grey` as a live Qt or CSS colour value | **none** - every occurrence is in a comment |
| `en_US.json` UI strings | **already American**, so zero i18n churn and no translation impact |
| other locales | **untouched on purpose** - `Centre` is correct French, and their spelling is not ours to normalize |

The diff is 163 insertions / 163 deletions: a pure 1:1 word swap with no structural change.

### The guard

`test_american_english.py` covers the English a user actually **reads**: the UI strings, README, changelog and TRANSLATORS. It deliberately does **not** police Python comments - not user-facing, and the noise would drown the signal.

One deliberate omission worth noting: **`analysis` is not on the list.** Only the verb differs (*analyse* / *analyze*); the noun is spelled the same in both, so flagging it would produce false positives. Same reasoning for `practice` as a noun.

**Verified by reintroducing `colours` into `changelog.md` and watching the test fail**, rather than assuming it would.

1147 tests pass.

---

Still to do, separately: the **published v2.1.3 release body** on GitHub carries the old spelling. I will re-apply the corrected notes to it once this merges.