### PR TITLE
fix(logging): stop one call producing 98.5% of the log, and make updates observable

### DIFF
--- a/src/netspeedtray/core/controller.py
+++ b/src/netspeedtray/core/controller.py
@@ -373,7 +373,13 @@ class StatsController(QObject):
         responsive in the default 'auto' mode (H1). A NIC change is picked up within the
         refresh window (the speed briefly attributes to the old primary)."""
         now = time.monotonic()
-        if self.primary_interface is not None and (now - self.last_primary_check_time) < self._PRIMARY_REFRESH_SEC:
+        # Throttle on ELAPSED TIME ALONE. This used to also require `primary_interface is not None`,
+        # which meant the cache stopped applying in exactly the case it was built for: with no route
+        # (offline, VPN dropping, waking up), the lookup returns None, so the guard fell through and
+        # the blocking UDP connect + net_if_addrs ran on EVERY poll instead of every 15s - and logged
+        # a warning each time. One reporter's bundle was 137,497 of 139,638 lines from that single
+        # call (#260). `last_primary_check_time` starts at 0.0, so the first lookup still runs at once.
+        if (now - self.last_primary_check_time) < self._PRIMARY_REFRESH_SEC:
             return
         self.last_primary_check_time = now
         previous = self.primary_interface

--- a/src/netspeedtray/core/database.py
+++ b/src/netspeedtray/core/database.py
@@ -591,7 +591,7 @@ class DatabaseWorker(QThread):
         config = data
         _now = now or datetime.now()
         
-        self.logger.info("Starting periodic database maintenance...")
+        self.logger.debug("Starting periodic database maintenance...")
         cursor = self.conn.cursor()
         try:
             self._aggregate_raw_to_minute(cursor, _now)
@@ -606,7 +606,7 @@ class DatabaseWorker(QThread):
             cursor.execute("INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_maintenance_at', ?)", (str(int(_now.timestamp())),))
             self.conn.commit()
             
-            self.logger.info("Database maintenance tasks committed successfully.")
+            self.logger.debug("Database maintenance tasks committed successfully.")
 
             # Bound the WAL file: long-lived reader connections (the Monitor's graph worker) can hold
             # back the automatic checkpoint, letting -wal grow across a long session. A TRUNCATE
@@ -659,9 +659,9 @@ class DatabaseWorker(QThread):
             WHERE timestamp < ?
             GROUP BY (timestamp / 60) * 60, stat_type
         """, (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Aggregated %d per-minute hardware records.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Aggregated %d per-minute hardware records.", cursor.rowcount)
         cursor.execute(f"DELETE FROM {constants.data.HARDWARE_STATS_TABLE_RAW} WHERE timestamp < ?", (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Pruned %d raw hardware records after aggregation.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Pruned %d raw hardware records after aggregation.", cursor.rowcount)
 
 
     def _aggregate_hardware_minute_to_hour(self, cursor: sqlite3.Cursor, now: datetime) -> None:
@@ -683,9 +683,9 @@ class DatabaseWorker(QThread):
             WHERE timestamp < ?
             GROUP BY hour_timestamp, stat_type
         """, (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Aggregated %d per-hour hardware records.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Aggregated %d per-hour hardware records.", cursor.rowcount)
         cursor.execute(f"DELETE FROM {constants.data.HARDWARE_STATS_TABLE_MINUTE} WHERE timestamp < ?", (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Pruned %d minute hardware records after aggregation.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Pruned %d minute hardware records after aggregation.", cursor.rowcount)
 
     @staticmethod
     def _retention_cutoff(now: datetime, retention_days: float) -> int:
@@ -744,10 +744,10 @@ class DatabaseWorker(QThread):
             WHERE timestamp < ?
             GROUP BY minute_timestamp, interface_name
         """, (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Aggregated %d per-minute records.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Aggregated %d per-minute records.", cursor.rowcount)
         
         cursor.execute(f"DELETE FROM {constants.data.SPEED_TABLE_RAW} WHERE timestamp < ?", (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Pruned %d raw records after aggregation.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Pruned %d raw records after aggregation.", cursor.rowcount)
 
 
     def _aggregate_minute_to_hour(self, cursor: sqlite3.Cursor, now: datetime) -> None:
@@ -769,10 +769,10 @@ class DatabaseWorker(QThread):
             WHERE timestamp < ?
             GROUP BY hour_timestamp, interface_name
         """, (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Aggregated %d per-hour records.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Aggregated %d per-hour records.", cursor.rowcount)
 
         cursor.execute(f"DELETE FROM {constants.data.SPEED_TABLE_MINUTE} WHERE timestamp < ?", (cutoff,))
-        if cursor.rowcount > 0: self.logger.info("Pruned %d minute records after aggregation.", cursor.rowcount)
+        if cursor.rowcount > 0: self.logger.debug("Pruned %d minute records after aggregation.", cursor.rowcount)
 
 
     def _prune_data_with_grace_period(self, cursor: sqlite3.Cursor, config: Dict[str, Any], now: datetime) -> bool:

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -253,11 +253,14 @@ class _DownloadWorker(QObject):
             raise RuntimeError("no published checksum for the portable build")
         actual = _sha256_file(self._dest)
         if actual != expected:
+            logger.warning("Portable update checksum MISMATCH for %s", self._expected_name)
             raise RuntimeError("checksum mismatch - the download may be corrupt or tampered")
+        logger.info("Portable update checksum verified for %s", self._expected_name)
         _safe_extract(self._dest, self._extract_dir or "")
         app_folder = os.path.dirname(_locate_portable_exe(self._extract_dir or ""))
         ready = _unique_dir(self._ready_target)
         shutil.move(app_folder, ready)   # move the verified tree out of the temp dir, off the UI thread
+        logger.info("Portable update staged; the user must copy this folder over their install.")
         self.staged.emit(ready)
 
 
@@ -317,6 +320,8 @@ class SecureUpdater(QObject):
             return
 
         self._active = True
+        logger.info("Update starting: mode=%s version=%s", "portable" if self._portable else "installer",
+                    self._latest_version or "?")
         title = getattr(self.i18n, "UPDATE_DOWNLOADING_TITLE", "Downloading update")
         cancel = getattr(self.i18n, "CANCEL_BUTTON", "Cancel")
         self._progress = QProgressDialog(title, cancel, 0, 100, self._parent)

--- a/src/netspeedtray/tests/unit/test_log_noise.py
+++ b/src/netspeedtray/tests/unit/test_log_noise.py
@@ -1,0 +1,137 @@
+"""
+The log has to stay readable, because it is the only evidence a bug report carries.
+
+A support bundle for #260 arrived with **137,497 of its 139,638 lines - 98.5% - from one call**:
+`get_primary_interface_name()` logging a WARNING every second while the reporter's Wi-Fi had no
+route. That flood rotated away every genuinely useful entry, so the actual question (did the
+portable update stage correctly?) was unanswerable from a bundle the reporter had gone to the
+trouble of attaching.
+
+Two independent faults produced it, and both are pinned here:
+
+1. `StatsController._update_primary_interface_name` throttled the expensive lookup to once per
+   15 s - but only `if self.primary_interface is not None`. With no route the lookup returns None,
+   so the guard fell through and the blocking UDP connect ran on *every* poll. The cache stopped
+   working in exactly the situation it existed for, which is also a real performance bug on the
+   GUI-adjacent path, not just a logging one.
+2. `get_primary_interface_name()` logged a warning per failed attempt. Having no route is a normal
+   recurring *state* (offline, VPN reconnecting, resuming from sleep), not an event.
+"""
+
+import logging
+import socket
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from netspeedtray.utils import network_utils as nu
+
+
+@pytest.fixture(autouse=True)
+def _reset_latch():
+    """The unreachable latch is module state - each test starts clean."""
+    nu._unreachable_since = None
+    yield
+    nu._unreachable_since = None
+
+
+class _UnreachableSocket:
+    """A socket whose connect() fails the way Windows fails with no route."""
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+    def settimeout(self, *a): pass
+    def connect(self, *a): raise OSError("[WinError 10051] unreachable network")
+
+
+def _run_offline(times):
+    with patch("socket.socket", lambda *a, **k: _UnreachableSocket()):
+        for _ in range(times):
+            assert nu.get_primary_interface_name() is None
+
+
+def test_repeated_failures_log_one_warning(caplog):
+    """100 failed attempts must produce ONE warning, not 100."""
+    with caplog.at_level(logging.DEBUG, logger="NetSpeedTray.NetworkUtils"):
+        _run_offline(100)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, f"expected 1 warning for 100 failures, got {len(warnings)}"
+
+
+def test_repeats_drop_to_debug(caplog):
+    """The repeats still exist for anyone who turns DEBUG on - they are just not in the file log."""
+    with caplog.at_level(logging.DEBUG, logger="NetSpeedTray.NetworkUtils"):
+        _run_offline(5)
+    debugs = [r for r in caplog.records if r.levelno == logging.DEBUG and "unreachable" in r.message]
+    assert len(debugs) == 4, f"expected 4 DEBUG repeats after the first warning, got {len(debugs)}"
+
+
+def test_at_info_level_a_long_outage_is_one_line(caplog):
+    """The real-world check: at the file handler's INFO level, an outage costs a single line."""
+    with caplog.at_level(logging.INFO, logger="NetSpeedTray.NetworkUtils"):
+        _run_offline(500)
+    assert len(caplog.records) == 1, (
+        f"500 failed attempts wrote {len(caplog.records)} lines at INFO; #260's bundle had 137,497"
+    )
+
+
+def test_recovery_is_logged_once_and_rearms(caplog):
+    """Coming back logs once, and a later outage warns again rather than staying silent forever."""
+    with caplog.at_level(logging.INFO, logger="NetSpeedTray.NetworkUtils"):
+        _run_offline(3)
+        nu._note_reachable()
+        _run_offline(3)
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(warns) == 2, "the second outage must warn again"
+    assert len(infos) == 1 and "reachable again" in infos[0].message
+
+
+def test_recovery_without_a_preceding_failure_is_silent(caplog):
+    """The happy path must not log anything - it runs on every poll."""
+    with caplog.at_level(logging.DEBUG, logger="NetSpeedTray.NetworkUtils"):
+        nu._note_reachable()
+    assert not [r for r in caplog.records if "reachable again" in r.message]
+
+
+def test_the_lookup_is_throttled_even_when_it_fails():
+    """The regression that caused the flood.
+
+    A failing lookup must still arm the 15s cache. Previously the guard also required
+    `primary_interface is not None`, so a None result meant the expensive blocking call ran on
+    every single poll.
+    """
+    from netspeedtray.core.controller import StatsController
+
+    c = StatsController.__new__(StatsController)
+    c.logger = logging.getLogger("test")
+    c.primary_interface = None
+    c.last_primary_check_time = 0.0
+
+    with patch("netspeedtray.core.controller.get_primary_interface_name", return_value=None) as look:
+        c._update_primary_interface_name()          # first call: must run
+        assert look.call_count == 1
+        for _ in range(60):                          # a minute of polls, still offline
+            c._update_primary_interface_name()
+        assert look.call_count == 1, (
+            f"the failing lookup ran {look.call_count} times in 60 polls - the throttle is not "
+            f"applying when it returns None"
+        )
+
+
+def test_the_throttle_still_expires():
+    """Throttling must not become 'never look again' - a NIC change has to be picked up."""
+    from netspeedtray.core.controller import StatsController
+
+    c = StatsController.__new__(StatsController)
+    c.logger = logging.getLogger("test")
+    c.primary_interface = None
+    c.last_primary_check_time = 0.0
+
+    with patch("netspeedtray.core.controller.get_primary_interface_name", return_value=None) as look:
+        c._update_primary_interface_name()
+        assert look.call_count == 1
+        # Pretend the refresh window has passed.
+        c.last_primary_check_time = time.monotonic() - (StatsController._PRIMARY_REFRESH_SEC + 1)
+        c._update_primary_interface_name()
+        assert look.call_count == 2, "the lookup must run again once the refresh window elapses"

--- a/src/netspeedtray/utils/network_utils.py
+++ b/src/netspeedtray/utils/network_utils.py
@@ -9,6 +9,7 @@ import ctypes
 import logging
 import socket
 import sys
+import time
 from ctypes import wintypes
 from dataclasses import dataclass
 from typing import Optional
@@ -46,6 +47,35 @@ def guid_to_friendly_name(guid: str) -> Optional[str]:
         logger.error(f"Error mapping GUID to friendly name: {e}", exc_info=True)
     return None
 
+# --- transient-state logging ------------------------------------------------------------------
+#
+# `get_primary_interface_name()` sits on the per-poll path. Logging a warning on every failed
+# attempt turned a normal condition - a laptop with no route - into a flood: one support bundle
+# arrived with 137,497 of its 139,638 lines from this one call, which rotated away every genuinely
+# useful entry and made the report undiagnosable (#260). Log the EDGE instead of the state.
+_unreachable_since: Optional[float] = None
+
+
+def _note_unreachable(err: BaseException) -> None:
+    """First failure warns; repeats drop to DEBUG."""
+    global _unreachable_since
+    if _unreachable_since is None:
+        _unreachable_since = time.monotonic()
+        logger.warning("No primary interface - the network looks unreachable (%s). "
+                       "Further attempts log at DEBUG until it comes back.", err)
+    else:
+        logger.debug("Primary interface still unreachable (%s).", err)
+
+
+def _note_reachable() -> None:
+    """Recovery closes the loop, so a reader can see how long the gap was."""
+    global _unreachable_since
+    if _unreachable_since is not None:
+        gap = time.monotonic() - _unreachable_since
+        _unreachable_since = None
+        logger.info("Primary interface reachable again after %.0fs.", gap)
+
+
 
 def get_primary_interface_name() -> Optional[str]:
     """
@@ -76,11 +106,15 @@ def get_primary_interface_name() -> Optional[str]:
         for iface_name, addrs in all_addrs.items():
             for addr in addrs:
                 if addr.family == socket.AF_INET and addr.address == local_ip:
+                    _note_reachable()
                     logger.debug(f"Determined primary interface: '{iface_name}' with IP {local_ip}")
                     return iface_name
                     
     except (OSError, socket.gaierror) as e:
-        logger.warning(f"Could not determine primary interface due to network error: {e}")
+        # Having no route is a NORMAL, recurring state (offline, VPN reconnecting, resuming from
+        # sleep), not an event worth a line per attempt. Log the EDGE: once on the way in, once on
+        # the way out. See _note_unreachable().
+        _note_unreachable(e)
         return None
     except Exception as e:
         logger.error(f"Unexpected error determining primary interface: {e}", exc_info=True)


### PR DESCRIPTION
A support bundle attached to #260 was **139,638 lines, of which 137,497 - 98.5% - came from a single call.** That flood rotated away every genuinely useful entry, so the question the reporter actually filed (*did the portable update stage?*) could not be answered from evidence they had gone to the trouble of sending.

```
137497  NetworkUtils | WARNING | network_utils.get_primary_interface_name:83
   303  TaskbarUtils | WARNING | taskbar_utils.get_all_taskbar_info:672
   303  TaskbarUtils | WARNING | taskbar_utils.create_primary_fallback_taskbar_info:311
   160  DatabaseWorker | INFO  | database._run_maintenance:609
   ...
```

### Two faults, and one is not a logging bug

**1. The throttle stopped applying in the exact case it exists for.** `StatsController._update_primary_interface_name` caches the expensive routing lookup to once per 15 s - but the guard also required `primary_interface is not None`:

```python
if self.primary_interface is not None and (now - self.last_primary_check_time) < self._PRIMARY_REFRESH_SEC:
```

With no route the lookup returns `None`, so the guard fell through and the **blocking UDP connect + `net_if_addrs` ran on every poll** instead of every 15 s. That is a real cost on the GUI-adjacent path - the thing the cache was written to protect (H1) - not only a log problem. Now throttled on elapsed time alone.

**2. A recurring state was logged as an event.** Having no route is normal - offline, VPN reconnecting, resuming from sleep. It now logs the **edge**: one WARNING on the way in, DEBUG for repeats, one INFO on recovery carrying the outage duration. At the file handler's INFO level, an outage of any length costs **one line**.

### Also

- **10 per-cycle database housekeeping lines demoted to DEBUG.** Migrations, schema builds, VACUUM and retention prunes **stay at INFO** - one-time or rare, and worth having in a bundle.
- **The update path is now observable.** It logged only three things, all failures, **none of which fire on a successful portable update** - which is why I could not tell @kiro5678 whether his update worked. It now records mode + version at start, the checksum verdict, and the staged result.

### Deliberately not touched

The **taskbar fallback warnings**. 606 lines, 0.4%, and they arrive in **bounded bursts** (114 in one minute when Explorer restarts) rather than as a steady leak - the burst is itself diagnostic signal. Not worth editing the Z-order path for.

### Verified

Reverted both fixes and re-ran: **5 of the 7 new tests fail**, one reporting

```
AssertionError: 500 failed attempts wrote 500 lines at INFO; #260 bundle had 137,497
```

The tests also pin that the throttle still **expires**, so this cannot become "never look again" and miss a NIC change.

1154 tests pass.