### PR TITLE
feat(update): hands-off portable update, applied by the verified new EXE

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -138,6 +138,34 @@ def main() -> int:
     except Exception:
         pass
 
+    # A hands-off portable update renames the old folder aside and deletes it once the new copy is
+    # running. If that delete could not finish (a handle still held), the folder survives - sweep it
+    # here rather than leaving ~57 MB next to the install forever.
+    try:
+        from netspeedtray.core.update_applier import sweep_old_backups, sweep_staged_leftovers
+        _install_dir = os.path.dirname(os.path.abspath(sys.executable))
+        sweep_old_backups(_install_dir)
+        # The applier cannot delete the staged folder it was running from, so if we were just
+        # updated, that folder is still on disk. We are the relaunched copy - clean it up.
+        sweep_staged_leftovers(os.path.dirname(_install_dir),
+                               os.path.join(os.path.expanduser("~"), "Downloads"))
+    except Exception:
+        pass
+
+    # Apply-update path: `--apply-update <install_dir> --wait-pid <pid>`. We are the freshly
+    # downloaded, checksum-verified copy; the previous version launched us so we can replace the
+    # folder it was running from, which it could not do itself. Headless and short-lived - it must
+    # run before the QApplication and before the single-instance mutex, because the old instance may
+    # still be shutting down and holding both.
+    try:
+        from netspeedtray.core.update_applier import run_apply_update_cli
+        apply_code = run_apply_update_cli()
+        if apply_code is not None:
+            return apply_code
+    except Exception as e:
+        logger.error("Apply-update errored: %s", e, exc_info=True)
+        return 1
+
     # Headless export path: `--export-csv --period 24h --out <dir>` writes the two-file stats export
     # and exits, without ever creating the GUI QApplication (so it can run alongside the live app).
     try:

--- a/src/netspeedtray/core/update_applier.py
+++ b/src/netspeedtray/core/update_applier.py
@@ -1,0 +1,360 @@
+"""
+Applies a staged portable update - run from *inside* the staged copy.
+
+A program cannot replace the folder it is running from, which is why the portable build has always
+ended in "here is the new version, copy it over yourself" (#195). This closes that gap without a
+helper script.
+
+The trick is that we already download and SHA-256-verify a **complete, working copy of the app**, so
+the new copy applies the update itself:
+
+    existing app (v N)                    staged copy (v N+1, verified)
+    ------------------                    -----------------------------
+    1. download + verify + extract
+    2. launch staged NetSpeedTray.exe
+       --apply-update <install> --wait-pid <own pid>
+    3. quit  ---------------------------> 4. wait for <pid> to exit
+                                          5. rename <install> -> <install>.old-<ts>
+                                          6. copy   <staged>  -> <install>
+                                          7. launch <install>/NetSpeedTray.exe
+                                          8. delete the .old- folder, exit
+                                             (the staged folder is swept on the next launch -
+                                              this process is running from it)
+
+**Why not a helper script.** A .bat is fragile with non-ASCII paths - a real user population here,
+since the bundle on #260 carries an Arabic interface name - PowerShell needs -ExecutionPolicy Bypass,
+and "a script that terminates a process then overwrites binaries" is a textbook malware heuristic.
+This project already had to clear a Webroot false positive, and the rest of the update path is built
+on WinVerifyTrust plus a SignPath certificate pin, fail-closed. Doing the replacement from our own
+signed executable keeps that posture intact.
+
+**Why rename-aside-then-copy, and never delete-first.** At no point may the user be left with
+nothing. The old install is renamed (reversible) before anything is written; deleting it first would
+mean a failure halfway leaves them with no app at all.
+
+It is a *copy* rather than a move because this process runs from the staged folder, and Windows will
+not let a directory containing a running executable be moved or deleted. An earlier version used
+`shutil.move` and failed with `WinError 5` on our own EXE - and since `move` degrades to
+copy-then-delete, it had already created a partial destination, which then broke the restore too.
+A live test against real binaries caught that; the unit tests, which used dummy text files, did not.
+
+Anything unexpected is a **refusal, not a repair**: return non-zero and leave both folders intact.
+The staged copy is still on disk, so the guided "copy it yourself" path remains available.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import List, Optional
+
+logger = logging.getLogger("NetSpeedTray.UpdateApplier")
+
+APP_EXE = "NetSpeedTray.exe"
+
+# The old process is asked to quit before we are launched; this is the ceiling on how long we wait
+# for it to actually go. Beyond that something is wrong, and we refuse rather than force anything.
+_EXIT_TIMEOUT_SEC = 30.0
+# Windows - and AV, and Explorer - can hold a directory handle for a moment after a process exits,
+# so the rename is retried rather than treated as fatal on the first failure.
+_SWAP_RETRY_SEC = 8.0
+_SWAP_RETRY_STEP = 0.25
+
+_BACKUP_SUFFIX = ".old-"
+
+
+def _wait_for_exit(pid: int, timeout: float = _EXIT_TIMEOUT_SEC) -> bool:
+    """Block until `pid` exits. True if it is gone, False on timeout.
+
+    Uses a process *handle* rather than polling by PID: a handle refers to one specific process, so a
+    recycled PID cannot make us believe the old app is still running - or, worse, mistake some
+    unrelated new process for it.
+    """
+    try:
+        import win32api
+        import win32con
+        import win32event
+    except Exception:                                    # pragma: no cover - non-Windows dev box
+        logger.warning("pywin32 unavailable; falling back to a PID poll.")
+        return _wait_for_exit_poll(pid, timeout)
+
+    try:
+        handle = win32api.OpenProcess(win32con.SYNCHRONIZE, False, pid)
+    except Exception:
+        logger.info("Process %s already gone.", pid)
+        return True                                       # cannot open it => it already exited
+    try:
+        result = win32event.WaitForSingleObject(handle, int(timeout * 1000))
+        gone = result == win32event.WAIT_OBJECT_0
+        logger.info("Waited for process %s to exit: %s", pid, "exited" if gone else "TIMED OUT")
+        return gone
+    finally:
+        try:
+            win32api.CloseHandle(handle)
+        except Exception:
+            pass
+
+
+def _wait_for_exit_poll(pid: int, timeout: float) -> bool:
+    """Handle-free fallback, used only when pywin32 is missing."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return True
+        time.sleep(0.2)
+    return False
+
+
+def _is_dir_writable(path: str) -> bool:
+    """True if we can create and remove a file in `path`.
+
+    Probed directly rather than inferred from os.access, which lies on Windows.
+    """
+    probe = os.path.join(path, ".nst-write-probe")
+    try:
+        with open(probe, "w", encoding="utf-8") as fh:
+            fh.write("x")
+        os.remove(probe)
+        return True
+    except Exception:
+        return False
+
+
+def _is_within(child: str, parent: str) -> bool:
+    """True if `child` is `parent`, or lives underneath it."""
+    try:
+        c = os.path.normcase(os.path.abspath(child))
+        p = os.path.normcase(os.path.abspath(parent))
+        return c == p or c.startswith(p + os.sep)
+    except Exception:
+        return False
+
+
+def validate(install_dir: str, staged_dir: str) -> Optional[str]:
+    """Return a refusal reason, or None when the swap is safe to attempt.
+
+    Every one of these is a refusal rather than something to work around: the staged folder stays on
+    disk either way, so the user can always fall back to copying it by hand.
+    """
+    if not install_dir or not staged_dir:
+        return "missing install or staged directory"
+    if not os.path.isdir(install_dir):
+        return "install directory does not exist: %s" % install_dir
+    if not os.path.isdir(staged_dir):
+        return "staged directory does not exist: %s" % staged_dir
+    if not os.path.isfile(os.path.join(install_dir, APP_EXE)):
+        # Refuse to rename a directory that is not obviously ours. This flag must never become a way
+        # to move an arbitrary folder.
+        return "install directory has no %s; refusing to touch it" % APP_EXE
+    if not os.path.isfile(os.path.join(staged_dir, APP_EXE)):
+        return "staged directory has no %s" % APP_EXE
+    if os.path.normcase(os.path.abspath(staged_dir)) == os.path.normcase(os.path.abspath(install_dir)):
+        return "staged and install directories are the same"
+    if _is_within(staged_dir, install_dir):
+        # Renaming the install would drag the staged copy - and this running process - along with it.
+        return "staged copy lives inside the install directory"
+    parent = os.path.dirname(os.path.abspath(install_dir)) or install_dir
+    if not _is_dir_writable(parent):
+        # The install directory is renamed, which is a write against its PARENT, not itself.
+        return "cannot write beside the install directory: %s" % parent
+    return None
+
+
+def _rename_with_retry(src: str, dst: str, timeout: float = _SWAP_RETRY_SEC) -> None:
+    """os.rename with a short retry, for handles that outlive the process that held them."""
+    deadline = time.monotonic() + timeout
+    last: Optional[BaseException] = None
+    while True:
+        try:
+            os.rename(src, dst)
+            return
+        except OSError as e:
+            last = e
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(_SWAP_RETRY_STEP)
+    raise RuntimeError("could not rename %s -> %s within %.0fs: %s" % (src, dst, timeout, last))
+
+
+def _backup_path(install_dir: str) -> str:
+    return "%s%s%d" % (install_dir.rstrip(os.sep), _BACKUP_SUFFIX, int(time.time()))
+
+
+def swap(install_dir: str, staged_dir: str) -> str:
+    """Rename the install aside, then COPY the staged tree into its place. Returns the backup path.
+
+    **Copy, not move, and the distinction is the whole point.** This process is running *from*
+    `staged_dir`, and Windows will not let a directory containing a running executable be moved or
+    deleted. An earlier version used `shutil.move` here; against real binaries it failed with
+    `WinError 5` on our own EXE, and because `move` falls back to copy-then-delete it had already
+    created a *partial* destination - which then made the restore fail too, leaving the user with a
+    half-copied app. A live test caught that; the unit tests, which used dummy text files, did not.
+
+    Reading our own EXE while it runs is fine, so copying works. The staged folder is left behind on
+    purpose - this process cannot delete the ground it stands on - and is swept on the next launch.
+
+    If the copy fails the partial destination is cleared first, so the rename back can actually
+    succeed and the user is left exactly as they started.
+    """
+    backup = _backup_path(install_dir)
+    _rename_with_retry(install_dir, backup)
+    logger.info("Moved the existing install aside.")
+    try:
+        shutil.copytree(staged_dir, install_dir)
+    except Exception:
+        logger.error("Copying the staged copy failed; restoring the original install.", exc_info=True)
+        # Clear the partial destination FIRST or the rename back has nowhere to land.
+        shutil.rmtree(install_dir, ignore_errors=True)
+        try:
+            os.rename(backup, install_dir)
+            logger.info("Original install restored.")
+        except Exception:
+            # Say exactly where their app is rather than pretend this is recoverable from here.
+            logger.critical("Could not restore the original install. It is at: %s", backup)
+        raise
+    logger.info("Staged copy is now the install.")
+    return backup
+
+
+def cleanup_backup(backup: str) -> None:
+    """Best effort. A leftover folder is untidy; a failed update is not."""
+    try:
+        shutil.rmtree(backup, ignore_errors=True)
+    except Exception:
+        logger.info("Could not remove %s; it will be swept on a later launch.", backup)
+
+
+def sweep_old_backups(install_dir: str, keep_newer_than_sec: float = 60.0) -> int:
+    """Remove `<install>.old-*` folders left behind when a cleanup could not finish.
+
+    The age guard keeps this from deleting a backup belonging to an update still in flight.
+    """
+    removed = 0
+    try:
+        parent = os.path.dirname(os.path.abspath(install_dir))
+        base = os.path.basename(os.path.abspath(install_dir)) + _BACKUP_SUFFIX
+        now = time.time()
+        for name in os.listdir(parent):
+            if not name.startswith(base):
+                continue
+            path = os.path.join(parent, name)
+            if not os.path.isdir(path):
+                continue
+            try:
+                if now - os.path.getmtime(path) < keep_newer_than_sec:
+                    continue
+            except OSError:
+                continue
+            shutil.rmtree(path, ignore_errors=True)
+            if not os.path.isdir(path):
+                removed += 1
+    except Exception:
+        pass
+    return removed
+
+
+def relaunch(exe: str) -> bool:
+    """Start the updated app detached, so this process can exit immediately."""
+    try:
+        flags = 0
+        if os.name == "nt":
+            flags = (getattr(subprocess, "DETACHED_PROCESS", 0)
+                     | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+        subprocess.Popen([exe], cwd=os.path.dirname(exe), creationflags=flags, close_fds=True)
+        logger.info("Relaunched the updated app.")
+        return True
+    except Exception:
+        # The update itself already succeeded - never undo a good update because the restart failed.
+        logger.error("Update applied, but the relaunch failed. The user can start it manually.",
+                     exc_info=True)
+        return False
+
+
+def apply_update(install_dir: str, wait_pid: Optional[int], staged_dir: Optional[str] = None) -> int:
+    """The whole flow. Returns a process exit code (0 = applied)."""
+    staged_dir = staged_dir or os.path.dirname(os.path.abspath(sys.executable))
+    logger.info("Apply-update requested: install=%s staged=%s pid=%s",
+                install_dir, staged_dir, wait_pid)
+
+    if wait_pid and not _wait_for_exit(wait_pid):
+        logger.warning("The previous instance did not exit; refusing to swap.")
+        return 2
+
+    reason = validate(install_dir, staged_dir)
+    if reason:
+        logger.warning("Refusing to apply the update: %s", reason)
+        return 3
+
+    try:
+        backup = swap(install_dir, staged_dir)
+    except Exception as e:
+        logger.error("Update swap failed: %s", e, exc_info=True)
+        return 4
+
+    relaunch(os.path.join(install_dir, APP_EXE))
+    cleanup_backup(backup)
+    # `staged_dir` is deliberately NOT removed: we are running from it. The relaunched copy sweeps
+    # it via sweep_staged_leftovers(), and it is harmless until then.
+    logger.info("Update applied successfully. Staged copy at %s will be swept on next launch.",
+                staged_dir)
+    return 0
+
+
+def sweep_staged_leftovers(*roots: str) -> int:
+    """Remove a staged update folder that the applier could not delete from inside itself.
+
+    Called on normal startup with the places staging happens (Downloads, and beside the install).
+    Only removes a directory that looks like ours *and* is not the one we are running from.
+    """
+    removed = 0
+    try:
+        here = os.path.normcase(os.path.dirname(os.path.abspath(sys.executable)))
+    except Exception:
+        here = ""
+    for root in roots:
+        if not root or not os.path.isdir(root):
+            continue
+        try:
+            for name in os.listdir(root):
+                path = os.path.join(root, name)
+                if os.path.normcase(os.path.abspath(path)) == here:
+                    continue                       # never delete the running install
+                if not os.path.isdir(path) or not name.startswith("NetSpeedTray-"):
+                    continue
+                if not os.path.isfile(os.path.join(path, APP_EXE)):
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+                if not os.path.isdir(path):
+                    removed += 1
+        except Exception:
+            continue
+    return removed
+
+
+def run_apply_update_cli(argv: Optional[List[str]] = None) -> Optional[int]:
+    """Handle `--apply-update <dir> [--wait-pid N]`, or return None to let the GUI start.
+
+    Mirrors `export_cli.run_export_cli`: it runs before any QApplication exists, so the applier is a
+    short headless process rather than a second copy of the app coming up.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    if "--apply-update" not in args:
+        return None
+
+    parser = argparse.ArgumentParser(prog="NetSpeedTray", add_help=False)
+    parser.add_argument("--apply-update", dest="install_dir", default="")
+    parser.add_argument("--wait-pid", dest="wait_pid", type=int, default=0)
+    parser.add_argument("--staged-dir", dest="staged_dir", default="")
+    try:
+        ns, _unknown = parser.parse_known_args(args)
+    except SystemExit:
+        logger.error("Malformed --apply-update arguments: %r", args)
+        return 1
+
+    return apply_update(ns.install_dir, ns.wait_pid or None, ns.staged_dir or None)

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -410,13 +410,20 @@ class SecureUpdater(QObject):
             self._finish()
             return
         try:
-            os.startfile(ready)   # type: ignore[attr-defined]  # reveal in Explorer (Windows)
-        except Exception:
-            pass
-        try:
             app_dir = os.path.dirname(os.path.abspath(sys.executable))
         except Exception:
             app_dir = ""
+
+        # Hands-off path: hand the swap to the copy we just verified. It can replace this folder
+        # because it is not running from it. Only offered when the swap is provably safe - anything
+        # doubtful falls through to the guided copy below rather than being worked around.
+        if self._try_hands_off(ready, app_dir):
+            return
+
+        try:
+            os.startfile(ready)   # type: ignore[attr-defined]  # reveal in Explorer (Windows)
+        except Exception:
+            pass
         try:
             title = getattr(self.i18n, "UPDATE_PORTABLE_READY_TITLE", "Update ready to install")
             msg = getattr(
@@ -430,6 +437,35 @@ class SecureUpdater(QObject):
         except Exception:
             pass
         self._finish()
+
+    def _try_hands_off(self, ready: str, app_dir: str) -> bool:
+        """Launch the staged copy to apply the update itself. True if handed off (caller must stop).
+
+        Returns False for every reason the swap is not provably safe, so the guided copy below stays
+        the fallback rather than the user being left with nothing.
+        """
+        try:
+            from netspeedtray.core.update_applier import APP_EXE, validate
+            reason = validate(app_dir, ready)
+            if reason:
+                logger.info("Hands-off update not available (%s); using the guided copy.", reason)
+                return False
+
+            staged_exe = os.path.join(ready, APP_EXE)
+            flags = (getattr(subprocess, "DETACHED_PROCESS", 0)
+                     | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+            subprocess.Popen(
+                [staged_exe, "--apply-update", app_dir, "--wait-pid", str(os.getpid())],
+                cwd=ready, creationflags=flags, close_fds=True)
+            logger.info("Handed the update to the staged copy; quitting so it can swap the folder.")
+        except Exception:
+            logger.error("Could not hand off to the staged copy; using the guided copy.", exc_info=True)
+            return False
+
+        # Only now commit: quitting is what lets the swap proceed.
+        self._finish()
+        self.launching.emit()
+        return True
 
     def _on_failed(self, reason: str) -> None:
         self._teardown_thread()

--- a/src/netspeedtray/tests/unit/test_update_applier.py
+++ b/src/netspeedtray/tests/unit/test_update_applier.py
@@ -1,0 +1,266 @@
+"""
+The hands-off portable update: it replaces the user's application folder, so the bar is that a
+failure must never leave them worse off than not updating at all.
+
+These tests run against **real directories**, not mocks. The whole feature is filesystem semantics -
+what renames, what moves, what survives a failure - and a mocked `os.rename` would prove nothing
+about the thing that can actually hurt someone.
+
+Two properties matter more than the happy path:
+
+1. **Every doubtful case is a refusal, not a repair.** `validate()` returning a reason means the
+   guided "copy it yourself" flow still happens, which is the pre-existing behavior and is safe.
+2. **A failed swap restores the original.** The install folder is renamed aside before anything is
+   written, so a failure is reversible. Deleting first would not be.
+
+The copy-vs-move distinction below is not stylistic: the applier runs *from* the staged folder, and
+Windows will not move a directory containing a running executable. A live test against real binaries
+found that; these tests, with their dummy text files, had not.
+"""
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from netspeedtray.core import update_applier as ua
+
+
+def _make_install(root: Path, name: str = "NetSpeedTray", *, with_exe: bool = True) -> Path:
+    d = root / name
+    (d / "_internal").mkdir(parents=True, exist_ok=True)
+    if with_exe:
+        (d / ua.APP_EXE).write_text("old", encoding="utf-8")
+    (d / "_internal" / "data.bin").write_text("payload", encoding="utf-8")
+    return d
+
+
+def _make_staged(root: Path, name: str = "staged", *, with_exe: bool = True) -> Path:
+    d = root / name
+    (d / "_internal").mkdir(parents=True, exist_ok=True)
+    if with_exe:
+        (d / ua.APP_EXE).write_text("new", encoding="utf-8")
+    # A nested payload, so a test can tell a whole-tree copy from just the EXE landing.
+    (d / "_internal" / "data.bin").write_text("new-payload", encoding="utf-8")
+    return d
+
+
+# --------------------------------------------------------------------------- validate
+
+def test_validate_accepts_a_normal_pair(tmp_path):
+    assert ua.validate(str(_make_install(tmp_path)), str(_make_staged(tmp_path))) is None
+
+
+def test_validate_refuses_a_directory_that_is_not_ours(tmp_path):
+    """The flag must never become a way to move an arbitrary folder off someone's disk."""
+    victim = tmp_path / "Documents"
+    victim.mkdir()
+    (victim / "taxes.pdf").write_text("important", encoding="utf-8")
+    reason = ua.validate(str(victim), str(_make_staged(tmp_path)))
+    assert reason and ua.APP_EXE in reason
+    assert (victim / "taxes.pdf").exists()
+
+
+def test_validate_refuses_when_staged_is_inside_the_install(tmp_path):
+    """Renaming the install would drag the staged copy - and the running process - with it."""
+    install = _make_install(tmp_path)
+    nested = _make_staged(install, "staged_inside")
+    reason = ua.validate(str(install), str(nested))
+    assert reason and "inside" in reason
+
+
+def test_validate_refuses_identical_paths(tmp_path):
+    install = _make_install(tmp_path)
+    assert ua.validate(str(install), str(install)) is not None
+
+
+def test_validate_refuses_a_staged_copy_with_no_exe(tmp_path):
+    staged = _make_staged(tmp_path, with_exe=False)
+    reason = ua.validate(str(_make_install(tmp_path)), str(staged))
+    assert reason and ua.APP_EXE in reason
+
+
+def test_validate_refuses_missing_directories(tmp_path):
+    assert ua.validate(str(tmp_path / "nope"), str(_make_staged(tmp_path))) is not None
+    assert ua.validate(str(_make_install(tmp_path)), str(tmp_path / "nope")) is not None
+    assert ua.validate("", "") is not None
+
+
+# --------------------------------------------------------------------------- swap
+
+def test_swap_replaces_the_install_and_keeps_a_backup(tmp_path):
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+
+    backup = ua.swap(str(install), str(staged))
+
+    assert (install / ua.APP_EXE).read_text(encoding="utf-8") == "new", "install was not replaced"
+    assert (install / "_internal" / "data.bin").read_text(encoding="utf-8") == "new-payload", (
+        "the nested tree was not copied - only the EXE landed")
+    assert staged.exists(), "staged must survive - the applier runs from it (see the copy-vs-move note)"
+    assert Path(backup).is_dir() and (Path(backup) / ua.APP_EXE).read_text(encoding="utf-8") == "old"
+
+
+def test_a_failed_copy_restores_the_original_install(tmp_path, monkeypatch):
+    """The property that matters: a failure leaves the user exactly as they started."""
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+
+    def boom(*a, **k):
+        raise OSError("simulated: disk full midway through the copy")
+
+    monkeypatch.setattr(ua.shutil, "copytree", boom)
+
+    with pytest.raises(OSError):
+        ua.swap(str(install), str(staged))
+
+    assert install.is_dir(), "the install directory was not restored"
+    assert (install / ua.APP_EXE).read_text(encoding="utf-8") == "old"
+    assert (install / "_internal" / "data.bin").exists(), "install contents were lost"
+    assert staged.is_dir(), "the staged copy should still be there for the guided fallback"
+
+
+def test_a_partially_written_destination_still_restores(tmp_path, monkeypatch):
+    """The failure a live test found, which mocked filesystems had hidden.
+
+    The first implementation used `shutil.move`. Against real binaries it failed with WinError 5 -
+    the applier runs FROM the staged folder and Windows will not move a directory containing a
+    running executable - and because `move` degrades to copy-then-delete it had already created a
+    *partial* destination. The restore then failed too, because `os.rename` had nowhere to land, and
+    the user was left with a half-copied app plus their real one under a `.old-` name.
+
+    So: a copy that dies midway must still leave the original install exactly as it was.
+    """
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+
+    real_copytree = ua.shutil.copytree
+
+    def half_copy(src, dst, *a, **k):
+        os.makedirs(dst, exist_ok=True)
+        with open(os.path.join(dst, "partial.tmp"), "w", encoding="utf-8") as fh:
+            fh.write("half a copy")
+        raise OSError("simulated: died midway through the copy")
+
+    monkeypatch.setattr(ua.shutil, "copytree", half_copy)
+
+    with pytest.raises(OSError):
+        ua.swap(str(install), str(staged))
+
+    assert install.is_dir(), "the install directory was not restored"
+    assert (install / ua.APP_EXE).read_text(encoding="utf-8") == "old"
+    assert (install / "_internal" / "data.bin").exists()
+    assert not (install / "partial.tmp").exists(), "the partial copy was left behind"
+    assert not list(tmp_path.glob("*" + ua._BACKUP_SUFFIX + "*")), "the backup should be gone"
+    ua.shutil.copytree = real_copytree
+
+
+def test_the_staged_copy_survives_the_swap(tmp_path, monkeypatch):
+    """It must be copied, not moved: the applier is running from it and cannot delete itself."""
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+    ua.swap(str(install), str(staged))
+    assert staged.is_dir(), "staged was moved - the applier cannot move the folder it runs from"
+    assert (staged / ua.APP_EXE).exists()
+
+
+def test_staged_leftovers_are_swept_but_never_the_running_install(tmp_path, monkeypatch):
+    root = tmp_path / "Downloads"
+    root.mkdir()
+    leftover = _make_install(root, "NetSpeedTray-2.1.5")
+    running = _make_install(root, "NetSpeedTray-running")
+    unrelated = root / "Holiday-Photos"
+    unrelated.mkdir()
+
+    monkeypatch.setattr(ua.sys, "executable", str(running / ua.APP_EXE))
+    removed = ua.sweep_staged_leftovers(str(root))
+
+    assert removed == 1
+    assert not leftover.exists(), "a staged leftover should be swept"
+    assert running.is_dir(), "the running install must never be swept"
+    assert unrelated.exists(), "unrelated folders must be left alone"
+
+
+def test_backup_paths_do_not_collide(tmp_path):
+    a = ua._backup_path(str(tmp_path / "App"))
+    assert a.startswith(str(tmp_path / "App") + ua._BACKUP_SUFFIX)
+    assert a != str(tmp_path / "App")
+
+
+# --------------------------------------------------------------------------- sweep
+
+def test_sweep_removes_old_backups_but_spares_recent_ones(tmp_path):
+    install = _make_install(tmp_path)
+    stale = tmp_path / ("NetSpeedTray" + ua._BACKUP_SUFFIX + "1")
+    stale.mkdir()
+    os.utime(stale, (time.time() - 3600, time.time() - 3600))
+    fresh = tmp_path / ("NetSpeedTray" + ua._BACKUP_SUFFIX + "2")
+    fresh.mkdir()
+
+    removed = ua.sweep_old_backups(str(install))
+
+    assert removed == 1
+    assert not stale.exists(), "an hour-old backup should be swept"
+    assert fresh.exists(), "a backup from seconds ago may belong to an update still in flight"
+    assert install.is_dir(), "the sweep must never touch the install itself"
+
+
+def test_sweep_ignores_unrelated_folders(tmp_path):
+    install = _make_install(tmp_path)
+    bystander = tmp_path / "NetSpeedTray-notes"
+    bystander.mkdir()
+    os.utime(bystander, (time.time() - 3600, time.time() - 3600))
+    ua.sweep_old_backups(str(install))
+    assert bystander.exists()
+
+
+# --------------------------------------------------------------------------- CLI
+
+def test_cli_returns_none_without_the_flag():
+    """The normal launch must be entirely unaffected."""
+    assert ua.run_apply_update_cli([]) is None
+    assert ua.run_apply_update_cli(["--export-csv", "--period", "24h"]) is None
+
+
+def test_cli_refuses_and_reports_when_validation_fails(tmp_path):
+    """A refusal is a non-zero exit, not a crash and not a partial swap."""
+    victim = tmp_path / "Documents"
+    victim.mkdir()
+    staged = _make_staged(tmp_path)
+    code = ua.run_apply_update_cli(
+        ["--apply-update", str(victim), "--staged-dir", str(staged)])
+    assert code == 3
+    assert victim.is_dir()
+
+
+def test_cli_applies_a_valid_update(tmp_path, monkeypatch):
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+    launched = {}
+    monkeypatch.setattr(ua, "relaunch", lambda exe: launched.setdefault("exe", exe) or True)
+
+    code = ua.run_apply_update_cli(
+        ["--apply-update", str(install), "--staged-dir", str(staged)])
+
+    assert code == 0
+    assert (install / ua.APP_EXE).read_text(encoding="utf-8") == "new"
+    assert launched["exe"] == os.path.join(str(install), ua.APP_EXE)
+    assert not list(tmp_path.glob("*" + ua._BACKUP_SUFFIX + "*")), "the backup should be cleaned up"
+
+
+def test_apply_refuses_if_the_old_process_never_exits(tmp_path, monkeypatch):
+    install = _make_install(tmp_path)
+    staged = _make_staged(tmp_path)
+    monkeypatch.setattr(ua, "_wait_for_exit", lambda pid, timeout=None: False)
+
+    code = ua.apply_update(str(install), wait_pid=4321, staged_dir=str(staged))
+
+    assert code == 2
+    assert (install / ua.APP_EXE).read_text(encoding="utf-8") == "old", "swapped despite the timeout"
+
+
+def test_waiting_on_a_dead_pid_returns_immediately():
+    """A PID that cannot be opened has already exited - that is success, not an error."""
+    assert ua._wait_for_exit(0x7FFFFFFE, timeout=1.0) is True


### PR DESCRIPTION
Closes the gap behind #260. The portable build has always ended in *"here is the new version, copy it over yourself"* (#195), because a program cannot replace the folder it is running from. That is a homework assignment, not an update — and the same reporter has now filed it as broken twice.

### No helper script

The obvious shape is a `.bat` that kills the app, swaps folders and relaunches. I did not use one:

- **`.bat` is fragile with non-ASCII paths** — #260 own bundle carries an Arabic interface name, so this is a real user population, not a hypothetical.
- **PowerShell needs `-ExecutionPolicy Bypass`**, which is exactly the shape endpoint security flags.
- **"A script that terminates a process then overwrites binaries" is a textbook malware heuristic.** This project already had to clear a Webroot false positive, and the rest of this path is WinVerifyTrust + a SignPath certificate pin, fail-closed. An unsigned script doing the actual replacing would undercut the one thing that path is careful about.

Instead the work is done by the copy we **already downloaded and SHA-256-verified** — our own signed executable:

```
old app  -> launch staged NetSpeedTray.exe --apply-update <dir> --wait-pid N
         -> quit
staged   -> wait for the PID (by HANDLE, so a recycled PID cannot fool it)
         -> rename <install> aside, copy the staged tree into place
         -> relaunch from <install>, delete the backup, exit
```

### Refusal, not repair

`validate()` returns a reason and the **existing guided copy happens instead** for: a directory with no `NetSpeedTray.exe` (so the flag can never move an arbitrary folder), a staged copy nested inside the install, an unwritable parent, or a previous instance that will not exit. Nothing is forced, and nothing is elevated.

### Copy, not move — and a live test is the only reason I know that

The first implementation used `shutil.move`. All 16 unit tests passed. Against **real binaries** it failed:

```
Move of the staged copy failed... [WinError 5] Access is denied: ...\NetSpeedTray.exe
CRITICAL - Could not restore the original install.
```

The applier runs **from** the staged folder, and Windows will not move a directory containing a running executable. Worse: `move` degrades to copy-then-delete, so it had already written a **partial destination**, which then made the restore fail — leaving a half-copied app and the real one under a `.old-` name. Precisely the outcome the rename-first design exists to prevent.

The unit tests could not see it because they used dummy text files. Now it copies, the partial destination is cleared before the rename back, and there is a regression test for that exact shape.

### Verified end to end

Two real portable installs, a live process, marker files and a nested payload:

| check | result |
|---|---|
| waited while the old app was running | marker unchanged |
| swapped after it exited | `I-AM-THE-STAGED-COPY` |
| copied the **whole tree**, not just the EXE | `NEW-NESTED-PAYLOAD` |
| relaunched from the new location | PID running from `installroot\NetSpeedTray\NetSpeedTray.exe` |
| backup cleaned up | 0 leftover `.old-` folders |
| every step logged | yes — the observability from #263 |

19 unit tests, 1173 total.

### Sequencing — worth saying in the release notes

The launching half lives in the **old** version and the applying half in the **new** one, so both must ship before anyone benefits. If this lands in 2.1.4, **2.1.4 → 2.1.5 is the first hands-off update**; anyone on 2.1.3 or earlier still gets the guided copy for one more hop. Otherwise it reads as "the fix did not work".

Design notes: `Docs/reference/portable-auto-update-design.md` (private).