### PR TITLE
fix(gpu): total VRAM no longer depends on where the temperature comes from

### DIFF
--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -373,7 +373,14 @@ class StatsMonitorThread(QThread):
         # 4. nvidia-smi fallback for temp/power (vram_total comes as bonus). The subprocess
         #    runs on a slow sub-cadence; values are cached and reused on intervening polls so
         #    a synchronous (up to 1.5s) nvidia-smi call never stalls the network readout.
-        if self._nvidia_smi_path and (need_smi_temp or need_smi_power):
+        # Total VRAM is a property of the card, not a reading, so it is fetched once and cached for
+        # the life of the process - which is why asking for it here costs nothing on later polls.
+        # It has to be its own reason to call nvidia-smi: this used to run only when temp or power
+        # were needed FROM it, so with LibreHardwareMonitor supplying those, nvidia-smi never ran and
+        # the total silently never arrived. Users saw VRAM as used-only with LHM open and used/total
+        # with it closed, which is a bizarre thing to have to notice (#250).
+        need_smi_vram_total = self._nvidia_cache_vram_total is None
+        if self._nvidia_smi_path and (need_smi_temp or need_smi_power or need_smi_vram_total):
             now_mono = time.monotonic()
             if (now_mono - self._nvidia_last_poll) >= self._NVIDIA_POLL_INTERVAL_SEC:
                 # Stamp first: a hung/failed call then waits the full interval before retry,
@@ -415,8 +422,11 @@ class StatsMonitorThread(QThread):
                 temp_c = self._nvidia_cache_temp
             if need_smi_power and power_w is None and self._nvidia_cache_power is not None:
                 power_w = self._nvidia_cache_power
-            if vram_total is None and self._nvidia_cache_vram_total is not None:
-                vram_total = self._nvidia_cache_vram_total
+
+        # Outside the gate on purpose: once the total is known it applies on every poll, whatever the
+        # reason nvidia-smi did or did not run this time round.
+        if vram_total is None and self._nvidia_cache_vram_total is not None:
+            vram_total = self._nvidia_cache_vram_total
 
         # 5. RAPL PP1 fallback for Intel iGPU power (if no LHM/nvidia-smi power).
         # Init the PDH query FIRST (it's idempotent and sets _power_pp1_counter on first call) -

--- a/src/netspeedtray/tests/unit/test_hardware_monitoring.py
+++ b/src/netspeedtray/tests/unit/test_hardware_monitoring.py
@@ -66,6 +66,7 @@ class TestHardwareMonitoring:
         monitor_thread._nvidia_smi_path = "nvidia-smi"
 
         mock_get_val.return_value = (None, 55.0)
+        monitor_thread._nvidia_cache_vram_total = 8192.0   # already known: not a reason to call smi
 
         # Set up a mock LHM WMI object
         mock_ohm = MagicMock()
@@ -80,13 +81,14 @@ class TestHardwareMonitoring:
             result = monitor_thread._poll_gpu_hybrid()
 
             assert result.temp == 68.0            # From LHM, not nvidia-smi
-            mock_sub.assert_not_called()   # nvidia-smi not reached when LHM provides temp
+            mock_sub.assert_not_called()   # LHM supplies temp, and the total is already known
 
     @patch('win32pdh.GetFormattedCounterValue')
     @patch('win32pdh.CollectQueryData')
     def test_poll_gpu_hybrid_no_temp_flag(self, mock_collect, mock_get_val, monitor_thread):
         """With include_temp=False and include_power=False, nvidia-smi is not called."""
         monitor_thread._gpu_query = 123
+        monitor_thread._nvidia_cache_vram_total = 8192.0   # already known: not a reason to call smi
         monitor_thread._gpu_util_counter = 1
         monitor_thread._gpu_vram_counter = None
         monitor_thread._nvidia_smi_path = "nvidia-smi"
@@ -98,7 +100,7 @@ class TestHardwareMonitoring:
 
             assert result.temp is None
             assert result.power is None
-            mock_sub.assert_not_called()  # No subprocess call when neither temp nor power needed
+            mock_sub.assert_not_called()  # nothing needed, and the total is already known
 
     def test_poll_gpu_hybrid_no_smi(self, monitor_thread):
         """AMD/Intel with no nvidia-smi and no LHM: total, temp, and power are None."""
@@ -189,13 +191,79 @@ class TestHardwareMonitoring:
 
         mock_ohm.ExecQuery.side_effect = mock_exec_query
         monitor_thread._wmi_ohm = mock_ohm
+        monitor_thread._nvidia_cache_vram_total = 8192.0   # already known: not a reason to call smi
 
         with patch('subprocess.check_output') as mock_sub:
             result = monitor_thread._poll_gpu_hybrid(include_temp=True, include_power=True)
 
             assert result.temp == 72.0
             assert result.power == 95.2
-            mock_sub.assert_not_called()  # nvidia-smi not needed
+            mock_sub.assert_not_called()  # LHM supplies both, and the total is already known
+
+    @patch('win32pdh.GetFormattedCounterValue')
+    @patch('win32pdh.CollectQueryData')
+    def test_total_vram_arrives_even_when_lhm_supplies_temp_and_power(
+            self, mock_collect, mock_get_val, monitor_thread):
+        """#250: total VRAM must not depend on where the temperature comes from.
+
+        nvidia-smi used to run only when temp or power were needed FROM it. With
+        LibreHardwareMonitor supplying both, it never ran - and `memory.total`, which only that call
+        provides, silently never arrived. The reporter saw VRAM as used-only with LHM open and
+        used/total with it closed, which is a very strange thing to have to notice.
+        """
+        monitor_thread._gpu_query = 123
+        monitor_thread._gpu_util_counter = 1
+        monitor_thread._gpu_vram_counter = None
+        monitor_thread._nvidia_smi_path = "nvidia-smi"
+        monitor_thread._nvidia_cache_vram_total = None       # the total is NOT yet known
+        monitor_thread._nvidia_last_poll = -9999.0           # bypass the sub-cadence throttle
+        mock_get_val.return_value = (None, 55.0)
+
+        # LHM supplies temperature, so the old gate would have skipped nvidia-smi entirely.
+        mock_ohm = MagicMock()
+        sensor = MagicMock()
+        sensor.Value = 68.0
+        sensor.Identifier = "/nvidiagpu/0/temperature/0"
+        sensor.Name = "GPU Core"
+        mock_ohm.ExecQuery.return_value = [sensor]
+        monitor_thread._wmi_ohm = mock_ohm
+
+        with patch('subprocess.check_output', return_value="68, 8192, 95.2\n") as mock_sub:
+            result = monitor_thread._poll_gpu_hybrid(include_temp=True, include_power=False)
+            mock_sub.assert_called_once()                    # called for the total, not the temp
+
+        assert result.temp == 68.0, "temperature must still come from LHM"
+        assert result.vram_total == 8192.0, "total VRAM never arrived - this is the #250 bug"
+
+    @patch('win32pdh.GetFormattedCounterValue')
+    @patch('win32pdh.CollectQueryData')
+    def test_a_known_total_vram_is_applied_without_calling_smi(
+            self, mock_collect, mock_get_val, monitor_thread):
+        """Once known, the cached total applies on every poll - it is a property of the card.
+
+        The application used to sit *inside* the same gate, so even an already-cached total was
+        dropped on any poll where nvidia-smi was not called.
+        """
+        monitor_thread._gpu_query = 123
+        monitor_thread._gpu_util_counter = 1
+        monitor_thread._gpu_vram_counter = None
+        monitor_thread._nvidia_smi_path = "nvidia-smi"
+        monitor_thread._nvidia_cache_vram_total = 8192.0
+        mock_get_val.return_value = (None, 55.0)
+
+        mock_ohm = MagicMock()
+        sensor = MagicMock()
+        sensor.Value = 68.0
+        sensor.Identifier = "/nvidiagpu/0/temperature/0"
+        sensor.Name = "GPU Core"
+        mock_ohm.ExecQuery.return_value = [sensor]
+        monitor_thread._wmi_ohm = mock_ohm
+
+        with patch('subprocess.check_output') as mock_sub:
+            result = monitor_thread._poll_gpu_hybrid(include_temp=True, include_power=False)
+            mock_sub.assert_not_called()
+
+        assert result.vram_total == 8192.0, "a cached total must survive a poll that skips smi"
 
     # ------------------------------------------------------------------
     # CPU power polling


### PR DESCRIPTION
Reported incidentally by @PilaScat on #250, while we were discussing something else entirely:

> when I have LHM open it doesn't show me the total VRAM but only the one in use, when it's closed instead it does

That is a very strange thing to have to notice, and the cause is exactly that odd.

### Cause

`memory.total` is only ever supplied by `nvidia-smi`, and that call was gated on whether temperature or power were needed **from it**:

```python
if self._nvidia_smi_path and (need_smi_temp or need_smi_power):
```

With LibreHardwareMonitor running, LHM supplies temp and power, so both flags are false, `nvidia-smi` never runs, and the total never arrives. **Total VRAM was a side effect of a call made for a different reason** — the comment in the code even said so: *"vram_total comes as bonus"*.

Two faults, both fixed:

1. **The total is now its own reason to call `nvidia-smi`.** It is a property of the card rather than a reading, so it is fetched **once** and cached for the life of the process — asking for it costs nothing on later polls.
2. **Applying the cached total moved outside that gate.** It used to sit inside, so even an already-known total was dropped on any poll where `nvidia-smi` was not called.

### About the three tests I changed

`test_poll_gpu_hybrid_lhm_temp`, `test_poll_gpu_hybrid_no_temp_flag` and the LHM temp+power test all asserted `nvidia-smi.assert_not_called()`. That was **the bug stated as a requirement**.

They now seed a known total first, so they assert the thing they were always about — LHM supplies the readings — instead of forbidding the one call that fetches the total. Two new tests cover the corrected contract, including that a cached total survives a poll where `nvidia-smi` is skipped.

**Verified by reverting the fix: both new tests fail on the old gating.** 1175 tests pass.