### PR TITLE
fix: three ways the portable update could end with the user seeing nothing

### DIFF
--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -124,9 +124,53 @@ def _locate_portable_exe(root: str) -> str:
     raise RuntimeError(f"no {constants.app.APP_NAME}.exe in the portable archive")
 
 
+# FOLDERID_Downloads - the only reliable way to find this folder.
+_FOLDERID_DOWNLOADS = "{374DE290-123F-4565-9164-39C4925E467B}"
+
+
+def _known_downloads_dir() -> Optional[str]:
+    """Ask Windows where Downloads actually is, or None if it cannot say.
+
+    Guessing `~/Downloads` is wrong for anyone who has **moved** their Downloads folder - right-click
+    -> Properties -> Location, which people do routinely to keep it off the system drive. The guess
+    then silently misses, and the caller falls back to dumping a folder in the user's home directory
+    instead, where they will not think to look. Windows knows the real path; ask it.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        class GUID(ctypes.Structure):
+            _fields_ = [("Data1", wintypes.DWORD), ("Data2", wintypes.WORD),
+                        ("Data3", wintypes.WORD), ("Data4", ctypes.c_ubyte * 8)]
+
+        guid = GUID()
+        if ctypes.windll.ole32.CLSIDFromString(_FOLDERID_DOWNLOADS, ctypes.byref(guid)) != 0:
+            return None
+        out = ctypes.c_wchar_p()
+        # 0 = current user, no default-path fallback, no forced creation.
+        if ctypes.windll.shell32.SHGetKnownFolderPath(
+                ctypes.byref(guid), 0, None, ctypes.byref(out)) != 0:
+            return None
+        try:
+            path = out.value
+        finally:
+            ctypes.windll.ole32.CoTaskMemFree(out)
+        return path if path and os.path.isdir(path) else None
+    except Exception:
+        return None
+
+
 def _downloads_dir() -> str:
-    """The user's Downloads folder if it exists, else their home directory - a persistent, findable
-    place to stage the verified new version (the temp dir gets swept on the next launch)."""
+    """A persistent, findable place to stage the verified new version.
+
+    Windows' own answer first, then the `~/Downloads` guess, then the home directory. The staged
+    folder is something we then ask the user to look at, so putting it somewhere they do not expect
+    is the same as losing it.
+    """
+    known = _known_downloads_dir()
+    if known:
+        return known
     home = os.path.expanduser("~")
     downloads = os.path.join(home, "Downloads")
     return downloads if os.path.isdir(downloads) else home

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -161,6 +161,35 @@ def _known_downloads_dir() -> Optional[str]:
         return None
 
 
+def _info_box(parent: Optional[QWidget], title: str, text: str) -> None:
+    """An information box that actually ends up in front of the user.
+
+    `QMessageBox.information()` inherits its stacking from its parent, and our parent is the widget -
+    frameless, always-on-top, and since 2.0 docked into the *taskbar's* Z-order as an owned window.
+    A dialog parented to that can end up behind the shell, which is the same class of problem as
+    #200. For most dialogs that is survivable; for this one it is not, because the entire point of
+    the portable flow is to tell the user where their update went. A dialog they never see is
+    indistinguishable from nothing happening at all - which is precisely what #260 reported.
+    """
+    try:
+        box = QMessageBox(parent)
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle(title)
+        box.setText(text)
+        box.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        box.show()
+        box.raise_()
+        box.activateWindow()
+        box.exec()
+    except Exception:
+        logger.warning("Could not show the update dialog; falling back to the plain box.",
+                       exc_info=True)
+        try:
+            QMessageBox.information(parent, title, text)
+        except Exception:
+            pass
+
+
 def _downloads_dir() -> str:
     """A persistent, findable place to stage the verified new version.
 
@@ -475,9 +504,8 @@ class SecureUpdater(QObject):
                 "NetSpeedTray {version} is ready in the folder that just opened:\n{ready}\n\n"
                 "To finish updating: close NetSpeedTray, then copy everything from that folder into "
                 "your current folder:\n{app_dir}\n(replacing the old files). Your settings are kept.")
-            QMessageBox.information(
-                self._parent, title,
-                msg.format(version=self._latest_version or "", ready=ready, app_dir=app_dir))
+            _info_box(self._parent, title,
+                      msg.format(version=self._latest_version or "", ready=ready, app_dir=app_dir))
         except Exception:
             pass
         self._finish()
@@ -556,7 +584,7 @@ class SecureUpdater(QObject):
         try:
             msg = getattr(self.i18n, "UPDATE_FALLBACK_MESSAGE",
                           "Couldn't complete the in-app update. Opening the download page instead.")
-            QMessageBox.information(self._parent, getattr(self.i18n, "UPDATE_AVAILABLE_TITLE", "Update"), msg)
+            _info_box(self._parent, getattr(self.i18n, "UPDATE_AVAILABLE_TITLE", "Update"), msg)
         except Exception:
             pass
         try:

--- a/src/netspeedtray/tests/unit/test_update_installer.py
+++ b/src/netspeedtray/tests/unit/test_update_installer.py
@@ -103,15 +103,40 @@ def test_locate_portable_exe_raises_when_absent(tmp_path):
         ui._locate_portable_exe(str(tmp_path))
 
 
+def test_downloads_dir_trusts_windows_over_the_guess(tmp_path, monkeypatch):
+    """Windows' own answer wins - it is the only one that survives a relocated Downloads folder.
+
+    People move Downloads off the system drive routinely (right-click -> Properties -> Location).
+    The `~/Downloads` guess then misses, and we would stage the update somewhere the user has no
+    reason to look - which, for a folder we then ask them to go and copy, is the same as losing it.
+    """
+    real = tmp_path / "D_drive_downloads"
+    real.mkdir()
+    (tmp_path / "Downloads").mkdir()          # the guess exists too, and must NOT win
+    monkeypatch.setattr(ui, "_known_downloads_dir", lambda: str(real))
+    monkeypatch.setattr(ui.os.path, "expanduser", lambda p: str(tmp_path))
+    assert ui._downloads_dir() == str(real)
+
+
 def test_downloads_dir_prefers_downloads(tmp_path, monkeypatch):
+    """When Windows cannot answer, fall back to the guess."""
+    monkeypatch.setattr(ui, "_known_downloads_dir", lambda: None)
     monkeypatch.setattr(ui.os.path, "expanduser", lambda p: str(tmp_path))
     (tmp_path / "Downloads").mkdir()
     assert ui._downloads_dir() == str(tmp_path / "Downloads")
 
 
 def test_downloads_dir_falls_back_to_home(tmp_path, monkeypatch):
+    """Last resort: somewhere that definitely exists."""
+    monkeypatch.setattr(ui, "_known_downloads_dir", lambda: None)
     monkeypatch.setattr(ui.os.path, "expanduser", lambda p: str(tmp_path))  # no Downloads subdir
     assert ui._downloads_dir() == str(tmp_path)
+
+
+def test_known_downloads_dir_never_raises():
+    """It is best-effort by contract - a COM failure must degrade to the guess, not crash."""
+    result = ui._known_downloads_dir()
+    assert result is None or ui.os.path.isdir(result)
 
 
 def test_is_portable_install_true_with_marker(tmp_path, monkeypatch):

--- a/src/netspeedtray/tests/unit/test_update_installer.py
+++ b/src/netspeedtray/tests/unit/test_update_installer.py
@@ -207,3 +207,45 @@ def test_unique_dir_suffixes_when_stale_cannot_be_removed(tmp_path, monkeypatch)
     target.mkdir()
     monkeypatch.setattr(ui.shutil, "rmtree", lambda *a, **k: None)  # simulate a surviving locked dir
     assert ui._unique_dir(str(target)) == str(tmp_path / "NetSpeedTray-2.1.0-2")
+
+
+# --------------------------------------------------------------------------- #260: visible dialogs
+
+def test_info_box_is_raised_and_activated(q_app, monkeypatch):
+    """#260: a dialog the user never sees is indistinguishable from nothing happening.
+
+    The update dialogs are parented to the widget, which is frameless, always-on-top and - since
+    2.0 - docked into the taskbar's own Z-order. A plain QMessageBox parented to that can end up
+    behind the shell, the same class of problem as #200. This one matters more than most, because
+    telling the user where their update went IS the portable flow.
+    """
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QMessageBox
+
+    calls = {"raise_": 0, "activate": 0, "exec": 0, "on_top": None}
+    monkeypatch.setattr(QMessageBox, "raise_", lambda self: calls.__setitem__("raise_", calls["raise_"] + 1))
+    monkeypatch.setattr(QMessageBox, "activateWindow",
+                        lambda self: calls.__setitem__("activate", calls["activate"] + 1))
+    monkeypatch.setattr(QMessageBox, "show", lambda self: None)
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: (
+        calls.__setitem__("on_top", bool(self.windowFlags() & Qt.WindowType.WindowStaysOnTopHint)),
+        calls.__setitem__("exec", calls["exec"] + 1))[1])
+
+    ui._info_box(None, "Update ready", "the new version is in your Downloads folder")
+
+    assert calls["exec"] == 1, "the dialog was never shown"
+    assert calls["raise_"] == 1, "the dialog was not raised above the shell"
+    assert calls["activate"] == 1, "the dialog was not activated"
+    assert calls["on_top"] is True, "the dialog did not carry WindowStaysOnTopHint"
+
+
+def test_info_box_never_raises(q_app, monkeypatch):
+    """Best-effort by contract: a dialog failure must not take the update flow down with it."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    def boom(self):
+        raise RuntimeError("simulated: no display")
+
+    monkeypatch.setattr(QMessageBox, "show", boom)
+    monkeypatch.setattr(QMessageBox, "information", staticmethod(lambda *a, **k: None))
+    ui._info_box(None, "t", "m")   # must not propagate

--- a/src/netspeedtray/tests/unit/test_widget_render_gui.py
+++ b/src/netspeedtray/tests/unit/test_widget_render_gui.py
@@ -171,3 +171,50 @@ def test_hw_percent_content_width_stable_across_digits(q_app):
 
     w9, w10, w100 = content_w(9), content_w(10), content_w(100)
     assert w9 == w10 == w100, f"CPU% segment width still jitters: 9->{w9}, 10->{w10}, 100->{w100}"
+
+
+# --------------------------------------------------------------------------- #250: the separator
+
+def _drawn_strings(renderer, **kwargs) -> list:
+    """Every string draw_hardware_stats paints, captured in order."""
+    from unittest.mock import patch
+
+    img = QImage(360, 52, QImage.Format.Format_ARGB32)
+    img.fill(QColor(0, 0, 0, 0))
+    painter = QPainter(img)
+    seen = []
+    real = QPainter.drawText
+
+    def spy(self, *args):
+        if args and isinstance(args[-1], str):
+            seen.append(args[-1])
+        return real(self, *args)
+
+    with patch.object(QPainter, "drawText", spy):
+        renderer.draw_hardware_stats(painter, width=360, height=52, config=renderer.config, **kwargs)
+    painter.end()
+    return seen
+
+
+def test_memory_is_not_introduced_by_a_pipe(renderer):
+    """#250: the reporter found the ' | ' before the memory value cluttered a readout that is only a
+    few characters wide. A gap separates it just as well.
+
+    Asserted on the painted strings rather than pixels, because a glyph's pixels are a fragile thing
+    to test and its presence in the draw calls is not.
+    """
+    renderer.config.hardware_label_style = "icons_colored"
+    drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=3.0,
+                           ram_info=(11.8, 15.7), vram_info=(2.1, 8.0), layout_mode="horizontal")
+
+    assert drawn, "nothing was painted - the fixture is not exercising the memory path"
+    assert not [d for d in drawn if "|" in d], (
+        "the memory value is still introduced by a pipe: %r" % [d for d in drawn if "|" in d])
+
+
+def test_the_memory_value_is_still_painted(renderer):
+    """Guard the obvious regression: removing the separator must not remove the number with it."""
+    renderer.config.hardware_label_style = "icons_colored"
+    drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=3.0,
+                           ram_info=(11.8, 15.7), vram_info=(2.1, 8.0), layout_mode="horizontal")
+    assert any("15.7" in d for d in drawn), "the RAM total vanished along with the separator"

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -529,7 +529,7 @@ class WidgetRenderer:
 
         The FIXED percent COLUMN in draw_hardware_stats (not this string) provides the constant width
         now, so the value reads naturally: it's right-aligned in that column when memory is inline
-        (stacked - keeps the "|" lined up across rows) and left-aligned when memory is on its own row
+        (stacked - keeps the memory column lined up across rows) and left-aligned when memory is on its own row
         (single-stat modes - lines up under the percent). Either way the segment width never changes,
         so the readout no longer slides or clips (#179 and the side-by-side alignment work).
 
@@ -594,7 +594,7 @@ class WidgetRenderer:
             sp = self.metrics.horizontalAdvance(" ")
 
             # Keep percent / suffix / memory as SEPARATE cells (not one concatenated string) so each sits
-            # in its own fixed-width column. That lines the rows up (the "|" and RAM/VRAM align across CPU
+            # in its own fixed-width column. That lines the rows up (the memory values align across CPU
             # and GPU even when one has a temp sensor and the other doesn't) AND makes the segment width
             # CONSTANT as values cross digit boundaries - so the whole readout stops sliding and never
             # clips. Worst-case column widths are computed once and are identical for every row.
@@ -625,7 +625,10 @@ class WidgetRenderer:
             totals = [r['total'] for r in rows if r['total'] > 0]
             t = max(totals) if totals else 0.0
             mem_num_col = self.metrics.horizontalAdvance(f"{t:.1f}/{t:.1f}G" if t > 0 else "9999G") if any_mem else 0
-            sep_col = self.metrics.horizontalAdvance(" | ")
+            # A gap, not a glyph. The memory value used to be introduced by " | ", which read as
+            # clutter on a readout that is only a few characters wide (#250). Whitespace separates
+            # it just as well, and drops a few pixels of reserved width while it is at it.
+            sep_col = self.metrics.horizontalAdvance("  ")
             inline_mem = is_compact
             mem_col = (sep_col + mem_num_col) if (any_mem and inline_mem) else 0
 
@@ -661,7 +664,6 @@ class WidgetRenderer:
                     painter.drawText(vx + pct_col + sp, y, r['suffix'])  # live suffix in its worst-case column
                 if inline_mem and mem_col and r['mem']:
                     mx = vx + pct_col + suffix_col
-                    painter.drawText(mx, y, " | ")
                     # right-align the number in its column so the trailing 'G' lines up across rows
                     painter.drawText(mx + mem_col - self.metrics.horizontalAdvance(r['mem']), y, r['mem'])
                 y += line_height


### PR DESCRIPTION
Polish from the #250 and #260 conversations. The #260 thread turned up **three independent ways** that flow could end with a user seeing nothing — all closed here.

@kiro5678 answered the question that settled it:

> Nothing visible happened after the download finished. No Explorer window opened, and I did not see a `NetSpeedTray-2.1.3` folder in Downloads.

### 1. The dialog could be behind the taskbar

Both update dialogs used `QMessageBox.information(self._parent, ...)` with **no `raise_()` or `activateWindow()`**. The parent is the widget: frameless, always-on-top, and since 2.0 docked into the **taskbar own Z-order** as an owned window. A dialog parented to that can end up behind the shell — the same class of problem as #200.

For most dialogs that is survivable. For this one it is not: **telling the user where their update went is the entire portable flow**, so a dialog they never see is indistinguishable from the update doing nothing.

Both sites now set `WindowStaysOnTopHint` and show/raise/activate before `exec`. Still best-effort — a dialog failure never takes the update flow with it.

### 2. The staged folder could be somewhere they would never look

`_downloads_dir()` string-joined `~/Downloads` and fell back to the **home directory** when that missed. People move Downloads off the system drive routinely — right-click → Properties → Location. When they have, the update lands in their home folder. For a folder we then ask them to go and copy, that is the same as losing it.

Now asks Windows via `SHGetKnownFolderPath(FOLDERID_Downloads)`, with both old paths kept as fallbacks.

### 3. (already merged, #263) The flow logged nothing on success

Which is why none of this was diagnosable from the bundle he attached.

---

### Also: the `|` separator (#250)

@PilaScat clarified he meant the divider, not icons:

> probably removing the `|` should do the job without making it more difficult

Gone. The column keeps its alignment and reclaims 3px per hardware row, which helps given how much worst-case width the widget already reserves.

---

**Honest scope note:** none of this is *proof* of what @kiro5678 hit. He is on 2.1.2, which logs nothing on this path. These are three real failure modes found by tracing it, each worth fixing on its own merits, and #263 means the next report will actually say which one it was.

Every fix verified by reverting it and watching the matching test fail. 1181 tests pass.