### PR TITLE
fix(widget): show nothing for VRAM on an integrated GPU, not 0.0G

### DIFF
--- a/src/netspeedtray/tests/unit/test_widget_render_gui.py
+++ b/src/netspeedtray/tests/unit/test_widget_render_gui.py
@@ -218,3 +218,41 @@ def test_the_memory_value_is_still_painted(renderer):
     drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=3.0,
                            ram_info=(11.8, 15.7), vram_info=(2.1, 8.0), layout_mode="horizontal")
     assert any("15.7" in d for d in drawn), "the RAM total vanished along with the separator"
+
+
+# --------------------------------------------------------------------------- iGPU VRAM
+
+def test_igpu_vram_is_blank_not_zero(renderer):
+    """An integrated GPU has no dedicated video memory, and PDH dutifully reports 0.0 GB.
+
+    Painting "0.0G" spends widget width to say nothing, and reads as a measurement rather than an
+    absence. The Monitor's Overview tile has always hidden itself in this case; the widget and the
+    Hardware telemetry strip had not, which is the drift this closes.
+    """
+    renderer.config.hardware_label_style = "icons_colored"
+    drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=3.0,
+                           ram_info=(9.2, 15.7),      # real RAM: total known
+                           vram_info=(0.0, 0.0),      # iGPU: nothing dedicated, no total
+                           layout_mode="horizontal")
+
+    assert any("15.7" in d for d in drawn), "RAM must still be painted"
+    assert not [d for d in drawn if "0.0G" in d], (
+        "the iGPU still paints a 0.0G: %r" % [d for d in drawn if "0.0G" in d])
+
+
+def test_a_real_gpu_with_vram_still_shows_it(renderer):
+    """The guard must not swallow a genuine reading."""
+    renderer.config.hardware_label_style = "icons_colored"
+    drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=30.0,
+                           ram_info=(9.2, 15.7), vram_info=(2.1, 8.0),
+                           layout_mode="horizontal")
+    assert any("2.1" in d and "8.0" in d for d in drawn), "a real VRAM reading was hidden"
+
+
+def test_a_gpu_with_no_total_but_real_usage_still_shows_it(renderer):
+    """AMD/Intel dGPUs have no nvidia-smi, so no total - but their usage is still worth showing."""
+    renderer.config.hardware_label_style = "icons_colored"
+    drawn = _drawn_strings(renderer, cpu_usage=8.0, gpu_usage=30.0,
+                           ram_info=(9.2, 15.7), vram_info=(2.5, 0.0),
+                           layout_mode="horizontal")
+    assert any("2.5G" in d for d in drawn), "usage without a known total was hidden"

--- a/src/netspeedtray/utils/helpers.py
+++ b/src/netspeedtray/utils/helpers.py
@@ -77,6 +77,25 @@ def get_app_data_path() -> Path:
         raise OSError(f"Error with app data directory: {path}. Check disk space or path validity.") from e
 
 
+# An integrated GPU has no dedicated video memory, and the PDH counter dutifully reports 0.0 GB for
+# it. Rendering that as "0.0G" spends widget width to tell the user nothing - worse, it reads as a
+# measurement rather than an absence. Treat a reading this small as "there is nothing here".
+VRAM_READING_FLOOR_GB: float = 0.05
+
+
+def has_dedicated_vram(used: Optional[float]) -> bool:
+    """True when a GPU reports dedicated video memory worth displaying.
+
+    Kept in one place because three call sites need the same answer and had drifted: the Monitor's
+    Overview tile already hid itself on an iGPU, while the widget and the Hardware telemetry strip
+    both showed a flat "0.0 GB".
+    """
+    try:
+        return used is not None and float(used) >= VRAM_READING_FLOOR_GB
+    except (TypeError, ValueError):
+        return False
+
+
 def is_portable_install() -> bool:
     """
     True when the app is running as the portable ZIP build.

--- a/src/netspeedtray/utils/widget_renderer.py
+++ b/src/netspeedtray/utils/widget_renderer.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from dataclasses import dataclass, field
 
 from netspeedtray.core.widget_state import SpeedDataSnapshot, AggregatedSpeedData
-from netspeedtray.utils.helpers import format_speed, calculate_monotone_cubic_interpolation
+from netspeedtray.utils.helpers import has_dedicated_vram, format_speed, calculate_monotone_cubic_interpolation
 from PyQt6.QtGui import QPainter, QColor, QFont, QFontMetrics, QPen, QPainterPath
 from PyQt6.QtCore import Qt, QPointF, QRect, QRectF
 from netspeedtray import constants
@@ -603,7 +603,14 @@ class WidgetRenderer:
                 mem_text, total = "", 0.0
                 if mem_info and mem_info[0] is not None:
                     used, total = mem_info[0], (mem_info[1] or 0.0)
-                    mem_text = f"{used:.1f}/{total:.1f}G" if total > 0 else f"{used:.1f}G"
+                    # An iGPU has no dedicated VRAM and PDH reports 0.0 for it. Draw nothing rather
+                    # than spend width on a "0.0G" that reads like a measurement. RAM is unaffected:
+                    # it always has a real total. Matches the Monitor's Overview tile, which has
+                    # always hidden itself in this case.
+                    if total <= 0 and not has_dedicated_vram(used):
+                        mem_text = ""
+                    else:
+                        mem_text = f"{used:.1f}/{total:.1f}G" if total > 0 else f"{used:.1f}G"
                 rows.append({'label': label, 'color': color_hex, 'total': total,
                              'pct': self._fmt_hw_percent(val),
                              'suffix': self._build_hw_suffix(temp, power, show_temps, show_power),

--- a/src/netspeedtray/views/monitor/hardware/telemetry.py
+++ b/src/netspeedtray/views/monitor/hardware/telemetry.py
@@ -18,6 +18,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QWidget, QFrame, QHBoxLayout, QVBoxLayout, QLabel
 
 from netspeedtray.utils import styles as su
+from netspeedtray.utils.helpers import has_dedicated_vram
 from netspeedtray.constants.styles import styles as tokens
 
 
@@ -95,7 +96,11 @@ class TelemetryStrip(QWidget):
             self._gpu.set_value(self._proc_text(getattr(w, "gpu_usage", 0.0),
                                                 getattr(w, "gpu_temp", None), getattr(w, "gpu_power", None)))
         self._update_mem(self._ram, getattr(w, "ram_used", None), getattr(w, "ram_total", None))
-        self._update_mem(self._vram, getattr(w, "vram_used", None), getattr(w, "vram_total", None))
+        # An iGPU reports 0.0 GB dedicated VRAM; hide the tile rather than show it, exactly as the
+        # Overview tab already does. Passing None is what _update_mem treats as "no reading".
+        _vu = getattr(w, "vram_used", None)
+        self._update_mem(self._vram, _vu if has_dedicated_vram(_vu) else None,
+                         getattr(w, "vram_total", None))
 
     def _set_tile_visible(self, tile, visible: bool) -> None:
         """Show/hide a tile AND reclaim its stretch so the remaining tiles fill the width (no gap)."""


### PR DESCRIPTION
An integrated GPU has no dedicated video memory, and the PDH counter dutifully reports **0.0 GB** for it. Painting `0.0G` spends widget width to say nothing — and reads as a *measurement* rather than an *absence*.

Spotted on the 2.1.4 smoke test: this machine is an Intel UHD 770 with no NVIDIA, so the GPU row rendered `0.0G` next to the CPU row's honest `9.2/15.7G`.

### This is a consistency fix, not a new rule

The Monitor's Overview tile **already made this decision**, and its comment already names the case:

```python
# There's no dedicated VRAM reading when it's None OR ~0 (an iGPU reports 0 dedicated VRAM).
vram_reading = vu is not None and float(vu) >= 0.05
```

The **widget** and the **Hardware telemetry strip** had drifted from it and both showed a flat zero. The threshold and the predicate now live once, in `helpers.has_dedicated_vram()`, so the three cannot disagree again.

### Scoped so it only ever suppresses an absence

| case | before | after |
|---|---|---|
| iGPU, no dedicated VRAM | `0.0G` | *(blank)* |
| dGPU with known total | `2.1/8.0G` | `2.1/8.0G` |
| AMD/Intel dGPU - real usage, no `nvidia-smi` so no total | `2.5G` | `2.5G` |
| RAM (always has a total) | `9.2/15.7G` | `9.2/15.7G` |

Only *used ~0 **and** no total* blanks the cell.

The column keeps its width, so the CPU row's RAM figure stays aligned and the GPU row simply has nothing in that column - which is the honest picture rather than a hole.

**Verified by reverting: the iGPU test fails on the old renderer.** 1186 tests pass.
