### PR TITLE
fix(monitor): the All timeline spans the data, not a decade

### DIFF
--- a/src/netspeedtray/tests/unit/test_all_timeline_range.py
+++ b/src/netspeedtray/tests/unit/test_all_timeline_range.py
@@ -1,0 +1,71 @@
+"""
+The "All" period has to span the data that exists, not a decade.
+
+`HistoryPeriodConstants.get_start_time` falls back to `now - 10 years` for TIMELINE_ALL when it is
+not told the earliest row in the database:
+
+    if earliest_db:
+         return earliest_db
+    return now - timedelta(days=365*10)
+
+That fallback is reasonable in isolation. What was not reasonable is that the Monitor's graph only
+looked the earliest row up for **SYSTEM UPTIME**, so "All" always took the fallback: an axis running
+from roughly 2016 with every real sample crushed into a sliver at the right edge. The one period
+whose entire job is to show everything was the only one that showed nothing.
+
+The Overview tab had always asked for both periods; `graph_host` had drifted from it.
+"""
+
+from datetime import datetime, timedelta
+
+from netspeedtray import constants
+
+hp = constants.data.history_period
+
+
+def test_all_starts_at_the_earliest_row_when_told():
+    now = datetime(2026, 8, 23, 12, 0, 0)
+    earliest = datetime(2026, 6, 27, 20, 0, 0)
+    assert hp.get_start_time("TIMELINE_ALL", now, earliest_db=earliest) == earliest
+
+
+def test_all_without_the_earliest_row_spans_a_decade():
+    """Pins the fallback that made this visible - and why it must not be the normal path."""
+    now = datetime(2026, 8, 23, 12, 0, 0)
+    start = hp.get_start_time("TIMELINE_ALL", now, earliest_db=None)
+    assert start is not None
+    assert (now - start).days >= 365 * 9, "the fallback is what produced the ~2016 axis"
+
+
+def test_graph_host_requests_the_earliest_row_for_all():
+    """The regression itself: the lookup must be gated on ALL as well as SYSTEM UPTIME.
+
+    Asserted against the source because the alternative is standing up a Monitor window, a main
+    widget and a live database to observe one boolean.
+    """
+    import inspect
+    from netspeedtray.views.monitor import graph_host
+
+    src = inspect.getsource(graph_host.GraphHost._time_range)
+    assert "TIMELINE_ALL" in src, (
+        "graph_host._time_range no longer asks for the earliest row on the All period - the axis "
+        "will fall back to a ten-year span")
+    assert "TIMELINE_SYSTEM_UPTIME" in src, "the uptime period must keep working too"
+
+
+def test_the_lookup_latches_on_the_attempt_not_the_result():
+    """An empty database returns None legitimately; retrying would be a UI-thread DB call per tick."""
+    import inspect
+    from netspeedtray.views.monitor import graph_host
+
+    src = inspect.getsource(graph_host.GraphHost._time_range)
+    assert "_earliest_db_fetched" in src, (
+        "the lookup is gated on a cached VALUE rather than on whether it was attempted, so an empty "
+        "database would re-query on every refresh and realtime tick")
+
+
+def test_other_periods_are_unaffected():
+    now = datetime(2026, 8, 23, 12, 0, 0)
+    assert hp.get_start_time("TIMELINE_WEEK", now) == now - timedelta(days=7)
+    assert hp.get_start_time("TIMELINE_MONTH", now) == now - timedelta(days=30)
+    assert hp.get_start_time("TIMELINE_24_HOURS", now) == now - timedelta(days=1)

--- a/src/netspeedtray/views/monitor/graph_host.py
+++ b/src/netspeedtray/views/monitor/graph_host.py
@@ -104,6 +104,7 @@ class GraphHost(QObject):
         self._accept_from_seq = 0             # drop in-flight results from a previous stat (cross-tab)
         self._cached_boot_time = None         # fetched once for the uptime range (mirrors GraphWindow)
         self._cached_earliest_db = None
+        self._earliest_db_fetched = False
 
         # shims the coordinator drives (matplotlib-free)
         self.ui = _UiShim()
@@ -304,9 +305,18 @@ class GraphHost(QObject):
         # Fetch boot/earliest ONCE for the uptime range. These are UI-thread DB calls and _time_range
         # runs on every refresh + realtime tick - GraphWindow caches them the same way (and the cache
         # is naturally fresh each session, since GraphHost is recreated per Monitor window).
-        if period_key == "TIMELINE_SYSTEM_UPTIME" and self._cached_boot_time is None:
+        # ALL needs the earliest row too, not just SYSTEM UPTIME. Without it, get_start_time() falls
+        # back to `now - 10 years`, so "All" drew an axis from ~2016 with every real sample crushed
+        # into a sliver at the right edge - the one period whose whole job is to show everything was
+        # the one that showed nothing. The Overview tab already asked for both; this path had drifted.
+        if period_key in ("TIMELINE_SYSTEM_UPTIME", "TIMELINE_ALL") and not self._earliest_db_fetched:
+            # Latch on the ATTEMPT, not on the result: an empty database legitimately returns None,
+            # and this runs on every refresh and realtime tick - retrying would be a UI-thread DB
+            # call per tick, forever.
+            self._earliest_db_fetched = True
             try:
-                self._cached_boot_time = GraphLogic.get_boot_time()
+                if period_key == "TIMELINE_SYSTEM_UPTIME":
+                    self._cached_boot_time = GraphLogic.get_boot_time()
                 self._cached_earliest_db = self._main_widget.widget_state.get_earliest_data_timestamp()
             except Exception:
                 self._cached_boot_time = self._cached_earliest_db = None


### PR DESCRIPTION
Found by checking the **Month** and **All** periods, which the smoke tests had not touched.

**All** drew an x-axis running from roughly **2016**, with every real sample crushed into a sliver at the right edge. The one period whose entire job is to show everything was the only one that showed nothing.

### The database was fine

Earliest row is **2026-06-27** across every tier — no stray timestamps. The *range* was wrong.

`get_start_time()` falls back to `now - 10 years` for `TIMELINE_ALL` when it is not told the earliest timestamp:

```python
if earliest_db:
     return earliest_db
return now - timedelta(days=365*10)
```

…and `graph_host` only looked that up for one period:

```python
if period_key == "TIMELINE_SYSTEM_UPTIME" and self._cached_boot_time is None:
```

So **All always took the fallback.** The query it needed already existed and worked — it was simply never called.

The Monitor's **Overview tab had always asked for both periods**. This path had drifted from it — the same shape as the iGPU VRAM drift in #269, where one call site was right and another had not kept up.

### One detail worth noting

The lookup now latches on the **attempt**, not the cached value. An empty database returns `None` legitimately, and `_time_range` runs on every refresh *and* every realtime tick — gating on the result would mean a UI-thread database call per tick, forever.

### Verified live

| period | before | after |
|---|---|---|
| **All** | axis ~2016 → 2026, data invisible | **2026-07-01 → today, whole history legible** |
| Month | already correct | unchanged |
| Week | already correct | unchanged |

Confirmed on both the Network and Hardware tabs. 1191 tests pass.
