### PR TITLE
fix(update,db): four fixes the 2.2.0 beta and its rollback depend on

### DIFF
--- a/build/version_info.txt
+++ b/build/version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 1, 3, 0),
-    prodvers=(2, 1, 3, 0),
+    filevers=(2, 1, 4, 0),
+    prodvers=(2, 1, 4, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -17,12 +17,12 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Erez C137'),
             StringStruct('FileDescription', 'NetSpeedTray'),
-            StringStruct('FileVersion', '2.1.3.0'),
+            StringStruct('FileVersion', '2.1.4.0'),
             StringStruct('InternalName', 'NetSpeedTray'),
             StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
             StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
             StringStruct('ProductName', 'NetSpeedTray'),
-            StringStruct('ProductVersion', '2.1.3'),
+            StringStruct('ProductVersion', '2.1.4'),
           ]
         )
       ]

--- a/src/netspeedtray/core/config_controller.py
+++ b/src/netspeedtray/core/config_controller.py
@@ -13,6 +13,7 @@ from PyQt6.QtGui import QColor
 from netspeedtray import constants
 from netspeedtray.utils.window_state import set_window_always_on_top
 from netspeedtray.utils.config import ConfigManager
+from netspeedtray.utils.timer_utils import calculate_timer_interval
 
 if TYPE_CHECKING:
     from netspeedtray.views.widget.main import NetworkSpeedWidget
@@ -175,8 +176,14 @@ class ConfigController:
             
             if w.monitor_thread:
                 w.monitor_thread.update_config(w.config)
+                # Resolve the SMART sentinel (-1.0) BEFORE handing the value to the sampler.
+                # set_interval() clamps with max(0.1, interval), so passing -1.0 through raw
+                # set the poll interval to 0.1s - 100ms, twenty times the intended 2s, and the
+                # one rate constants/update_mode.py explicitly rules out as "too jarring for
+                # human perception". Startup was already correct (main.py resolves it); only
+                # this path, taken on every settings save, was not.
                 update_rate = w.config.get("update_rate", constants.config.defaults.DEFAULT_UPDATE_RATE)
-                w.monitor_thread.set_interval(update_rate)
+                w.monitor_thread.set_interval(calculate_timer_interval(update_rate) / 1000.0)
             
             if w.widget_state:
                 self.logger.debug("Applying widget state config...")

--- a/src/netspeedtray/core/database.py
+++ b/src/netspeedtray/core/database.py
@@ -41,6 +41,10 @@ class DatabaseWorker(QThread):
         # no 100ms busy-poll, lower latency, near-zero idle CPU. None is a wake-up sentinel.
         self._queue: "queue.Queue[Optional[Tuple[str, Any]]]" = queue.Queue()
         self._stop_event = threading.Event()
+        # Set when the file on disk was written by a NEWER build than this one. Every write
+        # path is then refused - see _check_and_create_schema for why silence is not an option.
+        self._schema_incompatible = False
+        self._downgrade_warned = False
         self.logger = logging.getLogger(f"NetSpeedTray.{self.__class__.__name__}")
 
 
@@ -55,7 +59,11 @@ class DatabaseWorker(QThread):
             try:
                 self._initialize_connection()
                 self._check_and_create_schema()
-                self._ensure_indexes()  # idempotent; runs regardless of schema version
+                if not self._schema_incompatible:
+                    # Skipped on a downgrade: CREATE INDEX against a newer schema either errors
+                    # (a compatibility view cannot be indexed) or writes to a file this build
+                    # does not understand. Both are exactly what the guard exists to prevent.
+                    self._ensure_indexes()  # idempotent; runs regardless of schema version
                 initialized = True
                 break
             except sqlite3.Error as e:
@@ -119,6 +127,18 @@ class DatabaseWorker(QThread):
             except Exception:
                 pass
             return
+        if self._schema_incompatible:
+            # Downgrade: every task below writes (maintenance DELETEs and aggregates). Drop them
+            # rather than letting them fail into a swallowed OperationalError. Warn once - this
+            # fires per persist tick, and #263 was a 137,000-line flood from exactly this shape.
+            if not self._downgrade_warned:
+                self._downgrade_warned = True
+                self.logger.warning(
+                    "Refusing database task '%s' and all further writes: the file was written by a "
+                    "newer version of NetSpeedTray. This is logged once per session.", task,
+                )
+            return
+
         handlers = {
             "persist_speed": self._persist_speed_batch,
             "persist_hardware": self._persist_hardware_batch,
@@ -243,19 +263,130 @@ class DatabaseWorker(QThread):
         except Exception:
             return True
 
+    # Keep the newest N pre-migration backups; older ones are pruned. Nothing used to
+    # delete these at all, and at a year-scale database that is hundreds of MB of
+    # abandoned copies sitting in the user's roaming profile.
+    _BACKUP_RETENTION = 2
+
     def _backup_database(self) -> bool:
-        """Backs up the current database file before critical operations."""
+        """
+        Make a **verified**, WAL-safe copy of the database before a migration.
+
+        Uses ``VACUUM INTO`` rather than a file copy. ``shutil.copy2`` copies only the
+        main ``.db`` file, but in WAL mode everything committed since the last
+        checkpoint lives in the ``-wal`` sidecar - so a copy taken while the WAL is hot
+        silently loses it. That is precisely the state during an upgrade: the installer
+        force-kills the running app (``taskkill /F`` in setup.iss), so no checkpoint
+        runs. Measured against a hot WAL, a ``copy2`` backup recovered **zero of 30,000
+        committed rows** - and the result still passed ``PRAGMA integrity_check``,
+        because an empty database is a perfectly valid one.
+
+        ``VACUUM INTO`` reads through this connection, so it sees WAL content, and it
+        compacts the copy as a side effect.
+
+        The copy is then opened and checked against the source before this returns
+        True. A backup that silently isn't one is worse than no backup at all, because
+        the caller reasons about its existence.
+        """
+        backup_path: Optional[Path] = None
         try:
+            version = self._get_current_db_version()
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            backup_path = self.db_path.with_suffix(f".db.bak.v{self._get_current_db_version()}_{timestamp}")
+            backup_path = self.db_path.with_suffix(f".db.bak.v{version}_{timestamp}")
+
+            # VACUUM INTO refuses to write an existing file. The timestamp is only
+            # second-resolution while run()'s init retry backs off in 0.1s steps, so two
+            # attempts land in the same second - and that collision would fire in exactly
+            # the retry path a backup exists to protect.
+            suffix = 0
+            while backup_path.exists():
+                suffix += 1
+                backup_path = self.db_path.with_suffix(f".db.bak.v{version}_{timestamp}_{suffix}")
+
             self.logger.info("Backing up database to: %s", backup_path)
-            shutil.copy2(self.db_path, backup_path)
+            self.conn.execute("VACUUM INTO ?", (str(backup_path),))
+
+            if not self._verify_backup(backup_path, version):
+                self.logger.error("Pre-migration backup FAILED VERIFICATION; treating as no backup.")
+                backup_path.unlink(missing_ok=True)
+                return False
+
+            self._prune_old_backups()
             return True
         except Exception as e:
             # Don't swallow silently: the migration's data-loss guard assumes a backup was made, so a
             # disk-full / permission / lock failure here must be visible in the log (and the bak's absence).
             self.logger.error("Pre-migration database backup FAILED: %s", e)
+            if backup_path is not None:
+                try:
+                    backup_path.unlink(missing_ok=True)   # never leave a partial copy that looks real
+                except Exception:
+                    pass
             return False
+
+
+    def _verify_backup(self, backup_path: Path, expected_version: int) -> bool:
+        """
+        Open the backup and prove it holds the same data as the source.
+
+        Structural checks alone are not enough: the failure this exists to catch (a
+        WAL-blind copy) produces a *valid* database that is merely missing rows, which
+        ``integrity_check`` reports as ``ok``. So compare content - the schema version
+        and the row count of every history table.
+        """
+        check: Optional[sqlite3.Connection] = None
+        try:
+            # NOTE: `with sqlite3.connect(...)` commits/rolls back the transaction but does
+            # NOT close the connection. On Windows the leaked handle keeps the file locked,
+            # so _prune_old_backups() then fails with WinError 32. Close it explicitly.
+            check = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
+
+            if check.execute("PRAGMA quick_check").fetchone()[0] != "ok":
+                self.logger.error("Backup verification: quick_check did not return ok.")
+                return False
+
+            row = check.execute("SELECT value FROM metadata WHERE key='db_version'").fetchone()
+            if row is None or int(row[0]) != expected_version:
+                self.logger.error(
+                    "Backup verification: db_version is %s, expected %d.",
+                    row[0] if row else "missing", expected_version,
+                )
+                return False
+
+            tables = [r[0] for r in self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )]
+            for table in tables:
+                src = self.conn.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0]
+                dst = check.execute(f"SELECT COUNT(*) FROM '{table}'").fetchone()[0]
+                if src != dst:
+                    self.logger.error(
+                        "Backup verification: table '%s' has %d rows in the backup but %d in the "
+                        "source. The backup is incomplete.", table, dst, src,
+                    )
+                    return False
+            return True
+        except Exception as e:
+            self.logger.error("Backup verification failed to read the copy: %s", e)
+            return False
+        finally:
+            if check is not None:
+                check.close()
+
+
+    def _prune_old_backups(self) -> None:
+        """Keep only the newest `_BACKUP_RETENTION` backups; nothing else ever deleted them."""
+        try:
+            backups = sorted(
+                self.db_path.parent.glob(f"{self.db_path.stem}.db.bak.*"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            for stale in backups[self._BACKUP_RETENTION:]:
+                stale.unlink(missing_ok=True)
+                self.logger.debug("Pruned old database backup: %s", stale.name)
+        except Exception as e:
+            self.logger.warning("Could not prune old database backups: %s", e)
 
 
     def _migrate_schema(self, current_version: int) -> None:
@@ -411,6 +542,26 @@ class DatabaseWorker(QThread):
             # M7: version read failed unexpectedly. Never rebuild - preserve the file and
             # degrade gracefully. A retry on next launch may succeed once the lock clears.
             self.logger.error("DB version is UNKNOWN; refusing to migrate or rebuild - preserving the database as-is.")
+            return
+
+        if current_version > self._DB_VERSION:
+            # DOWNGRADE. The file was written by a newer build; this one cannot understand it.
+            # There is no migration to run - range(new, old) is empty - so the old code fell
+            # through and did two harmful things:
+            #   1. _migrate_schema() still ran _backup_database() unconditionally, writing a
+            #      full copy of the database on EVERY launch, which nothing ever deletes.
+            #   2. Reads kept working (a newer schema may expose compatibility views), while
+            #      every write raised OperationalError - a sqlite3.Error subclass that the
+            #      handlers below swallow. The app looked healthy and silently recorded nothing.
+            # Refusing outright is the only honest option: no backup, no writes, no maintenance.
+            self._schema_incompatible = True
+            self.logger.error(
+                "Database schema v%d was written by a NEWER version of NetSpeedTray than this one "
+                "(which understands v%d). Running READ-ONLY: history will be shown but nothing new "
+                "will be recorded, and no data will be modified or deleted. Upgrade again to resume "
+                "recording, or move %s aside to start a fresh history.",
+                current_version, self._DB_VERSION, self.db_path.name,
+            )
             return
 
         if current_version > 0:

--- a/src/netspeedtray/core/update_checker.py
+++ b/src/netspeedtray/core/update_checker.py
@@ -21,16 +21,68 @@ RELEASES_URL = f"https://api.github.com/repos/{constants.app.GITHUB_OWNER}/{cons
 CHECK_INTERVAL_HOURS = 24
 
 
+# Pre-release stage ordering. An unrecognised stage sorts ABOVE these but still
+# below any final release, so an unexpected tag can never look newer than a real one.
+_PRERELEASE_STAGES = {"alpha": 0, "a": 0, "beta": 1, "b": 1, "rc": 2, "c": 2, "pre": 2}
+_UNKNOWN_STAGE_RANK = 3
+
+
 def _parse_version(version_str: str) -> Tuple[int, ...]:
-    """Parse 'v1.3.1' or '1.3.1' into a comparable tuple of ints."""
+    """
+    Parse a release tag into a comparable tuple of ints.
+
+    The tag is split into a release core and an optional pre-release suffix, then
+    padded to a fixed shape so plain tuple comparison implements the ordering we
+    need for a beta cycle::
+
+        (major, minor, patch, is_final, stage_rank, stage_number)
+
+    - ``1.3`` and ``1.3.0`` are the same release -> both ``(1, 3, 0, 1, 0, 0)``.
+    - A final release outranks every pre-release of it (``is_final`` 1 beats 0),
+      so ``2.2.0`` > ``2.2.0-beta.4``.
+    - Successive pre-releases order correctly: ``beta.1`` < ``beta.2`` < ``rc.1``.
+      Without this a beta tester is stranded, because every ``2.2.0-beta.N``
+      compared EQUAL and `is_newer` could never advance between them.
+    - Build metadata (``+abc``) never affects precedence, per semver.
+
+    Never raises; an unparseable tag yields ``()`` so it sorts below everything.
+    """
     cleaned = version_str.lstrip("vV").strip()
-    parts = []
-    for part in cleaned.split("."):
+    cleaned = cleaned.split("+", 1)[0]              # build metadata is not precedence
+    core, _, pre = cleaned.partition("-")
+
+    release: list[int] = []
+    for part in core.split("."):
         try:
-            parts.append(int(part))
+            release.append(int(part))
         except ValueError:
             break
-    return tuple(parts)
+    if not release:
+        return ()                                   # unparseable sorts below everything
+
+    while len(release) < 3:                         # 1.3 and 1.3.0 are one release
+        release.append(0)
+
+    if not pre:
+        return (*release, 1, 0, 0)
+
+    stage_rank, stage_number = _UNKNOWN_STAGE_RANK, 0
+    for token in pre.replace("-", ".").split("."):
+        if token.isdigit():
+            stage_number = int(token)
+            continue
+        name = token.lower()
+        if name in _PRERELEASE_STAGES:
+            stage_rank = _PRERELEASE_STAGES[name]
+            continue
+        # digits glued to the stage name, e.g. 'beta2'
+        head = name.rstrip("0123456789")
+        tail = name[len(head):]
+        if head in _PRERELEASE_STAGES:
+            stage_rank = _PRERELEASE_STAGES[head]
+            if tail:
+                stage_number = int(tail)
+    return (*release, 0, stage_rank, stage_number)
 
 
 def is_newer(latest: str, current: str) -> bool:

--- a/src/netspeedtray/tests/unit/test_db_backup_integrity.py
+++ b/src/netspeedtray/tests/unit/test_db_backup_integrity.py
@@ -1,0 +1,130 @@
+"""
+The pre-migration backup must actually contain the user's data.
+
+`test_db_migration.test_backup_database_success` asserts a `.bak` file exists and
+that its name contains a version. It never opens it. That is the same blind spot
+that let `WinError 5` through on the portable updater despite 16 green tests: the
+assertion checks the artifact was produced, not that it works.
+
+It matters because the old implementation used `shutil.copy2`, which copies only
+the main `.db` file. In WAL mode, everything committed since the last checkpoint
+lives in the `-wal` sidecar, so a copy taken with a hot WAL silently loses it -
+and an empty-but-valid database still passes `PRAGMA integrity_check`.
+
+That is not a corner case, it is the default upgrade path: `build/setup.iss` runs
+`taskkill /F /IM NetSpeedTray.exe /T` before installing, which is
+`TerminateProcess` - no commit, no checkpoint, guaranteed hot WAL. So the one
+moment the backup matters is the one moment it was guaranteed to be incomplete.
+
+These tests open the copy and compare it to the source.
+"""
+import os
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(os.path.abspath("src"))
+from netspeedtray.core.widget_state import DatabaseWorker
+
+
+@pytest.fixture
+def worker(tmp_path):
+    w = DatabaseWorker(tmp_path / "speed_history.db")
+    w._initialize_connection()
+    w._check_and_create_schema()
+    yield w
+    if w.conn:
+        w.conn.close()
+
+
+def _seed(worker, rows=5000):
+    """Commit rows without checkpointing, leaving content in the WAL."""
+    worker.conn.execute("PRAGMA wal_autocheckpoint=0")
+    worker.conn.executemany(
+        "INSERT OR IGNORE INTO speed_history_raw "
+        "(timestamp, interface_name, upload_bytes_sec, download_bytes_sec) VALUES (?,?,?,?)",
+        [(1787000000 + i, "Wi-Fi", float(i), float(i * 2)) for i in range(rows)],
+    )
+    worker.conn.commit()
+    return rows
+
+
+def test_backup_captures_data_still_in_the_wal(worker, tmp_path):
+    """The regression: a hot WAL is the normal state during an upgrade."""
+    rows = _seed(worker)
+    wal = Path(str(worker.db_path) + "-wal")
+    assert wal.exists() and wal.stat().st_size > 0, "test needs a hot WAL to be meaningful"
+
+    assert worker._backup_database() is True
+
+    backup = next(tmp_path.glob("*.bak.*"))
+    with sqlite3.connect(f"file:{backup}?mode=ro", uri=True) as check:
+        assert check.execute("SELECT COUNT(*) FROM speed_history_raw").fetchone()[0] == rows
+
+
+def test_the_old_copy_based_backup_would_have_lost_it(worker, tmp_path):
+    """Pins WHY this changed, so nobody 'simplifies' it back to a file copy."""
+    rows = _seed(worker)
+    naive = tmp_path / "naive_copy.db"
+    shutil.copy2(worker.db_path, naive)
+
+    with sqlite3.connect(f"file:{naive}?mode=ro", uri=True) as check:
+        try:
+            recovered = check.execute("SELECT COUNT(*) FROM speed_history_raw").fetchone()[0]
+        except sqlite3.DatabaseError:
+            recovered = 0                     # the table itself never made it
+    assert recovered < rows, (
+        "a plain file copy is expected to miss WAL content; if this ever passes, "
+        "the journal mode or checkpoint behaviour changed - re-check the backup design"
+    )
+
+
+def test_verification_rejects_a_backup_missing_rows(worker, tmp_path):
+    """The exact WAL-blind failure mode: structurally valid, content missing."""
+    _seed(worker, rows=200)
+    assert worker._backup_database() is True
+    backup = next(tmp_path.glob("*.bak.*"))
+
+    # Make the copy look like one taken without WAL content: valid, but short.
+    victim = sqlite3.connect(backup)
+    victim.execute("DELETE FROM speed_history_raw WHERE timestamp > 1787000100")
+    victim.commit()
+    assert victim.execute("PRAGMA quick_check").fetchone()[0] == "ok"   # still 'valid'
+    victim.close()
+
+    assert worker._verify_backup(backup, worker._DB_VERSION) is False
+
+
+def test_verification_rejects_a_version_mismatch(worker, tmp_path):
+    _seed(worker, rows=50)
+    assert worker._backup_database() is True
+    backup = next(tmp_path.glob("*.bak.*"))
+    assert worker._verify_backup(backup, worker._DB_VERSION + 99) is False
+
+
+def test_failed_verification_leaves_no_file_behind(worker, monkeypatch, tmp_path):
+    """A backup that silently isn't one is worse than no backup."""
+    _seed(worker, rows=100)
+    monkeypatch.setattr(worker, "_verify_backup", lambda *a, **k: False)
+
+    assert worker._backup_database() is False, "an unverified backup must not report success"
+    assert list(tmp_path.glob("*.bak.*")) == [], "a failed backup must not leave a file behind"
+
+
+def test_repeated_backups_within_one_second_do_not_collide(worker, tmp_path):
+    """VACUUM INTO refuses an existing target; init retries are 0.1s apart."""
+    _seed(worker, rows=50)
+    assert worker._backup_database() is True
+    assert worker._backup_database() is True
+    assert len(list(tmp_path.glob("*.bak.*"))) == 2
+
+
+def test_old_backups_are_pruned(worker, tmp_path):
+    """Nothing used to delete these, at any size, ever."""
+    _seed(worker, rows=50)
+    for _ in range(5):
+        assert worker._backup_database() is True
+    assert len(list(tmp_path.glob("*.bak.*"))) == worker._BACKUP_RETENTION

--- a/src/netspeedtray/tests/unit/test_db_downgrade_guard.py
+++ b/src/netspeedtray/tests/unit/test_db_downgrade_guard.py
@@ -1,0 +1,137 @@
+"""
+Downgrade guard: what happens when an OLDER build opens a NEWER database.
+
+This is the 2.2.0-beta rollback path. A beta tester migrates their database to a
+newer schema, dislikes the beta, and reinstalls the previous release - which is
+exactly what beta testers do, and GitHub/WinGet keep every prior version
+downloadable forever.
+
+Before the guard, that produced two silent failures:
+
+  1. `_migrate_schema` ran `_backup_database()` unconditionally, but the loop
+     `range(current_version, _DB_VERSION)` is EMPTY on a downgrade. So a full copy
+     of the database was written to a new `.bak` on EVERY launch, and nothing in
+     the codebase ever deletes one.
+  2. Reads kept working - a newer schema may expose compatibility views - while
+     every write raised `OperationalError`. That is a `sqlite3.Error` subclass,
+     and every handler in the worker swallows it. The app looked completely
+     healthy and recorded nothing, permanently, with no user-visible signal.
+
+These tests assert the guard *actually holds*, not merely that it logged. Note
+the sibling lesson in `test_db_migration.test_backup_database_success`, which
+asserts a backup file exists but never opens it - the same blind spot that let
+`WinError 5` through on the portable updater.
+"""
+import sqlite3
+import sys
+import os
+from pathlib import Path
+
+import pytest
+
+sys.path.append(os.path.abspath("src"))
+from netspeedtray.core.widget_state import DatabaseWorker
+
+
+def _make_newer_db(path: Path, version: int) -> None:
+    """A database claiming a schema version this build does not understand."""
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
+    cur.execute("INSERT INTO metadata (key, value) VALUES ('db_version', ?)", (str(version),))
+    # A real future schema; the shape does not matter, only that this build
+    # cannot write it. A view stands in for a v8 compatibility view.
+    cur.execute("CREATE TABLE speed_raw (ts INTEGER, iface_id INTEGER, up_bytes INTEGER)")
+    cur.execute("INSERT INTO speed_raw VALUES (1787000000, 1, 4242)")
+    cur.execute(
+        "CREATE VIEW speed_history_raw AS "
+        "SELECT ts AS timestamp, 'Wi-Fi' AS interface_name, "
+        "up_bytes AS upload_bytes_sec, up_bytes AS download_bytes_sec FROM speed_raw"
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def worker(tmp_path):
+    db = tmp_path / "speed_history.db"
+    w = DatabaseWorker(db)
+    yield w
+    if w.conn:
+        w.conn.close()
+
+
+def test_newer_db_is_detected_and_flagged(worker, tmp_path):
+    _make_newer_db(worker.db_path, version=worker._DB_VERSION + 1)
+    worker._initialize_connection()
+    worker._check_and_create_schema()
+    assert worker._schema_incompatible is True
+
+
+def test_newer_db_writes_no_backup(worker, tmp_path):
+    """The bug that filled disks: a full .bak on every single launch."""
+    _make_newer_db(worker.db_path, version=worker._DB_VERSION + 1)
+    for _ in range(5):                      # five launches
+        worker._initialize_connection()
+        worker._check_and_create_schema()
+        if worker.conn:
+            worker.conn.close()
+            worker.conn = None
+    assert list(tmp_path.glob("*.bak*")) == []
+
+
+def test_newer_db_refuses_every_write_task(worker):
+    """Reads may still work; writes must be refused, not left to fail silently."""
+    _make_newer_db(worker.db_path, version=worker._DB_VERSION + 1)
+    worker._initialize_connection()
+    worker._check_and_create_schema()
+
+    for task in ("persist_speed", "persist_hardware", "persist_usage", "maintenance"):
+        # Must not raise, and must not reach a handler.
+        worker._execute_task(task, [(1787000001, "Wi-Fi", 1.0, 2.0)])
+
+    # The user's data is untouched: no new rows, and the original row survives.
+    conn = sqlite3.connect(f"file:{worker.db_path}?mode=ro", uri=True)
+    assert conn.execute("SELECT COUNT(*) FROM speed_raw").fetchone()[0] == 1
+    conn.close()
+
+
+def test_flush_barrier_still_completes_on_newer_db(worker):
+    """A reader waiting on the flush barrier must not hang forever."""
+    import threading
+
+    _make_newer_db(worker.db_path, version=worker._DB_VERSION + 1)
+    worker._initialize_connection()
+    worker._check_and_create_schema()
+
+    event = threading.Event()
+    worker._execute_task("__signal__", event)
+    assert event.is_set(), "the flush barrier must be honoured even when writes are refused"
+
+
+def test_matching_version_is_untouched(worker):
+    """The guard must not fire on the version this build actually understands."""
+    worker._initialize_connection()
+    worker._check_and_create_schema()          # builds a fresh, current schema
+    assert worker._schema_incompatible is False
+
+
+def test_older_db_still_migrates(worker, tmp_path):
+    """Guarding downgrades must not break the upgrade path it sits next to."""
+    conn = sqlite3.connect(worker.db_path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
+    cur.execute("INSERT INTO metadata (key, value) VALUES ('db_version', '2')")
+    for tier in ("raw", "minute", "hour"):
+        cur.execute(
+            f"CREATE TABLE speed_history_{tier} "
+            "(timestamp INTEGER, interface_name TEXT, upload_avg REAL, download_avg REAL)"
+        )
+    conn.commit()
+    conn.close()
+
+    worker._initialize_connection()
+    worker._check_and_create_schema()
+
+    assert worker._schema_incompatible is False
+    assert worker._get_current_db_version() == worker._DB_VERSION

--- a/src/netspeedtray/tests/unit/test_smart_interval_resolution.py
+++ b/src/netspeedtray/tests/unit/test_smart_interval_resolution.py
@@ -1,0 +1,89 @@
+"""
+SMART mode must never reach the sampler as a raw sentinel.
+
+`UpdateMode.SMART` is the sentinel -1.0, chosen so a slider position can mean
+"not a fixed rate". `MonitorThread.set_interval` clamps with `max(0.1, interval)`,
+so handing it -1.0 does not mean "use the default" - it means **0.1 seconds**.
+
+That is 100ms polling: twenty times the intended 2s, and the one rate that
+`constants/update_mode.py` explicitly rules out in its own header comment
+("DON'T OFFER 100ms - too jarring for human perception"). It also has a data
+consequence, because `speed_history_raw` has a 1-second-resolution primary key
+written with `INSERT OR IGNORE`: at 100ms roughly nine of every ten samples are
+silently discarded, and the survivor is the *first* sample of each second rather
+than an average.
+
+Startup was always correct - `views/widget/main.py` resolves the sentinel before
+using it. The break was in `ConfigController.apply_all_settings`, i.e. every
+settings save. A user on SMART started at 2s and silently dropped to 100ms the
+first time they opened Settings and clicked Save.
+
+`calculate_timer_interval()` already existed and already resolved the sentinel;
+the apply path simply did not call it.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.abspath("src"))
+from netspeedtray import constants
+from netspeedtray.constants.update_mode import UpdateMode
+from netspeedtray.core.config_controller import ConfigController
+from netspeedtray.utils.timer_utils import calculate_timer_interval
+
+
+# The floor set_interval() clamps to. Any resolved interval at or below this means
+# the sentinel leaked through.
+_CLAMP_FLOOR_SEC = 0.1
+
+
+def test_smart_sentinel_resolves_to_the_documented_interval():
+    resolved = calculate_timer_interval(UpdateMode.SMART) / 1000.0
+    assert resolved == constants.timers.SMART_MODE_INTERVAL_MS / 1000.0
+    assert resolved > _CLAMP_FLOOR_SEC
+
+
+@pytest.mark.parametrize("rate", [UpdateMode.SMART, 0, 0.0, -1.0, -0.5])
+def test_no_non_positive_rate_can_reach_the_clamp_floor(rate):
+    """`config.py` permits a min of -1.0, so -0.5 is schema-valid with no meaning."""
+    assert calculate_timer_interval(rate) / 1000.0 > _CLAMP_FLOOR_SEC
+
+
+@pytest.mark.parametrize("rate, expected", [
+    (UpdateMode.AGGRESSIVE, 1.0),
+    (UpdateMode.BALANCED, 2.0),
+    (UpdateMode.EFFICIENT, 5.0),
+    (UpdateMode.POWER_SAVER, 10.0),
+])
+def test_fixed_presets_pass_through_unchanged(rate, expected):
+    assert calculate_timer_interval(rate) / 1000.0 == expected
+
+
+def _widget_with_config(update_rate):
+    """Minimal widget stand-in: only the branches apply_all_settings touches."""
+    w = MagicMock()
+    w.config = {"update_rate": update_rate}
+    return w
+
+
+@pytest.mark.parametrize("rate", [UpdateMode.SMART, -1.0, 0.0])
+def test_apply_all_settings_never_hands_a_sentinel_to_the_sampler(rate):
+    """The actual regression: a settings save dropped SMART users to 100ms."""
+    widget = _widget_with_config(rate)
+    controller = ConfigController(widget, MagicMock())
+    controller.apply_all_settings()
+
+    widget.monitor_thread.set_interval.assert_called_once()
+    passed = widget.monitor_thread.set_interval.call_args[0][0]
+    assert passed > _CLAMP_FLOOR_SEC, (
+        f"set_interval({passed}) clamps to {_CLAMP_FLOOR_SEC}s = 100ms polling"
+    )
+    assert passed == constants.timers.SMART_MODE_INTERVAL_MS / 1000.0
+
+
+def test_apply_all_settings_preserves_an_explicit_rate():
+    widget = _widget_with_config(5.0)
+    ConfigController(widget, MagicMock()).apply_all_settings()
+    assert widget.monitor_thread.set_interval.call_args[0][0] == 5.0

--- a/src/netspeedtray/tests/unit/test_update_checker.py
+++ b/src/netspeedtray/tests/unit/test_update_checker.py
@@ -14,9 +14,13 @@ updates. These tests pin the REAL behavior of `_parse_version` and `is_newer`:
 Only the pure comparison/parsing is exercised here - no network, no Qt threads,
 no UpdateChecker instance (that would need real HTTP + a QThread).
 
-Known quirks that are intentional and should NOT be "fixed" in a patch are
-xfailed below with a clear note (zero-padding asymmetry: "1.3" vs "1.3.0",
-and pre-release tags being truncated rather than ordered).
+**2.1.4: the two quirks previously xfailed here are now FIXED**, because the
+2.2.0 beta cycle depends on them. `_parse_version` pads to a fixed shape,
+`(major, minor, patch, is_final, stage_rank, stage_number)`, which makes
+"1.3" == "1.3.0", keeps a final release above its own pre-releases, and orders
+successive pre-releases so `is_newer` can actually advance between betas.
+Before this, every "2.2.0-beta.N" parsed to (2, 2) and compared EQUAL, so a
+beta tester was stranded on whichever build they installed first.
 """
 import pytest
 
@@ -25,34 +29,45 @@ from netspeedtray.core.update_checker import _parse_version, is_newer, select_re
 
 # --- _parse_version: normalization -------------------------------------------
 
+# Shape is (major, minor, patch, is_final, stage_rank, stage_number).
+# is_final=1 for a real release, 0 for a pre-release.
 @pytest.mark.parametrize("raw, expected", [
-    ("1.3.1", (1, 3, 1)),
-    ("v1.3.1", (1, 3, 1)),     # lowercase v stripped
-    ("V1.3.1", (1, 3, 1)),     # uppercase V stripped
-    ("vv1.0", (1, 0)),         # lstrip removes *all* leading v/V chars
-    (" 1.2.3 ", (1, 2, 3)),    # surrounding whitespace stripped
-    ("1.3.10", (1, 3, 10)),    # multi-digit component kept as int 10, not "10"
-    ("2", (2,)),               # single component
-    ("0.0.0", (0, 0, 0)),
+    ("1.3.1", (1, 3, 1, 1, 0, 0)),
+    ("v1.3.1", (1, 3, 1, 1, 0, 0)),     # lowercase v stripped
+    ("V1.3.1", (1, 3, 1, 1, 0, 0)),     # uppercase V stripped
+    ("vv1.0", (1, 0, 0, 1, 0, 0)),      # lstrip removes *all* leading v/V chars
+    (" 1.2.3 ", (1, 2, 3, 1, 0, 0)),    # surrounding whitespace stripped
+    ("1.3.10", (1, 3, 10, 1, 0, 0)),    # multi-digit component kept as int 10
+    ("2", (2, 0, 0, 1, 0, 0)),          # single component padded to a full release
+    ("0.0.0", (0, 0, 0, 1, 0, 0)),
+    ("1.4.0+build7", (1, 4, 0, 1, 0, 0)),   # build metadata is not precedence
 ])
 def test_parse_version_normalizes(raw, expected):
     assert _parse_version(raw) == expected
 
 
 @pytest.mark.parametrize("raw, expected", [
-    ("", ()),                  # empty -> empty tuple, no crash
-    ("v", ()),                 # only the prefix
-    ("   ", ()),               # whitespace only
-    ("abc", ()),               # no numeric leading component
-    ("1.3.x", (1, 3)),         # stops at first non-int component
-    # A pre-release suffix is attached to the LAST numeric component, so the
-    # whole component (e.g. "3-beta") fails int() and parsing stops *before* it.
-    ("1.3-beta", (1,)),        # "3-beta" is non-int -> only (1,) survives
-    ("1.3.1-rc2", (1, 3)),     # "1-rc2" is non-int -> stops, (1, 3)
-    ("1..2", (1,)),            # empty middle component is non-int -> stops at it
+    ("", ()),                          # empty -> empty tuple, no crash
+    ("v", ()),                         # only the prefix
+    ("   ", ()),                       # whitespace only
+    ("abc", ()),                       # no numeric leading component
+    ("1.3.x", (1, 3, 0, 1, 0, 0)),     # stops at first non-int, then pads
+    ("1..2", (1, 0, 0, 1, 0, 0)),      # empty middle component stops parsing
 ])
 def test_parse_version_malformed_is_graceful(raw, expected):
-    # The contract is: never raise, return a (possibly short/empty) int tuple.
+    # The contract is: never raise, return a (possibly empty) int tuple.
+    assert _parse_version(raw) == expected
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("1.3-beta", (1, 3, 0, 0, 1, 0)),      # suffix no longer eats the component
+    ("1.3.1-rc2", (1, 3, 1, 0, 2, 2)),     # digits glued to the stage name
+    ("2.2.0-beta.1", (2, 2, 0, 0, 1, 1)),
+    ("2.2.0-alpha", (2, 2, 0, 0, 0, 0)),
+    ("2.2.0-rc.1", (2, 2, 0, 0, 2, 1)),
+    ("2.2.0-nightly", (2, 2, 0, 0, 3, 0)),  # unknown stage: above rc, below final
+])
+def test_parse_version_prerelease_shape(raw, expected):
     assert _parse_version(raw) == expected
 
 
@@ -104,58 +119,49 @@ def test_is_newer_malformed_does_not_crash():
     assert is_newer("1.3.4", "garbage") is True   # (1,3,4) > ()
 
 
-# --- known quirks: pin as xfail, do NOT change in a patch --------------------
+# --- release / pre-release ordering (fixed in 2.1.4) -------------------------
 
-@pytest.mark.xfail(
-    reason="Zero-padding asymmetry: tuple compare makes (1,3) < (1,3,0), so "
-           "is_newer('1.3.0','1.3') is True but is_newer('1.3','1.3.0') is "
-           "False. '1.3' and '1.3.0' are the same release; treating one as "
-           "newer is arguably wrong. Intentional/known - not a patch fix.",
-    strict=True,
-)
 def test_trailing_zero_components_treated_as_equal():
-    # If this ever starts passing, the normalization changed (good!) - update.
+    # "1.3" and "1.3.0" are the same release; neither is newer. Previously the
+    # shorter tuple compared as older, so "1.3.0" looked like an update over "1.3".
     assert is_newer("1.3.0", "1.3") is False
     assert is_newer("1.3", "1.3.0") is False
 
 
-def test_trailing_zero_asymmetry_actual_behavior():
-    # Documents the CURRENT (arguably-wrong) behavior so a regression is visible.
-    assert is_newer("1.3.0", "1.3") is True    # longer tuple wins
-    assert is_newer("1.3", "1.3.0") is False
-
-
-def test_prerelease_suffix_truncates_last_component():
-    # A '-beta'/'-rc' suffix is glued to the LAST numeric component, so that
-    # whole component fails int() and parsing stops *before* it. The suffixed
-    # component is lost entirely, not just its text part:
-    #   "1.4.0-beta" -> ["1","4","0-beta"] -> int("0-beta") fails -> (1, 4)
-    assert _parse_version("1.4.0-beta") == (1, 4)
-    assert _parse_version("1.4.0") == (1, 4, 0)
-
-
-def test_prerelease_compares_older_than_final_by_accident():
-    # Because the suffixed component is dropped, the pre-release tuple is SHORTER
-    # and therefore compares as older than the final release. This yields the
-    # arguably-desirable result (final > beta) but only as a side effect of
-    # truncation, not real semver ordering. Pinned so the accident is visible.
-    assert is_newer("1.4.0", "1.4.0-beta") is True       # (1,4,0) > (1,4)
+def test_final_release_outranks_its_own_prereleases():
+    assert is_newer("1.4.0", "1.4.0-beta") is True
+    assert is_newer("1.4.0", "1.4.0-rc.9") is True
     assert is_newer("1.4.0-beta", "1.4.0") is False
-    # The flip side of the same accident: a beta of a HIGHER version can look
-    # equal-or-older than a lower final because its last component vanished.
-    # "1.5.0-beta" -> (1,5) which is still > (1,4,0), so this one is fine:
+    assert is_newer("1.4.0-rc.9", "1.4.0") is False
+
+
+def test_prerelease_of_higher_version_beats_lower_final():
+    # A 2.2.0 beta IS newer than 2.1.4 - this is what lets a tester opt in.
     assert is_newer("1.5.0-beta", "1.4.0") is True
+    assert is_newer("2.2.0-beta.1", "2.1.4") is True
+    assert is_newer("2.1.4", "2.2.0-beta.1") is False
 
 
-@pytest.mark.xfail(
-    reason="No real semver pre-release ordering: '1.4.0-beta1' and "
-           "'1.4.0-beta2' both truncate to (1,4), so successive betas compare "
-           "EQUAL and is_newer can never advance between them. Proper "
-           "pre-release ordering is out of scope for a patch.",
-    strict=True,
-)
 def test_successive_prereleases_are_ordered():
+    """The 2.2.0 beta cycle depends on this.
+
+    Previously every '2.2.0-beta.N' truncated to (2, 2) and compared EQUAL, so a
+    beta tester could never be offered the next beta - they were stranded on
+    whichever build they installed first.
+    """
     assert is_newer("1.4.0-beta2", "1.4.0-beta1") is True
+    assert is_newer("2.2.0-beta.2", "2.2.0-beta.1") is True
+    assert is_newer("2.2.0-beta.10", "2.2.0-beta.9") is True   # numeric, not lexical
+    assert is_newer("2.2.0-beta.1", "2.2.0-beta.2") is False
+
+
+def test_prerelease_stages_are_ordered():
+    assert is_newer("2.2.0-beta.1", "2.2.0-alpha.9") is True
+    assert is_newer("2.2.0-rc.1", "2.2.0-beta.9") is True
+    # An unrecognised stage sorts above rc but still below the final release,
+    # so an unexpected tag can never look newer than a real one.
+    assert is_newer("2.2.0-nightly", "2.2.0-rc.1") is True
+    assert is_newer("2.2.0", "2.2.0-nightly") is True
 
 
 # --- release-asset selection (installer + portable) --------------------------


### PR DESCRIPTION
2.1.4 is the version anyone testing the 2.2.0 beta will roll back **to**, so these protections have to ship here rather than in a later patch. Each fix has a test that was **verified to fail without it**.

### Pre-release version ordering — `update_checker.py`

`_parse_version` stopped at the first non-integer component, so every `2.2.0-beta.N` parsed to `(2, 2)` and successive betas compared **EQUAL** — a tester would have been stranded on whichever build they installed first.

```
is_newer(v2.2.0-beta.2,  v2.2.0-beta.1)  = True    <- was False
is_newer(v2.2.0-beta.10, v2.2.0-beta.9)  = True    <- numeric, not lexical
is_newer(v2.2.0,         v2.2.0-rc.1)    = True    <- final outranks its prereleases
```

Two long-standing `xfail(strict=True)` cases now pass and were converted to real tests, per their own *"if this ever starts passing, the normalization changed (good!) — update"* note.

### Downgrade guard — `database.py`

On a downgrade the loop `range(new, old)` is empty, so the old code fell through and did two harmful things: it still wrote a full copy of the database to a `.bak` on **every launch** (nothing ever deleted them), and every write raised `OperationalError` — a `sqlite3.Error` subclass every handler swallows. Reads kept working, so the app looked completely healthy while recording nothing, permanently.

Now refuses outright: no backup, no writes, no maintenance, one clear log line (rate-limited — #263 was a 137k-line flood from exactly this shape).

**Verified live** against a v8 database: no `.bak`, row count unchanged, `last_maintenance_at` untouched.

### Verified WAL-safe backup — `database.py`

`shutil.copy2` copies only the main `.db`; in WAL mode everything since the last checkpoint lives in the sidecar, and the installer force-kills the app (`taskkill /F` in `setup.iss`), so the WAL is hot **exactly when the backup matters**.

Measured against a hot WAL: **zero of 30,000 committed rows recovered**, and the result still passed `integrity_check` — because an empty database is a valid one.

Now `VACUUM INTO` (reads through the connection, and compacts ~8×), then the copy is **opened and its row counts compared to the source** before it is trusted. Handles the target-exists case, since the filename is second-resolution while init retries back off 0.1s apart — that collision would have fired in precisely the retry path a backup exists to protect. Prunes to the newest two.

### SMART update rate — `config_controller.py`

`set_interval` clamps with `max(0.1, interval)`, so passing the `-1.0` sentinel raw meant **100 ms polling** — twenty times the intended 2 s, and the one rate `constants/update_mode.py` rules out in its own header.

Also a data bug: the raw tier's key is one-second with `INSERT OR IGNORE`, so roughly **nine of every ten samples were silently discarded**. `calculate_timer_interval()` already resolved the sentinel; this path simply never called it. One line.

---

### Verification beyond the suite

**1,225 tests passing** (was 1,191 + 2 xfailed). Because green unit tests have missed real failures in this repo before — `WinError 5` on the portable updater, and a backup test that asserts a file exists without ever opening it — each of these was also exercised live:

- full build, both artifacts, version resource intact
- a real v6→v7 migration on a real 50 MB database: backup produced, **70,733 rows verified identical**, compacted 50.6 MB → 6.5 MB
- a real downgrade against a v8 database
- the complete **2.1.4 → 2.1.5 portable update**: hand-off, swap, relaunch from the install path, leftover sweep

*(Writing the backup test surfaced the same class of bug in this PR's own new code within the hour: a SQLite connection used as a context manager commits but does not close, and the leaked handle locked the file on Windows. Fixed with an explicit `finally`.)*