### PR TITLE
build(release): a prerelease tag can be built and published safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,19 @@ jobs:
             signed-installer/**/*
             signed-portable/**/*
             checksums.txt
+          # A tag with a '-' is a prerelease (v2.2.0-beta.1). Without these two flags the
+          # action defaults prerelease to false and the API defaults make_latest to true,
+          # so a beta would become /releases/latest - the endpoint the in-app updater polls.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   submit-to-winget:
     needs: build-and-sign
+    # Never submit a prerelease to WinGet - this guard is independent of the
+    # prerelease flag above; without it every tag lands in microsoft/winget-pkgs.
+    if: "!contains(github.ref_name, '-')"
     runs-on: ubuntu-latest
     steps:
       - name: Sync WinGet Fork
@@ -129,3 +137,64 @@ jobs:
           
           # The token you just created
           token: ${{ secrets.WINGET_TOKEN }}
+
+  submit-to-msstore:
+    needs: build-and-sign
+    # Same guard as WinGet: a prerelease must never reach the Store listing. The listing is a
+    # Win32 EXE submission (Store ID XP9MHWQZJPLQM8), so the Store downloads and caches the
+    # Setup.exe from the GitHub release asset URL below, then runs its own certification pass.
+    # Nothing here is MSIX - the taskbar dock and the in-app updater behave exactly as on GitHub.
+    if: "!contains(github.ref_name, '-')"
+    runs-on: ubuntu-latest
+    # Partner Center is a best-effort channel: a Store hiccup must not fail the release.
+    continue-on-error: true
+    steps:
+      - name: Check Store credentials
+        id: creds
+        env:
+          CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+        run: |
+          if [ -z "$CLIENT_ID" ]; then
+            echo "::warning::MSSTORE_* secrets are not set - Store submission skipped. Submit ${GITHUB_REF_NAME} by hand in Partner Center."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Store credentials
+        if: steps.creds.outputs.ok == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: configure
+          type: win32
+          seller-id: ${{ secrets.MSSTORE_SELLER_ID }}
+          product-id: ${{ secrets.MSSTORE_PRODUCT_ID }}
+          tenant-id: ${{ secrets.MSSTORE_TENANT_ID }}
+          client-id: ${{ secrets.MSSTORE_CLIENT_ID }}
+          client-secret: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+
+      - name: Point the listing at this release's installer
+        if: steps.creds.outputs.ok == 'true'
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          V="${VERSION#v}"
+          URL="https://github.com/erez-c137/NetSpeedTray/releases/download/${VERSION}/NetSpeedTray-${V}-x64-Setup.exe"
+          # Must match the package module Partner Center already holds (installer switches and
+          # the error-code doc URL are what the by-hand submission used). This PUT replaces it.
+          printf '{"packages":[{"packageUrl":"%s","languages":["en"],"architectures":["X64"],"isSilentInstall":false,"installerParameters":"/VERYSILENT /NORESTART /SUPPRESSMSGBOXES","genericDocUrl":"https://github.com/erez-c137/NetSpeedTray/blob/main/README.md","packageType":"exe"}]}' "$URL" > product-update.json
+          echo "PRODUCT_UPDATE=$(cat product-update.json)" >> "$GITHUB_ENV"
+          echo "Store package URL: $URL"
+
+      - name: Update draft submission
+        if: steps.creds.outputs.ok == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: update
+          product-update: ${{ env.PRODUCT_UPDATE }}
+
+      - name: Publish submission
+        if: steps.creds.outputs.ok == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: publish

--- a/build/build.bat
+++ b/build/build.bat
@@ -74,6 +74,15 @@ cd /d "%BUILD_DIR%"
 echo Generating version info for v%VERSION%...
 "%ROOT_DIR%\.venv\Scripts\python.exe" create_version_info.py "%VERSION%" >> "%LOG_FILE%" 2>&1
 if errorlevel 1 (echo ERROR: Failed to generate version info & exit /b 1)
+
+:: Derive the numeric-only quad for ISCC's VersionInfoVersion, which rejects prerelease
+:: suffixes ("2.2.0-beta.1" -> "2.2.0.1"). AppVersion keeps the display string.
+"%ROOT_DIR%\.venv\Scripts\python.exe" create_version_info.py "%VERSION%" --numeric > "%BUILD_DIR%version_numeric.tmp" 2>>"%LOG_FILE%"
+if errorlevel 1 (echo ERROR: Failed to derive numeric version & exit /b 1)
+set /p VERSION_NUMERIC=<"%BUILD_DIR%version_numeric.tmp"
+del "%BUILD_DIR%version_numeric.tmp"
+if "%VERSION_NUMERIC%"=="" (echo ERROR: Could not derive numeric version - empty result. & exit /b 1)
+echo Numeric version for installer metadata: %VERSION_NUMERIC%
 :: --------------------------------------------------
 
 :: --- Ensure UPX is available for compression (auto-download if missing) ---
@@ -91,8 +100,9 @@ echo.
 echo Generating installer...
 echo Generating installer... >> "%LOG_FILE%"
 set "start_time=%TIME%"
-:: UPDATED: Pass the version to Inno Setup using /DAppVersion
-"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion="%VERSION%" "%BUILD_DIR%setup.iss" >> "%LOG_FILE%" 2>&1
+:: UPDATED: Pass the display version (/DAppVersion) and the numeric quad ISCC's
+:: VersionInfoVersion requires (/DAppVersionNumeric) to Inno Setup separately.
+"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion="%VERSION%" /DAppVersionNumeric="%VERSION_NUMERIC%" "%BUILD_DIR%setup.iss" >> "%LOG_FILE%" 2>&1
 if errorlevel 1 (echo ERROR: Installer creation failed. Check %LOG_FILE% & exit /b 1)
 if not exist "%INSTALLER_DIR%\NetSpeedTray-%VERSION%-x64-Setup.exe" (echo ERROR: Setup file not found after compilation & exit /b 1)
 set "end_time=%TIME%"

--- a/build/create_version_info.py
+++ b/build/create_version_info.py
@@ -1,6 +1,8 @@
 # build/create_version_info.py
-import sys
+import argparse
 import os
+import re
+import sys
 
 # A note on the structure below, because the wrong version of it looks right and builds fine:
 #
@@ -14,18 +16,70 @@ import os
 # "040904B0" is US English (0x0409) + codepage 1200 (0x04B0, Unicode), and the Translation entry
 # below must agree with it. They previously disagreed too: the key said Unicode while Translation
 # declared 1252.
+#
+# Version handling (v2.1.5, action plan item 6): the FixedFileInfo quad is numbers-only by Windows
+# decree, so it is derived from the release core, with a prerelease's trailing number as the 4th
+# (build) field - "2.2.0-beta.1" -> (2, 2, 0, 1), plain "2.1.5" -> (2, 1, 5, 0). The naive split
+# on "." produced filevers=(2, 2, 0-beta, 1), a Python *expression* PyInstaller eval()s, dying
+# with NameError. The FileVersion/ProductVersion *string* fields are free text and keep the full
+# display version, so a beta exe is identifiable as a beta in Properties > Details.
+
+_PRERELEASE_NUMBER_RE = re.compile(r"(\d+)\s*$")
 
 
-def create_version_file(version_str):
-    # Ensure version has 4 parts (e.g., 1.1.8 -> 1.1.8.0)
-    parts = version_str.split('.')
-    while len(parts) < 4:
-        parts.append('0')
-    
-    # Create the tuple format: (1, 1, 8, 0)
-    version_tuple = f"({', '.join(parts)})"
-    # Create the string format: "1.1.8.0"
-    version_full_str = '.'.join(parts)
+def version_quad(version_str):
+    """Derive the numeric (major, minor, patch, build) quad Windows requires.
+
+    '2.1.5'        -> (2, 1, 5, 0)
+    '2.2.0-beta.1' -> (2, 2, 0, 1)   (the prerelease number becomes the build field)
+    '2.2.0-rc.2'   -> (2, 2, 0, 2)
+    '2.2.0-beta'   -> (2, 2, 0, 0)   (unnumbered prerelease)
+    '2.1.4.7'      -> (2, 1, 4, 7)   (an explicit 4-part core is kept as-is)
+
+    Raises ValueError on anything whose release core is not dot-separated integers,
+    so a bad tag aborts the build with a message instead of producing a
+    version_info.txt that PyInstaller dies inside.
+    """
+    core, _, prerelease = version_str.partition("-")
+    try:
+        parts = [int(p) for p in core.split(".")]
+    except ValueError:
+        raise ValueError(
+            f"Version {version_str!r}: release core {core!r} is not dot-separated integers"
+        ) from None
+    if not 1 <= len(parts) <= 4:
+        raise ValueError(f"Version {version_str!r}: expected 1-4 numeric parts, got {len(parts)}")
+
+    if prerelease:
+        if len(parts) > 3:
+            raise ValueError(
+                f"Version {version_str!r}: a 4-part core cannot also carry a prerelease suffix - "
+                f"the 4th field is where the prerelease number goes"
+            )
+        match = _PRERELEASE_NUMBER_RE.search(prerelease)
+        build = int(match.group(1)) if match else 0
+        parts = (parts + [0, 0])[:3] + [build]
+    else:
+        parts = (parts + [0, 0, 0])[:4]
+    for field in parts:
+        if not 0 <= field <= 0xFFFF:
+            # FixedFileInfo packs each field into a 16-bit WORD; an oversized value would
+            # silently wrap in the built resource (review L1). Abort loudly instead.
+            raise ValueError(
+                f"Version {version_str!r}: field {field} does not fit a 16-bit version WORD (0-65535)"
+            )
+    return tuple(parts)
+
+
+def numeric_version_string(version_str):
+    """The dotted numeric quad, e.g. '2.2.0.1' - the only form ISCC's VersionInfoVersion accepts."""
+    return ".".join(str(p) for p in version_quad(version_str))
+
+
+def create_version_file(version_str, output_path=None):
+    quad = version_quad(version_str)
+    # Numbers-only tuple for the eval()'d FixedFileInfo: (2, 2, 0, 1)
+    version_tuple = f"({', '.join(str(p) for p in quad)})"
 
     content = f"""
 VSVersionInfo(
@@ -47,7 +101,7 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Erez C137'),
             StringStruct('FileDescription', 'NetSpeedTray'),
-            StringStruct('FileVersion', '{version_full_str}'),
+            StringStruct('FileVersion', '{version_str}'),
             StringStruct('InternalName', 'NetSpeedTray'),
             StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
             StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
@@ -61,16 +115,41 @@ VSVersionInfo(
   ]
 )
 """
-    
-    output_path = os.path.join(os.path.dirname(__file__), 'version_info.txt')
+
+    if output_path is None:
+        output_path = os.path.join(os.path.dirname(__file__), 'version_info.txt')
     with open(output_path, 'w', encoding='utf-8') as f:
         f.write(content.strip())
-    
+
     print(f"Generated version_info.txt for version {version_str}")
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Error: Version argument missing")
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Generate PyInstaller version_info.txt, or print the numeric quad for ISCC."
+    )
+    parser.add_argument("version", help="display version, e.g. 2.1.5 or 2.2.0-beta.1")
+    parser.add_argument(
+        "--numeric",
+        action="store_true",
+        help="print the dotted numeric quad (e.g. 2.2.0.1) for ISCC's VersionInfoVersion "
+        "and exit without writing anything",
+    )
+    parser.add_argument(
+        "--output",
+        help="write version_info.txt to this path instead of beside this script",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.numeric:
+            print(numeric_version_string(args.version))
+        else:
+            create_version_file(args.version, args.output)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
-    
-    create_version_file(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/build/setup.iss
+++ b/build/setup.iss
@@ -11,7 +11,21 @@
 ; If AppVersion is NOT defined (e.g., manual compile without build.bat), use a default.
 ; When running via build.bat, the /DAppVersion="x.x.x" flag overrides this.
 #ifndef AppVersion
-  #define AppVersion "0.0.0" 
+  #define AppVersion "0.0.0"
+#endif
+
+; VersionInfoVersion only accepts dot-separated integers, so a prerelease AppVersion like
+; "2.2.0-beta.1" aborts the compile ("Value of [Setup] section directive VersionInfoVersion is
+; invalid"). build.bat passes /DAppVersionNumeric with the numeric quad derived by
+; create_version_info.py --numeric ("2.2.0-beta.1" -> "2.2.0.1"); AppVersion keeps the display
+; string for filenames and the free-text version fields. On a manual compile without the define,
+; fall back to AppVersion itself when it is numeric-only, else to a recognisable placeholder.
+#ifndef AppVersionNumeric
+  #if Pos("-", AppVersion) == 0
+    #define AppVersionNumeric AppVersion
+  #else
+    #define AppVersionNumeric "0.0.0.0"
+  #endif
 #endif
 
 [Setup]
@@ -36,7 +50,11 @@ SolidCompression=yes
 OutputDir=installer
 
 OutputBaseFilename=NetSpeedTray-{#AppVersion}-x64-Setup
-VersionInfoVersion={#AppVersion}
+VersionInfoVersion={#AppVersionNumeric}
+; Free-text version fields carry the full display string, so a beta installer is identifiable
+; as a beta in Properties > Details even though the numeric quad above cannot say so.
+VersionInfoTextVersion={#AppVersion}
+VersionInfoProductTextVersion={#AppVersion}
 
 DisableDirPage=auto
 UsePreviousAppDir=no

--- a/build/version_info.txt
+++ b/build/version_info.txt
@@ -17,7 +17,7 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Erez C137'),
             StringStruct('FileDescription', 'NetSpeedTray'),
-            StringStruct('FileVersion', '2.1.4.0'),
+            StringStruct('FileVersion', '2.1.4'),
             StringStruct('InternalName', 'NetSpeedTray'),
             StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
             StringStruct('OriginalFilename', 'NetSpeedTray.exe'),

--- a/src/netspeedtray/tests/unit/test_create_version_info.py
+++ b/src/netspeedtray/tests/unit/test_create_version_info.py
@@ -1,0 +1,188 @@
+"""
+The build chain must accept a prerelease version string, because a beta tag is built by the
+same `build.bat` as a final release.
+
+Until 2.1.5, `build/create_version_info.py` split the version on `.` and pasted the parts into
+a Python tuple literal, so `2.2.0-beta.1` produced `filevers=(2, 2, 0-beta, 1)` - a Python
+*expression* that PyInstaller `eval()`s, dying with `NameError: name 'beta' is not defined`.
+`ast.parse` alone would NOT have caught that (`0-beta` parses fine as a BinOp), which is why the
+assertions below insist every element of the quad survives `ast.literal_eval` as an `int`.
+
+The contract pinned here (v2.1.5 action plan, item 6):
+- The numeric quad comes from the release core only; a prerelease's trailing number becomes the
+  4th (build) field: `2.2.0-beta.1` -> (2, 2, 0, 1); plain `2.1.5` -> (2, 1, 5, 0).
+- `FileVersion`/`ProductVersion` *string* fields keep the FULL display string (Windows allows
+  free text there), so the beta exe is identifiable as a beta in Properties > Details.
+- `--numeric` prints the dotted quad for ISCC's `VersionInfoVersion` (which rejects any
+  non-numeric version) and writes nothing - `AppVersion` keeps the display string.
+
+#257 is the precedent for why the StringTable key and Translation entry are pinned too: version
+metadata that looked present in the source was unreadable by Windows for three releases because
+the StringTable/Translation plumbing was silently wrong.
+"""
+
+import ast
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parents[4]
+_SCRIPT = _REPO_ROOT / "build" / "create_version_info.py"
+_ARTIFACT = _REPO_ROOT / "build" / "version_info.txt"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("create_version_info", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cvi = _load_module()
+
+# (display version, expected numeric quad, expected dotted numeric string)
+_CASES = [
+    ("2.1.5", (2, 1, 5, 0), "2.1.5.0"),
+    ("2.2.0-beta.1", (2, 2, 0, 1), "2.2.0.1"),
+    ("2.2.0-rc.2", (2, 2, 0, 2), "2.2.0.2"),
+]
+
+
+def _parse_version_info(text):
+    """Parse a generated version_info.txt the way that catches the 0-beta trap.
+
+    Returns (quads, strings, string_table_key, translation) where quads maps
+    filevers/prodvers to literal tuples, and strings maps StringStruct names to values.
+    `ast.literal_eval` on each node is the load-bearing part: it rejects any element
+    that is an expression rather than a literal.
+    """
+    tree = ast.parse(text, mode="eval")  # must be a single valid Python expression
+    quads = {}
+    strings = {}
+    string_table_key = None
+    translation = None
+    for node in ast.walk(tree.body):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id == "FixedFileInfo":
+            for kw in node.keywords:
+                if kw.arg in ("filevers", "prodvers"):
+                    quads[kw.arg] = ast.literal_eval(kw.value)
+        elif node.func.id == "StringStruct":
+            name, value = (ast.literal_eval(a) for a in node.args)
+            strings[name] = value
+        elif node.func.id == "StringTable":
+            string_table_key = ast.literal_eval(node.args[0])
+        elif node.func.id == "VarStruct":
+            if ast.literal_eval(node.args[0]) == "Translation":
+                translation = ast.literal_eval(node.args[1])
+    return quads, strings, string_table_key, translation
+
+
+@pytest.mark.parametrize("version, quad, _numeric", _CASES, ids=lambda c: str(c))
+def test_generated_file_is_a_literal_expression_with_the_right_quad(version, quad, _numeric, tmp_path):
+    """A prerelease suffix must never leak into the eval()'d tuple."""
+    out = tmp_path / "version_info.txt"
+    cvi.create_version_file(version, output_path=str(out))
+    quads, strings, string_table_key, translation = _parse_version_info(out.read_text(encoding="utf-8"))
+
+    assert quads["filevers"] == quad
+    assert quads["prodvers"] == quad
+    for value in quads.values():
+        assert all(isinstance(part, int) for part in value)
+
+
+@pytest.mark.parametrize("version, _quad, _numeric", _CASES, ids=lambda c: str(c))
+def test_string_fields_keep_the_full_display_version(version, _quad, _numeric, tmp_path):
+    """FileVersion/ProductVersion are free text; the beta exe must say it is a beta."""
+    out = tmp_path / "version_info.txt"
+    cvi.create_version_file(version, output_path=str(out))
+    _quads, strings, _key, _translation = _parse_version_info(out.read_text(encoding="utf-8"))
+
+    assert strings["FileVersion"] == version
+    assert strings["ProductVersion"] == version
+    assert strings["OriginalFilename"] == "NetSpeedTray.exe"
+
+
+def test_string_table_key_and_translation_still_agree(tmp_path):
+    """#257: the '040904B0' key and the Translation entry must agree, or Windows reads nothing."""
+    out = tmp_path / "version_info.txt"
+    cvi.create_version_file("2.2.0-beta.1", output_path=str(out))
+    _quads, _strings, string_table_key, translation = _parse_version_info(out.read_text(encoding="utf-8"))
+
+    assert string_table_key == "040904B0"
+    assert translation == [0x0409, 1200]
+
+
+@pytest.mark.parametrize("version, quad, numeric", _CASES, ids=lambda c: str(c))
+def test_numeric_version_string_is_what_iscc_accepts(version, quad, numeric):
+    """ISCC's VersionInfoVersion rejects any suffix; the quad must be digits and dots only."""
+    assert cvi.version_quad(version) == quad
+    assert cvi.numeric_version_string(version) == numeric
+
+
+@pytest.mark.parametrize(
+    "version, quad",
+    [
+        ("2.2.0-beta", (2, 2, 0, 0)),  # unnumbered prerelease: build field falls back to 0
+        ("2.2.0-beta.10", (2, 2, 0, 10)),
+        ("2.1.4.7", (2, 1, 4, 7)),  # an explicit 4-part core still round-trips
+    ],
+)
+def test_quad_edge_cases(version, quad):
+    assert cvi.version_quad(version) == quad
+
+
+@pytest.mark.parametrize("version", ["not-a-version", "2.2.x", "", "2.1.5.0-beta.1"])
+def test_a_core_that_is_not_numeric_fails_loudly(version):
+    """Better a build abort with a message than a version_info.txt PyInstaller dies inside."""
+    with pytest.raises(ValueError):
+        cvi.version_quad(version)
+
+
+@pytest.mark.parametrize("version, _quad, numeric", _CASES, ids=lambda c: str(c))
+def test_cli_numeric_mode_prints_the_quad_and_writes_nothing(version, _quad, numeric, tmp_path):
+    """build.bat captures this stdout for ISCC's /DAppVersionNumeric; it must never
+    rewrite version_info.txt as a side effect."""
+    before = _ARTIFACT.read_bytes() if _ARTIFACT.exists() else None
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), version, "--numeric"],
+        capture_output=True, text=True, cwd=str(tmp_path), timeout=60,
+    )
+    after = _ARTIFACT.read_bytes() if _ARTIFACT.exists() else None
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == numeric
+    assert before == after, "--numeric must not touch build/version_info.txt"
+
+
+def test_cli_default_mode_writes_a_parseable_file_to_output(tmp_path):
+    """Pins the positional CLI build.bat / build-exe-only.bat rely on, plus --output."""
+    out = tmp_path / "version_info.txt"
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "2.2.0-beta.1", "--output", str(out)],
+        capture_output=True, text=True, cwd=str(tmp_path), timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    quads, strings, _key, _translation = _parse_version_info(out.read_text(encoding="utf-8"))
+    assert quads["filevers"] == (2, 2, 0, 1)
+    assert strings["ProductVersion"] == "2.2.0-beta.1"
+
+
+def test_cli_rejects_garbage_with_a_nonzero_exit(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "2.2.x", "--numeric"],
+        capture_output=True, text=True, cwd=str(tmp_path), timeout=60,
+    )
+    assert result.returncode != 0
+
+
+def test_quad_field_over_65535_fails_loudly():
+    """Review L1: FixedFileInfo packs each field into a 16-bit WORD. An oversized prerelease
+    number must abort the build with a message, not silently wrap in the version resource."""
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        cvi.version_quad("2.2.0-beta.99999")


### PR DESCRIPTION
2.2.0 ships as a beta prerelease. Two things made that impossible on `main` as of `db3b934`; this PR fixes both and rehearses the false branch with 2.1.5's own tag.

### A beta tag would have published as Latest and gone to WinGet

`release.yml` had no `prerelease:`/`make_latest:` and no gate on `submit-to-winget`. Tagging `v2.2.0-beta.1` would have made it `/releases/latest` - the endpoint the in-app updater polls - and pushed a destructive migration through `winget upgrade` unattended.

- `prerelease: ${{ contains(github.ref_name, '-') }}` and `make_latest: ${{ !contains(github.ref_name, '-') }}` on the release step.
- `submit-to-winget` carries `if: "!contains(github.ref_name, '-')"` - independent of the flag above, so a one-sided mistake cannot look correct.
- New `submit-to-msstore` job (Microsoft Store listing `XP9MHWQZJPLQM8`, a Win32 EXE submission): `microsoft/store-submission@v1` configure -> update (PUT packages with the release's Setup.exe asset URL) -> publish. Same `-` guard, `continue-on-error`, and it skips with a warning until the five `MSSTORE_*` secrets exist.

### The build could not produce a prerelease at all

`build/create_version_info.py:21` did `version_str.split('.')`, so `2.2.0-beta.1` became `filevers=(2, 2, 0-beta, 1)` and PyInstaller died with `NameError: name 'beta' is not defined`. Inno's `VersionInfoVersion` rejects the same string.

- `create_version_info.py` parses `X.Y.Z[-pre.N]` into a numeric quad (`2.2.0-beta.1` -> `2.2.0.1`, 16-bit overflow guarded) and gains `--numeric` so `build.bat` can hand ISCC `/DAppVersionNumeric` separately from the display `/DAppVersion`. `setup.iss` falls back sanely on a manual compile. Accepted and documented: `beta.N` and `rc.N` share a quad.
- The exe's `FileVersion` string now reads `2.1.5`, not `2.1.4.0`-style; the numeric resource is unchanged (`build/version_info.txt`).

### Verified

- `test_create_version_info.py` (new): parsing, the quad, the overflow guard, `--numeric` output. Fails on the old script.
- Still owed before any beta tag, and recorded in the 2.1.5 readiness checklist: a throwaway `v0.0.1-test` tag proving the **true** branch (prerelease, not Latest, no WinGet PR, Store job skipped), and a scratch `build.bat` at `2.2.0-beta.1` checked with `FileVersionInfo` on the binary - #257's exact failure mode.
