### PR TITLE
fix(monitor,sensors): the dead graph hover and placeholder thermal zones (#275, #237)

### DIFF
--- a/src/netspeedtray/core/monitor_thread.py
+++ b/src/netspeedtray/core/monitor_thread.py
@@ -123,6 +123,11 @@ class StatsMonitorThread(QThread):
         self._wmi_ohm: Any = None
         self._ohm_guidance_logged: bool = False  # One-time "no sensor source" guidance, logged only when NO namespace connects
         self._last_temp_source_sig: Optional[Tuple[str, str]] = None  # (source, sensor) of the last-logged CPU-temp read; re-logged only on change (#216)
+        # ACPI thermal-zone placeholder detection (#237, #275): first raw value seen per zone, the
+        # zones that have moved since (trusted for good), and the ones already logged as placeholders.
+        self._thermal_first_raw: Dict[Any, float] = {}
+        self._thermal_moved: set = set()
+        self._thermal_placeholder_logged: set = set()
         self._lhm_notice_emitted: bool = False  # One-time notification flag
         self._lhm_check_polls: int = 0  # Count polls before emitting notice
         self._last_identity_poll: float = 0.0  # monotonic ts of the last network-identity sub-poll (0 = poll immediately)
@@ -535,6 +540,10 @@ class StatsMonitorThread(QThread):
             self._thermal_query = None
             self._thermal_counters = []
             self._thermal_hp_counters = []
+            for key in [k for k in self._thermal_first_raw if k[0] == "pdh"]:
+                self._thermal_first_raw.pop(key, None)
+                self._thermal_moved.discard(key)
+                self._thermal_placeholder_logged.discard(key)
 
     def _init_power_query(self) -> bool:
         """Initializes Windows PDH query for Intel RAPL power counters (Energy Meter).
@@ -821,6 +830,8 @@ class StatsMonitorThread(QThread):
                                 # Standard: tenths of Kelvin → Celsius
                                 celsius = (val / 10.0) - 273.15
                                 if 0.0 < celsius < 150.0:
+                                    if self._is_placeholder_zone(("pdh", handle), val):
+                                        continue
                                     readings.append(celsius)
                                 # Some OEMs (HP, Dell) report direct Celsius
                                 elif 15.0 < val < 110.0:
@@ -835,6 +846,8 @@ class StatsMonitorThread(QThread):
                                 if val is not None:
                                     celsius = (val / 10.0) - 273.15
                                     if 0.0 < celsius < 150.0:
+                                        if self._is_placeholder_zone(("pdh", handle), val):
+                                            continue
                                         readings.append(celsius)
                             except: continue
 
@@ -853,11 +866,13 @@ class StatsMonitorThread(QThread):
                 except Exception:
                     self._wmi = win32com.client.GetObject("winmgmts:root\\wmi")
             temps = self._wmi.ExecQuery("SELECT CurrentTemperature FROM MSAcpi_ThermalZoneTemperature")
-            for t in temps:
+            for idx, t in enumerate(temps):
                 raw = t.CurrentTemperature
                 # Standard ACPI: tenths of Kelvin (valid range ~2932-3932 for 20-120°C)
                 celsius = (raw / 10.0) - 273.15
                 if 0.0 < celsius < 150.0:
+                    if self._is_placeholder_zone(("msacpi", idx), float(raw)):
+                        continue
                     return self._log_temp(celsius, "MSAcpi", "Thermal Zone")
                 # Some OEMs (HP, Dell, Lenovo) return direct Celsius instead
                 if 15.0 < raw < 110.0:
@@ -868,6 +883,31 @@ class StatsMonitorThread(QThread):
             if "RPC server is unavailable" in str(e) or "0x800706ba" in str(e):
                 self._wmi = None
         return None
+
+    def _is_placeholder_zone(self, key: Any, raw: float) -> bool:
+        """True when an ACPI thermal zone is firmware filling in a field rather than a sensor.
+
+        #275's board answers exactly 290.0 K on every poll (shown as 17 °C); #237's answers 300.0 K
+        (27 °C). Real zones report tenths of a kelvin - a Celsius-derived value lands on x.x5 - and
+        they drift. So a zone is a placeholder while its reading is a whole ten-kelvin multiple
+        (raw % 100 == 0 in tenths) AND it has never reported anything else. The first time a zone's
+        value changes it is trusted for good, so a genuine coarse sensor that starts on a round
+        value loses at most its first poll, and one that passes through a round value later loses
+        nothing.
+        """
+        first = self._thermal_first_raw.setdefault(key, raw)
+        if raw != first:
+            self._thermal_moved.add(key)
+        if key in self._thermal_moved or raw % 100 != 0:
+            return False
+        if key not in self._thermal_placeholder_logged:
+            self._thermal_placeholder_logged.add(key)
+            self.logger.info(
+                "Ignoring ACPI thermal zone %s: it reports a fixed %.1f K (%.1f°C) on every poll - "
+                "a firmware placeholder, not a sensor (#275). No CPU temperature will be shown "
+                "unless a real source (e.g. LibreHardwareMonitor) is available.",
+                key, raw / 10.0, raw / 10.0 - 273.15)
+        return True
 
     def _log_temp(self, celsius: float, source: str, sensor: str) -> float:
         """Logs the selected CPU-temperature source once, and again only when it

--- a/src/netspeedtray/tests/unit/test_cpu_temp_sensor_selection.py
+++ b/src/netspeedtray/tests/unit/test_cpu_temp_sensor_selection.py
@@ -142,3 +142,87 @@ class TestLegitimateCpuSensorsStillResolve:
         ])
         with patch.object(thread, "_init_ohm_wmi"):
             assert thread._poll_cpu_temperature() == 57.0
+
+# ---------------------------------------------------------------------------------------------
+# ACPI thermal zones that are placeholders, not sensors (#237, #275)
+# ---------------------------------------------------------------------------------------------
+
+def _pdh_returning(raw_by_poll):
+    """A win32pdh stub exposing ONE thermal zone whose High Precision Temperature counter returns
+    the next value in `raw_by_poll` (tenths of a kelvin) on each poll. The standard Temperature
+    counter is left unreadable so the high-precision path is the only source."""
+    import itertools
+    pdh = MagicMock()
+    pdh.OpenQuery.return_value = 7
+    pdh.EnumObjectItems.return_value = (None, ["\_TZ.TZ00"])
+    handles = itertools.count(100)
+    pdh.AddCounter.side_effect = lambda q, path: next(handles)   # 100 = HP, 101 = standard
+    values = iter(raw_by_poll)
+
+    def formatted(handle, fmt):
+        if handle == 100:
+            return (0, float(next(values)))
+        raise OSError("counter unavailable")
+    pdh.GetFormattedCounterValue.side_effect = formatted
+    return pdh
+
+
+class TestAcpiPlaceholderZonesAreNotSensors:
+    """#275's board reports exactly 290.0 K on every poll and shows as 17 °C; #237's reports 300.0 K
+    and shows as 27 °C. Real zones report tenths of a kelvin and drift. A zone that only ever
+    returns one round-kelvin value is firmware filling in a field, and the honest readout is none."""
+
+    def _only_pdh(self, thread, pdh):
+        thread._init_ohm_wmi = lambda: None            # no LHM/OHM
+        thread._wmi_ohm = None
+        return (
+            patch("netspeedtray.core.monitor_thread.win32pdh", pdh),
+            patch("netspeedtray.core.monitor_thread.win32com.client", None),
+        )
+
+    def test_a_fixed_round_kelvin_zone_is_ignored(self, thread):
+        p1, p2 = self._only_pdh(thread, _pdh_returning([2900.0] * 5))     # 290.0 K forever (#275)
+        with p1, p2:
+            assert [thread._poll_cpu_temperature() for _ in range(5)] == [None] * 5
+
+    def test_three_hundred_kelvin_forever_is_the_237_case(self, thread):
+        p1, p2 = self._only_pdh(thread, _pdh_returning([3000.0] * 3))
+        with p1, p2:
+            assert [thread._poll_cpu_temperature() for _ in range(3)] == [None] * 3
+
+    def test_a_real_zone_is_read_normally(self, thread):
+        p1, p2 = self._only_pdh(thread, _pdh_returning([3284.0, 3291.0]))  # 55.25, 55.95 °C
+        with p1, p2:
+            assert thread._poll_cpu_temperature() == pytest.approx(55.25)
+            assert thread._poll_cpu_temperature() == pytest.approx(55.95)
+
+    def test_a_zone_that_moves_is_trusted_even_on_a_round_value(self, thread):
+        # Starts on 300.0 K (looks like #237), then moves - a real, coarse sensor. From then on it
+        # is trusted, including when it lands back on the round value.
+        p1, p2 = self._only_pdh(thread, _pdh_returning([3000.0, 3010.0, 3000.0]))
+        with p1, p2:
+            assert thread._poll_cpu_temperature() is None
+            assert thread._poll_cpu_temperature() == pytest.approx(27.85)
+            assert thread._poll_cpu_temperature() == pytest.approx(26.85)
+
+    def test_the_placeholder_is_logged_once_not_per_poll(self, thread):
+        p1, p2 = self._only_pdh(thread, _pdh_returning([2900.0] * 4))
+        with p1, p2:
+            for _ in range(4):
+                thread._poll_cpu_temperature()
+        placeholder_logs = [c for c in thread.logger.info.call_args_list
+                            if "placeholder" in str(c.args[0]).lower()]
+        assert len(placeholder_logs) == 1
+
+    def test_the_wmi_fallback_applies_the_same_rule(self, thread):
+        """Source 3 (MSAcpi_ThermalZoneTemperature) is the same zone through a different door."""
+        zone = MagicMock(); zone.CurrentTemperature = 2900
+        wmi = MagicMock(); wmi.ExecQuery.return_value = [zone]
+        thread._init_ohm_wmi = lambda: None
+        thread._wmi_ohm = None
+        thread._wmi = wmi
+        with patch("netspeedtray.core.monitor_thread.win32pdh", None):
+            assert thread._poll_cpu_temperature() is None
+            zone.CurrentTemperature = 3284
+            assert thread._poll_cpu_temperature() == pytest.approx(55.25)
+

--- a/src/netspeedtray/tests/unit/test_graph_hover.py
+++ b/src/netspeedtray/tests/unit/test_graph_hover.py
@@ -1,31 +1,49 @@
 """
 GraphHoverTooltip - the Monitor graph's lightweight hover readout (ported feature: the one thing the
-old Graph window had that the Monitor lacked). The mouse-snap path needs a live matplotlib canvas, so
-that's covered by a standalone smoke script; here we cover the canvas-free formatting: the network graph
-formats values as speed, the hardware graphs as percent, and the timestamp + series name are shown.
+old Graph window had that the Monitor lacked). The mouse-snap path needs a live Qt canvas, so that is
+covered by the GUI smoke test; here we cover everything canvas-free: which lines the tooltip reads,
+how a series drawn in several segments collapses to one row, and the formatting - the network graph
+as speed in the user's unit, the hardware graphs as percent, timestamp and series name shown.
+
+Two 2.1.5 fixes are pinned here. The network axes are plotted in Mbps (the renderer converts
+bytes/sec before plotting) while `format_speed()` takes bytes/sec; the tooltip fed one to the other,
+reading 40 Mbps as 40 B/s. Nobody saw it because no network line carried a label, so the hover never
+fired at all on that tab. The test that used to assert the bytes/sec contract asserted the bug.
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import matplotlib.dates as mdates
+import pytest
+from matplotlib.figure import Figure
 
 from netspeedtray.constants.i18n import I18nStrings
 from netspeedtray.views.monitor.graph_hover import GraphHoverTooltip
 
 
-def _host(stat):
-    return SimpleNamespace(_current_stat=stat,
-                           config={"unit_type": "bits_decimal", "decimal_places": 1},
-                           i18n=I18nStrings("en_US"))
+def _host(stat, **cfg):
+    config = {"unit_type": "bits_decimal", "decimal_places": 1}
+    config.update(cfg)
+    return SimpleNamespace(_current_stat=stat, config=config, i18n=I18nStrings("en_US"))
 
 
-def test_network_hover_formats_speed():
+# ----------------------------------------------------------------------------- formatting
+
+def test_network_hover_formats_the_plotted_mbps_as_speed():
     t = GraphHoverTooltip(_host("network"))
     x = mdates.date2num(datetime(2026, 6, 28, 14, 30, 0))
-    html = t._format(x, [("Download", 4.0e6, "#42B883")])
+    html = t._format(x, [("Download", 40.0, "#42B883")])      # 40 Mbps, as the axis carries it
     assert "14:30:00" in html
-    assert "Download" in html and "Mbps" in html      # bytes/sec -> bits/sec speed
-    assert "32.0" in html                              # 4 MB/s == 32 Mbps
+    assert "Download" in html and "Mbps" in html
+    assert "40.0" in html
+    assert "320" not in html                                   # the old readout: 40 B/s -> 320 bps
+
+
+def test_network_hover_honours_the_bytes_unit_setting():
+    t = GraphHoverTooltip(_host("network", unit_type="bytes_decimal"))
+    x = mdates.date2num(datetime(2026, 6, 28, 14, 30, 0))
+    html = t._format(x, [("Download", 40.0, "#42B883")])      # 40 Mbps == 5 MB/s
+    assert "5.0" in html and "MB/s" in html
 
 
 def test_hardware_hover_formats_percent():
@@ -35,3 +53,52 @@ def test_hardware_hover_formats_percent():
     assert "09:05:00" in html
     assert "CPU" in html and "42%" in html
     assert "RAM" in html and "67%" in html             # multiple series at the cursor time
+
+
+# ----------------------------------------------------------------------------- which lines are read
+
+T0 = datetime(2026, 6, 28, 12, 0, 0)
+
+
+def _axes_with(lines):
+    """A real matplotlib Axes (bare Figure, no Qt) with datetime-plotted lines, the way the renderer
+    draws them. The hover must read x in axis units - `event.xdata` is a date number, and the
+    lines' original data are datetimes, which cannot be compared to it."""
+    fig = Figure()
+    ax = fig.add_subplot(111)
+    for label, start, ys, style in lines:
+        xs = [start + timedelta(seconds=i) for i in range(len(ys))]
+        ax.plot(xs, ys, label=label, **style)
+    return ax
+
+
+def test_rows_at_reads_datetime_lines_and_skips_unlabelled_helpers():
+    ax = _axes_with([
+        ("Download", T0, [1.0, 2.0, 3.0, 4.0], {}),
+        ("Upload", T0, [0.5, 0.6, 0.7, 0.8], {}),
+        ("_bridge", T0, [0.0, 0.0, 0.0, 0.0], {"linestyle": "--"}),   # the renderer's gap bridge
+    ])
+    x = mdates.date2num(T0 + timedelta(seconds=2))
+    rows, nearest = GraphHoverTooltip(_host("network"))._rows_at(ax, x)
+    assert {r[0]: r[1] for r in rows} == {"Download": 3.0, "Upload": 0.7}
+    assert nearest == pytest.approx(x)
+
+
+def test_rows_at_collapses_a_segmented_series_to_the_segment_under_the_cursor():
+    """With gaps in the data the renderer plots one series as several segments sharing a label.
+    The tooltip shows that series once, from the segment the cursor is on - not once per segment."""
+    ax = _axes_with([
+        ("Download", T0, [1.0, 1.0, 1.0], {}),
+        ("Download", T0 + timedelta(seconds=10), [9.0, 9.0, 9.0], {}),
+    ])
+    ax.set_xlim(mdates.date2num(T0), mdates.date2num(T0 + timedelta(seconds=13)))
+    x = mdates.date2num(T0 + timedelta(seconds=11))
+    rows, _ = GraphHoverTooltip(_host("network"))._rows_at(ax, x)
+    assert [(r[0], r[1]) for r in rows] == [("Download", 9.0)]
+
+
+def test_rows_at_returns_nothing_far_from_any_sample():
+    ax = _axes_with([("Download", T0, [1.0, 2.0, 3.0], {})])
+    ax.set_xlim(mdates.date2num(T0), mdates.date2num(T0 + timedelta(minutes=10)))
+    x = mdates.date2num(T0 + timedelta(minutes=5))
+    assert GraphHoverTooltip(_host("network"))._rows_at(ax, x) == ([], None)

--- a/src/netspeedtray/tests/unit/test_graph_series_labels.py
+++ b/src/netspeedtray/tests/unit/test_graph_series_labels.py
@@ -1,0 +1,115 @@
+"""
+Every line the Monitor graph draws for a measured series carries a legend label, and every helper
+line (the dashed zero bridge across a gap) does not. The hover tooltip keys on exactly that:
+`GraphHoverTooltip._rows_at` reads `line.get_label()` and skips matplotlib's auto `_childN`. Until
+2.1.5 only the combined-hardware path passed `label=`, so the hover was dead on the Network tab and
+on the other two Hardware layouts - silently, because the tooltip simply never appeared.
+
+These go through the real GraphRenderer code paths onto real matplotlib axes (a bare Figure, no Qt
+canvas) and inspect the artists, because a mocked `ax.plot` cannot tell a labelled line from an
+unlabelled one the way matplotlib does. `_init_matplotlib` is replaced per test via monkeypatch -
+never by class assignment, which leaks into every later test in the session.
+"""
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from netspeedtray.constants import styles as style_constants
+from netspeedtray.constants.i18n import I18nStrings
+from netspeedtray.views.graph.renderer import GraphRenderer
+
+
+def _bare_init(self):
+    self.figure = Figure(figsize=(8, 6), dpi=100)
+    self.canvas = MagicMock()
+    gs = self.figure.add_gridspec(5, 1)
+    self.ax_download = self.figure.add_subplot(gs[0])
+    self.ax_upload = self.figure.add_subplot(gs[1])
+    self.ax_cpu = self.figure.add_subplot(gs[2])
+    self.ax_gpu = self.figure.add_subplot(gs[3])
+    self.ax_ram = self.figure.add_subplot(gs[4])
+    self.axes = [self.ax_download, self.ax_upload, self.ax_cpu, self.ax_gpu, self.ax_ram]
+    self._is_dark_mode = False
+    self._current_text_color = style_constants.LIGHT_MODE_TEXT_COLOR
+    self._current_grid_color = style_constants.GRID_COLOR_LIGHT
+
+
+@pytest.fixture
+def renderer(monkeypatch):
+    monkeypatch.setattr(GraphRenderer, "_init_matplotlib", _bare_init)
+    return GraphRenderer(MagicMock(), I18nStrings("en_US"))
+
+
+def _labels(ax):
+    return [str(line.get_label()) for line in ax.get_lines()]
+
+
+def _measured(ax):
+    return [lbl for lbl in _labels(ax) if not lbl.startswith("_")]
+
+
+T0 = datetime(2026, 6, 28, 12, 0, 0)
+PERIOD = "TIMELINE_24_HOURS"
+
+
+def _stamps(n, start=T0, step_s=1.0):
+    return [start + timedelta(seconds=i * step_s) for i in range(n)]
+
+
+# ----------------------------------------------------------------------------- network
+
+def test_network_lines_are_labelled_download_and_upload(renderer):
+    dts = _stamps(30)
+    renderer._plot_high_res(dts, np.full(30, 2.0), np.full(30, 10.0))
+    assert _measured(renderer.ax_download) == [renderer.i18n.DOWNLOAD_LABEL]
+    assert _measured(renderer.ax_upload) == [renderer.i18n.UPLOAD_LABEL]
+
+
+def test_gap_segments_are_labelled_and_the_bridge_is_not(renderer):
+    """Two chunks five minutes apart. Each measured segment carries the label; the dashed zero
+    bridge the renderer draws across the gap does not, so the hover can never report it."""
+    dts = _stamps(20) + _stamps(20, start=T0 + timedelta(minutes=5))
+    renderer._plot_high_res(dts, np.full(40, 1.0), np.full(40, 10.0))
+    lines = renderer.ax_download.get_lines()
+    measured = [line for line in lines if not str(line.get_label()).startswith("_")]
+    helpers = [line for line in lines if str(line.get_label()).startswith("_")]
+    assert len(measured) >= 2
+    assert {str(line.get_label()) for line in measured} == {renderer.i18n.DOWNLOAD_LABEL}
+    assert helpers, "the gap bridge should be drawn, unlabelled"
+    assert all(line.get_linestyle() == "--" for line in helpers)
+
+
+# ----------------------------------------------------------------------------- hardware
+
+def _hw_rows(n=30, value=50.0):
+    return [(T0 + timedelta(seconds=i), value) for i in range(n)]
+
+
+def test_hardware_separate_lines_carry_their_role_names(renderer):
+    data = {"cpu": _hw_rows(), "gpu": _hw_rows(value=30.0), "ram": _hw_rows(value=70.0)}
+    renderer._render_hwseparate(data, T0, T0 + timedelta(seconds=30), PERIOD, hw_styles={})
+    assert _measured(renderer.ax_cpu) == [renderer._hw_role_label("cpu")]
+    assert _measured(renderer.ax_gpu) == [renderer._hw_role_label("gpu")]
+    assert _measured(renderer.ax_ram) == [renderer._hw_role_label("ram")]
+
+
+def test_hardware_single_line_carries_its_role_name(renderer):
+    renderer._render_hwsingle(_hw_rows(), T0, T0 + timedelta(seconds=30), PERIOD, "gpu", hw_styles={})
+    assert _measured(renderer.ax_download) == [renderer._hw_role_label("gpu")]
+
+
+def test_hardware_combined_uses_the_same_names(renderer):
+    data = {"cpu": _hw_rows(), "gpu": _hw_rows(value=30.0)}
+    renderer._render_hwcombined(data, T0, T0 + timedelta(seconds=30), PERIOD, hw_styles={})
+    assert _measured(renderer.ax_download) == [renderer._hw_role_label("cpu"), renderer._hw_role_label("gpu")]
+
+
+def test_role_names_are_the_localized_ui_strings(renderer):
+    i18n = renderer.i18n
+    assert renderer._hw_role_label("cpu") == i18n.ORDER_TYPE_CPU
+    assert renderer._hw_role_label("gpu") == i18n.ORDER_TYPE_GPU
+    assert renderer._hw_role_label("ram") == i18n.MONITOR_TILE_RAM
+    assert renderer._hw_role_label("vram") == "VRAM"       # anything unmapped: readable, never `_child`

--- a/src/netspeedtray/views/graph/renderer.py
+++ b/src/netspeedtray/views/graph/renderer.py
@@ -797,6 +797,16 @@ class GraphRenderer(QObject):
         from netspeedtray.utils.mpl_fonts import shape_rtl
         return shape_rtl(text, getattr(self.i18n, "language", None))
 
+    def _hw_role_label(self, role: str) -> str:
+        """The name a hardware series carries as its matplotlib label - one place, so the legend and
+        the hover tooltip (which reads `line.get_label()` and skips unlabelled `_childN` lines)
+        agree wherever the line is drawn."""
+        return {
+            "cpu": getattr(self.i18n, "ORDER_TYPE_CPU", "CPU"),
+            "gpu": getattr(self.i18n, "ORDER_TYPE_GPU", "GPU"),
+            "ram": getattr(self.i18n, "MONITOR_TILE_RAM", "RAM"),
+        }.get(role, str(role).upper())
+
     def _format_hardware_axes(self, stat_type: str):
         """Formats the single axis for hardware utilization."""
         label = self.i18n.GRAPH_CPU_UTIL_AXIS_LABEL if stat_type == "cpu" else self.i18n.GRAPH_GPU_UTIL_AXIS_LABEL
@@ -837,9 +847,7 @@ class GraphRenderer(QObject):
         smooth = bool(styles.get("smoothing"))
         fixed = bool(styles.get("fixed_axis", True))
 
-        roles = (("cpu", getattr(self.i18n, "ORDER_TYPE_CPU", "CPU")),
-                 ("gpu", getattr(self.i18n, "ORDER_TYPE_GPU", "GPU")),
-                 ("ram", getattr(self.i18n, "MONITOR_TILE_RAM", "RAM")))
+        roles = tuple((role, self._hw_role_label(role)) for role in ("cpu", "gpu", "ram"))
         all_ts, handles, data_max = [], [], 0.0
         for role, label in roles:
             series = data_dict.get(role) or []
@@ -968,7 +976,7 @@ class GraphRenderer(QObject):
             dts = [datetime.fromtimestamp(t) for t in ts]
             ys = self._smooth_series(arr[:, 1], styles.get("smooth_window", 5)) if smooth else arr[:, 1]
             color, _ls = styles.get(role) or hv.graph_line_style(role)
-            ax.plot(dts, ys, color=color, linewidth=1.5, zorder=10)
+            ax.plot(dts, ys, color=color, linewidth=1.5, zorder=10, label=self._hw_role_label(role))
             self._apply_hw_ylim(ax, fixed, float(arr[:, 1].max()))
             any_data = True
             all_ts.append(ts)
@@ -1002,7 +1010,7 @@ class GraphRenderer(QObject):
         values = raw[:, 1]
         ys = self._smooth_series(values, styles.get("smooth_window", 5)) if smooth else values
         color, _ls = styles.get(stat_type) or hv.graph_line_style(stat_type)   # solid for a lone line
-        ax.plot(dts, ys, color=color, linewidth=1.5, zorder=10)
+        ax.plot(dts, ys, color=color, linewidth=1.5, zorder=10, label=self._hw_role_label(stat_type))
 
         xs, xe = self._hw_xlim(period_key, start_time, end_time, timestamps.min(), timestamps.max())
         ax.set_xlim(xs, xe)
@@ -1178,8 +1186,12 @@ class GraphRenderer(QObject):
                 seg_ts, seg_up, seg_down = self._process_plot_segment(ts, up, down, enable_spline=ENABLE_SPLINE)
                 
                 # Plot
-                self.ax_download.plot(seg_ts, seg_down, color=color_down, linewidth=1.5, zorder=10)
-                self.ax_upload.plot(seg_ts, seg_up, color=color_up, linewidth=1.5, zorder=10)
+                # label= is what the hover tooltip keys on; the dashed gap bridges stay unlabelled
+                # on purpose so the hover never reads a synthesized zero as a measurement.
+                self.ax_download.plot(seg_ts, seg_down, color=color_down, linewidth=1.5, zorder=10,
+                                      label=self.i18n.DOWNLOAD_LABEL)
+                self.ax_upload.plot(seg_ts, seg_up, color=color_up, linewidth=1.5, zorder=10,
+                                    label=self.i18n.UPLOAD_LABEL)
                 
                 # Add Gradient (per segment)
                 self._apply_gradient_fill(self.ax_download, np.array(seg_ts), seg_down, color_down, 'download')
@@ -1217,16 +1229,18 @@ class GraphRenderer(QObject):
                     self.line_upload.set_data(dense_ts, dense_up)
                 except Exception as e:
                     self.logger.debug(f"High-res update failed, rebuilding: {e}")
-                    self.line_download, = self.ax_download.plot(dense_ts, dense_down, color=color_down, linewidth=1.5, zorder=10)
-                    self.line_upload, = self.ax_upload.plot(dense_ts, dense_up, color=color_up, linewidth=1.5, zorder=10)
+                    self.line_download, = self.ax_download.plot(dense_ts, dense_down, color=color_down, linewidth=1.5, zorder=10,
+                                                                label=self.i18n.DOWNLOAD_LABEL)
+                    self.line_upload, = self.ax_upload.plot(dense_ts, dense_up, color=color_up, linewidth=1.5, zorder=10,
+                                                            label=self.i18n.UPLOAD_LABEL)
             else:
                 self.line_download, = self.ax_download.plot(
                     dense_ts, dense_down, 
-                    color=color_down, linewidth=1.5, zorder=10
+                    color=color_down, linewidth=1.5, zorder=10, label=self.i18n.DOWNLOAD_LABEL
                 )
                 self.line_upload, = self.ax_upload.plot(
                     dense_ts, dense_up, 
-                    color=color_up, linewidth=1.5, zorder=10
+                    color=color_up, linewidth=1.5, zorder=10, label=self.i18n.UPLOAD_LABEL
                 )
             
             # Apply premium gradient fills

--- a/src/netspeedtray/views/monitor/graph_hover.py
+++ b/src/netspeedtray/views/monitor/graph_hover.py
@@ -14,7 +14,7 @@ top-level matplotlib import here is fine - this module is only imported from ins
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 import numpy as np
 import matplotlib.dates as mdates
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import QLabel
 from netspeedtray.utils import styles as su
 from netspeedtray.constants.styles import styles as tokens
 from netspeedtray.utils.helpers import format_speed
+from netspeedtray import constants
 
 # Don't pop a tooltip when the cursor is miles from any point (in axis-fraction of the x-range).
 _MAX_SNAP_FRAC = 0.04
@@ -87,26 +88,7 @@ class GraphHoverTooltip(QObject):
             if ax is None or event.xdata is None or self._label is None:
                 self._hide()
                 return
-            xmin, xmax = ax.get_xlim()
-            span = (xmax - xmin) or 1.0
-            rows: List[Tuple[str, float, str]] = []   # (label, y, color)
-            nearest_x = None
-            best_dx = None
-            for line in ax.get_lines():
-                lbl = line.get_label()
-                if not lbl or lbl.startswith("_"):     # skip crosshairs / non-legend helper lines
-                    continue
-                xd = np.asarray(line.get_xdata(), dtype=float)
-                yd = np.asarray(line.get_ydata(), dtype=float)
-                if xd.size == 0 or yd.size != xd.size:
-                    continue
-                idx = int(np.argmin(np.abs(xd - event.xdata)))
-                dx = abs(xd[idx] - event.xdata)
-                if dx > span * _MAX_SNAP_FRAC:          # cursor too far from this line's samples
-                    continue
-                rows.append((str(lbl), float(yd[idx]), line.get_color()))
-                if best_dx is None or dx < best_dx:
-                    best_dx, nearest_x = dx, xd[idx]
+            rows, nearest_x = self._rows_at(ax, event.xdata)
             if not rows or nearest_x is None:
                 self._hide()
                 return
@@ -118,12 +100,48 @@ class GraphHoverTooltip(QObject):
             self.logger.debug("hover move skipped: %s", e)
             self._hide()
 
+    def _rows_at(self, ax, x: float) -> Tuple[List[Tuple[str, float, str]], Optional[float]]:
+        """The value of every labelled series at the sample nearest `x`, plus that sample's x.
+
+        Lines without a legend label (matplotlib's `_childN`) are helpers - crosshairs and the
+        renderer's dashed zero bridges across gaps - and are skipped, so the hover never reports a
+        synthesized zero as a measurement. The renderer draws one series as several segments when
+        the data has gaps; those share a label and collapse to ONE row, the segment nearest the
+        cursor. X is read in axis units (`orig=False`), which is what `event.xdata` is in - the
+        original data are datetimes and cannot be compared to it.
+        """
+        xmin, xmax = ax.get_xlim()
+        span = (xmax - xmin) or 1.0
+        best: Dict[str, Tuple[float, float, str, float]] = {}   # label -> (dx, y, color, x_at)
+        for line in ax.get_lines():
+            lbl = line.get_label()
+            if not lbl or str(lbl).startswith("_"):
+                continue
+            xd = np.asarray(line.get_xdata(orig=False), dtype=float)
+            yd = np.asarray(line.get_ydata(orig=False), dtype=float)
+            if xd.size == 0 or yd.size != xd.size:
+                continue
+            idx = int(np.argmin(np.abs(xd - x)))
+            dx = abs(xd[idx] - x)
+            if dx > span * _MAX_SNAP_FRAC:          # cursor too far from this line's samples
+                continue
+            cur = best.get(str(lbl))
+            if cur is None or dx < cur[0]:
+                best[str(lbl)] = (dx, float(yd[idx]), line.get_color(), float(xd[idx]))
+        if not best:
+            return [], None
+        rows = [(lbl, y, color) for lbl, (_dx, y, color, _xa) in best.items()]
+        nearest_x = min(best.values(), key=lambda t: t[0])[3]
+        return rows, nearest_x
+
     def _format(self, x_num: float, rows: List[Tuple[str, float, str]]) -> str:
         when = mdates.num2date(x_num).strftime("%H:%M:%S")
         is_net = self._host._current_stat == "network"
         parts = [f"<span style='color:{su.semantic_colors()['text_secondary']};'>{when}</span>"]
         for lbl, y, color in rows:
-            val = self._fmt_speed(y) if is_net else f"{y:.0f}%"
+            # The network axes are plotted in Mbps (the renderer converts bytes/sec before plotting)
+            # but format_speed() takes bytes/sec - convert back, or every readout is off by 125,000x.
+            val = self._fmt_speed(y * constants.network.units.MEGA_DIVISOR / constants.network.units.BITS_PER_BYTE) if is_net else f"{y:.0f}%"
             parts.append(f"<span style='color:{color};'>{lbl}</span> {val}")
         return "<br>".join(parts)
 


### PR DESCRIPTION
Two Monitor-side bugs that were invisible for opposite reasons: one showed nothing, the other showed a confident wrong number.

### The graph hover was dead on every tab but one

`graph_hover.py` skips any line whose matplotlib label is empty or starts with `_`. Of every `ax.plot(...)` in `renderer.py` exactly one passed `label=` (the combined-hardware path), so matplotlib named the rest `_child0`, `_child1`... and the hover skipped them all. Reproduced by rendering through the real `GraphRenderer` and inspecting artists: lines the hover could use on the Network tab: 0.

And had it fired, it would have been wrong by 125,000x: the network axes carry Mbps (converted at `renderer.py:617-618`) while `_fmt_speed()` feeds `format_speed()`, which takes bytes/sec. 40 Mbps would have read 320 bps. The existing test asserted that contract, i.e. the bug.

- `renderer.py`: `label=` on every measured plot call - the network segments and both fast paths (`DOWNLOAD_LABEL`/`UPLOAD_LABEL`), `_render_hwseparate` and `_render_hwsingle` via a new `_hw_role_label()` that `_render_hwcombined` now shares. The dashed zero bridges across gaps stay unlabelled **on purpose** so a synthesized zero is never reported as a measurement.
- `graph_hover.py`: `_rows_at()` converts Mbps back before formatting, reads x with `get_xdata(orig=False)` (the originals are datetimes and cannot be compared to `event.xdata`), and collapses a series the renderer split at gaps to one row - the segment under the cursor.

### A CPU "temperature" that never moves (#275, #237)

#275's board answers exactly 290.0 K on every poll (shown as 17 °C); #237's answers 300.0 K (27 °C). Both are firmware placeholders that pass the `0 < c < 150` range check in `_poll_cpu_temperature`. Real ACPI zones report tenths of a kelvin - a Celsius-derived value lands on x.x5 - and they drift.

- `monitor_thread._is_placeholder_zone()`: a zone is a placeholder while its raw value is a whole ten-kelvin multiple (`raw % 100 == 0` in tenths) AND it has never reported anything else. The first change trusts it for good, so a genuine coarse sensor loses at most its first poll. Applied to both PDH counters and the MSAcpi WMI fallback; logged once per zone; state cleared when the PDH query is torn down.
- Affected machines show no CPU temperature instead of a wrong one. The honest number still needs a real source (LHM v0.9.4 today, #187 later).

### Verified

- `test_graph_series_labels.py` (new) renders through the real code paths onto a bare `Figure` and inspects `line.get_label()` - a mocked `ax.plot` cannot tell a labelled line from an unlabelled one. `_init_matplotlib` is monkeypatched per test, never class-assigned (that leaks into every later test).
- `test_graph_hover.py`: Mbps contract, the bytes unit setting, datetime lines, helper skipping, segment collapse.
- `test_cpu_temp_sensor_selection.py`: the 290 K and 300 K cases, a real zone, a zone that moves, log-once, the WMI door.
- All shown failing without the fix: 11 of 12 hover/label tests, 5 of 6 placeholder tests.
