### PR TITLE
fix(display): honest numbers - light traffic, unit boundaries, 10 GbE, the SMART sampling interval

### DIFF
--- a/src/netspeedtray/tests/unit/test_export_cli.py
+++ b/src/netspeedtray/tests/unit/test_export_cli.py
@@ -2,10 +2,17 @@
 Headless export CLI - the `--export-csv` arg path. Covers the pure logic: the flag gates the whole
 feature (absent -> None so the GUI proceeds), the friendly period tokens map onto real PERIOD_MAP
 keys, and an unknown period is rejected with a non-zero code rather than silently exporting nothing.
+
+Also home of the shared poll-interval normalizer tests (2.1.5 item 9): the CLI is one of the four
+sites where the SMART sentinel (-1.0) leaked through `or 1.0` and stamped coverage 0.0% on every
+exported row.
 """
 import logging
 
+import pytest
+
 from netspeedtray.utils import export_cli as CLI
+from netspeedtray.utils.timer_utils import resolve_poll_interval_seconds
 from netspeedtray import constants
 
 
@@ -59,3 +66,72 @@ def test_cli_does_not_crash_when_std_streams_are_none(monkeypatch):
     monkeypatch.setattr("sys.stderr", None)
     # The error path (unknown period) reaches the first guarded write - it must return 2, not crash.
     assert CLI.run_export_cli(["--export-csv", "--period", "fortnight"]) == 2
+
+
+# --- the shared poll-interval normalizer (2.1.5 item 9) ------------------------
+
+def test_resolve_poll_interval_passes_positive_rates_through():
+    assert resolve_poll_interval_seconds(1.0) == 1.0
+    assert resolve_poll_interval_seconds(5) == 5.0
+
+
+def test_resolve_poll_interval_smart_sentinel_is_two_seconds():
+    # SMART samples at SMART_MODE_INTERVAL_MS (2000 ms), NOT 1 s: the `or 1.0` idiom let the
+    # truthy -1.0 sentinel straight through, and normalizing to 1.0 would be wrong by 2x.
+    expected = constants.timers.SMART_MODE_INTERVAL_MS / 1000.0
+    assert expected == 2.0
+    assert resolve_poll_interval_seconds(-1.0) == expected
+    assert resolve_poll_interval_seconds(0) == expected      # historical smart sentinel
+    assert resolve_poll_interval_seconds(0.0) == expected
+
+
+def test_resolve_poll_interval_garbage_falls_back_to_smart():
+    expected = constants.timers.SMART_MODE_INTERVAL_MS / 1000.0
+    assert resolve_poll_interval_seconds(None) == expected
+    assert resolve_poll_interval_seconds("abc") == expected
+    assert resolve_poll_interval_seconds(float("nan")) == expected
+    assert resolve_poll_interval_seconds(float("inf")) == expected
+
+
+def test_smart_mode_coverage_is_100_percent():
+    """A fully-covered SMART-mode hour: 1800 samples at 2.0 s = 100% coverage - not 0.0 (the -1.0
+    leak, guarded out by summaries.coverage_pct) and not 50.0 (a wrong 1.0 s normalization)."""
+    from netspeedtray.utils.summaries import coverage_pct
+    poll = resolve_poll_interval_seconds(-1.0)
+    assert coverage_pct(1800, 3600, poll) == pytest.approx(100.0)
+    assert coverage_pct(1800, 3600, -1.0) == 0.0    # what the leak used to report
+    assert coverage_pct(1800, 3600, 1.0) == 50.0    # what a 1.0 s normalization would report
+
+
+def test_export_cli_normalizes_smart_poll_interval(monkeypatch, tmp_path):
+    """--export-csv with a SMART config must hand stats_exporter a 2.0 s poll interval, not the raw
+    -1.0 sentinel (export_cli.py's `or 1.0` was one of the four leak sites)."""
+    captured = {}
+
+    class _CM:
+        def load(self):
+            return {"update_rate": -1.0, "language": "en_US"}
+
+    class _WS:
+        def __init__(self, config, read_only=False):
+            pass
+
+        def get_earliest_data_timestamp(self):
+            return None
+
+        def cleanup(self):
+            pass
+
+    def _fake_export(ws, start, end, label, out_dir, basename, *, machine_id="", app_version="",
+                     interface=None, poll_interval=1.0):
+        captured["poll"] = poll_interval
+        return {}
+
+    monkeypatch.setattr("netspeedtray.utils.config.ConfigManager", _CM)
+    monkeypatch.setattr("netspeedtray.core.widget_state.WidgetState", _WS)
+    monkeypatch.setattr("netspeedtray.utils.stats_exporter.export_window", _fake_export)
+    monkeypatch.setattr("netspeedtray.utils.helpers.get_machine_id", lambda: "cafebabe12345678")
+
+    code = CLI.run_export_cli(["--export-csv", "--period", "24h", "--out", str(tmp_path)])
+    assert code == 0
+    assert captured["poll"] == 2.0

--- a/src/netspeedtray/tests/unit/test_format_speed.py
+++ b/src/netspeedtray/tests/unit/test_format_speed.py
@@ -136,3 +136,154 @@ def test_locale_decimal_separator(de):
 def test_non_number_raises_typeerror(en, bad):
     with pytest.raises(TypeError):
         format_speed(bad, en)
+
+
+# --- unit-boundary rounding: the unit is chosen from the ROUNDED value --------
+# (2.1.5 item 11a: 999.95..999.999 in any unit used to render "1000.0 <unit>" -
+# four integer digits in a slot sized for three - instead of promoting.)
+
+def test_rounding_boundary_promotes_kilo_to_mega(en):
+    # 124_999 B/s = 999.992 Kbit/s -> rounds to 1000.0 at dp=1 -> must promote
+    assert format_speed(124_999, en, split_unit=True) == ("1.0", en.MBITS_LABEL)
+
+
+def test_rounding_boundary_promotes_mega_to_giga(en):
+    # 124_999_999 B/s = 999.999992 Mbit/s
+    assert format_speed(124_999_999, en, split_unit=True) == ("1.0", en.GBITS_LABEL)
+
+
+def test_rounding_boundary_promotes_base_to_kilo(en):
+    # 124.95 B/s = 999.6 bit/s -> "%.0f" in the base unit would render "1000"
+    assert format_speed(124.95, en, split_unit=True) == ("1.0", en.KBITS_LABEL)
+
+
+def test_just_below_rounding_boundary_stays(en):
+    # 124_990 B/s = 999.92 Kbit/s -> 999.9 at dp=1: no promotion
+    assert format_speed(124_990, en, split_unit=True) == ("999.9", en.KBITS_LABEL)
+
+
+def test_rounding_boundary_at_dp0(en):
+    # dp=0: 999.6 Kbit rounds to "1000" -> promote; 999.2 stays "999"
+    assert format_speed(124_950, en, decimal_places=0, split_unit=True) == ("1", en.MBITS_LABEL)
+    assert format_speed(124_900, en, decimal_places=0, split_unit=True) == ("999", en.KBITS_LABEL)
+
+
+def test_rounding_boundary_binary_divisor(en):
+    # bytes_binary: 1_048_575 B/s = 1023.999 KiB/s -> 1024.0 at dp=1 -> promote to MiB/s
+    assert format_speed(1_048_575, en, unit_type="bytes_binary", split_unit=True) == ("1.0", en.MIBPS_LABEL)
+
+
+def test_top_of_scale_giga_still_renders_1000(en):
+    # ~1000 Gbit/s: giga is the top unit (no tera label), so "1000.0" is the honest render.
+    assert format_speed(124_999_999_000, en, split_unit=True) == ("1000.0", en.GBITS_LABEL)
+
+
+# --- D4: force_mega promotes to giga at the divisor (no widget widening) ------
+
+def test_force_mega_promotes_to_giga_at_10gbe(en):
+    # 1.25 GB/s = 10_000 Mbit/s: was "10000.0 Mbps" (overflows the '8888.8' slot); now giga.
+    assert format_speed(1_250_000_000, en, force_mega_unit=True, split_unit=True) == ("10.0", en.GBITS_LABEL)
+
+
+def test_force_mega_giga_promotion_at_rounded_boundary(en):
+    # 999.999992 Mbit rounds to 1000.0 at dp=1 -> promotes
+    assert format_speed(124_999_999, en, force_mega_unit=True, split_unit=True) == ("1.0", en.GBITS_LABEL)
+
+
+def test_force_mega_stays_mega_below_boundary(en):
+    assert format_speed(124_900_000, en, force_mega_unit=True, split_unit=True) == ("999.2", en.MBITS_LABEL)
+
+
+def test_force_mega_giga_promotion_bytes_mode(en):
+    # 1500 MB/s -> 1.5 GB/s (bytes modes promote too)
+    assert format_speed(1_500_000_000, en, unit_type="bytes_decimal", force_mega_unit=True,
+                        split_unit=True) == ("1.5", en.GBPS_LABEL)
+
+
+def test_force_mega_giga_promotion_binary(en):
+    # 8192 Mibit/s -> 8.0 Gibit/s (binary boundary is 1024, not 1000)
+    assert format_speed(1_073_741_824, en, unit_type="bits_binary", force_mega_unit=True,
+                        split_unit=True) == ("8.0", en.GIBITS_LABEL)
+
+
+# --- adaptive decimal floor in force_mega mode (2.1.5 item 11c) ---------------
+# At shipped defaults (always_mbps, dp=1) traffic under 6,250 B/s rendered "0.0 Mbps".
+# When the value rounds to zero but is >= 0.001 of the mega unit (1 kbps), extend the
+# decimals just enough to show the first significant digit, capped at 3.
+
+def test_adaptive_floor_shows_idle_traffic(en):
+    # 3000 B/s = 0.024 Mbit/s (Discord idle): was "0.0 Mbps"
+    assert format_speed(3_000, en, force_mega_unit=True, split_unit=True) == ("0.02", en.MBITS_LABEL)
+
+
+def test_adaptive_floor_extends_to_three_decimals(en):
+    # 500 B/s = 0.004 Mbit/s
+    assert format_speed(500, en, force_mega_unit=True, split_unit=True) == ("0.004", en.MBITS_LABEL)
+
+
+def test_adaptive_floor_at_exact_1kbps(en):
+    # 125 B/s = exactly 0.001 Mbit/s - the floor itself is shown
+    assert format_speed(125, en, force_mega_unit=True, split_unit=True) == ("0.001", en.MBITS_LABEL)
+
+
+def test_below_floor_renders_plain_zero(en):
+    # 124 B/s = 0.000992 Mbit/s - below the 1 kbps floor: plain zero at configured precision
+    assert format_speed(124, en, force_mega_unit=True, split_unit=True) == ("0.0", en.MBITS_LABEL)
+
+
+def test_adaptive_floor_with_dp2_config(en):
+    assert format_speed(500, en, force_mega_unit=True, decimal_places=2,
+                        split_unit=True) == ("0.004", en.MBITS_LABEL)
+
+
+def test_adaptive_floor_dp0_is_width_capped(en):
+    # dp=0's reference is "8888" (4 chars): the borrow may never outgrow it. "0.02" fits;
+    # "0.004" would not, so a dp=0 config keeps plain zero for values needing 3 decimals.
+    assert format_speed(3_000, en, force_mega_unit=True, decimal_places=0,
+                        split_unit=True) == ("0.02", en.MBITS_LABEL)
+    assert format_speed(500, en, force_mega_unit=True, decimal_places=0,
+                        split_unit=True) == ("0", en.MBITS_LABEL)
+
+
+def test_adaptive_floor_never_fires_on_true_zero(en):
+    assert format_speed(0, en, force_mega_unit=True, split_unit=True) == ("0.0", en.MBITS_LABEL)
+
+
+def test_auto_mode_untouched_at_low_traffic(en):
+    # auto never rendered zero for nonzero traffic; it must stay exactly as before
+    assert format_speed(3_000, en, split_unit=True) == ("24.0", en.KBITS_LABEL)
+    assert format_speed(1, en, split_unit=True) == ("8", en.BITS_LABEL)
+
+
+def test_adaptive_floor_respects_locale_separator(de):
+    assert format_speed(3_000, de, force_mega_unit=True, split_unit=True) == ("0,02", de.MBITS_LABEL)
+    assert format_speed(500, de, force_mega_unit=True, split_unit=True) == ("0,004", de.MBITS_LABEL)
+
+
+# --- width invariants: nothing new outgrows the reference string --------------
+
+def test_new_renderings_fit_reference_width(en):
+    ref_fm = get_reference_value_string(True, 1, "bits_decimal")     # "8888.8"
+    for speed in (3_000, 500, 125, 124, 1_250_000_000, 124_999_999):
+        val, _ = format_speed(speed, en, force_mega_unit=True, split_unit=True)
+        assert len(val) <= len(ref_fm), (speed, val)
+    ref_auto = get_reference_value_string(False, 1, "bits_decimal")  # "888.8"
+    for speed in (124_999, 124_999_999, 124.95):
+        val, _ = format_speed(speed, en, split_unit=True)
+        assert len(val) <= len(ref_auto), (speed, val)
+
+
+def test_fixed_width_pads_adaptive_and_promoted_values(en):
+    # fixed_width rjust against the UNCHANGED reference string keeps behaving.
+    ref = get_reference_value_string(True, 1, "bits_decimal")        # "8888.8" (6 chars)
+    val, _ = format_speed(500, en, force_mega_unit=True, fixed_width=True, split_unit=True)
+    assert val == "0.004".rjust(len(ref))
+    val2, _ = format_speed(1_250_000_000, en, force_mega_unit=True, fixed_width=True, split_unit=True)
+    assert val2 == "10.0".rjust(len(ref))
+
+
+def test_fixed_width_longer_than_reference_is_not_padded_or_truncated(en):
+    # "1000.0" at the top of the giga scale (6 chars) exceeds the auto reference "888.8"
+    # (5 chars): rjust must leave it alone - current behaviour, preserved.
+    val, unit = format_speed(124_999_999_000, en, fixed_width=True, split_unit=True)
+    assert val == "1000.0" and unit == en.GBITS_LABEL

--- a/src/netspeedtray/tests/unit/test_overview_tiles.py
+++ b/src/netspeedtray/tests/unit/test_overview_tiles.py
@@ -110,6 +110,33 @@ def test_latency_pill_classification(q_app):
     assert L(None, None, 0.0) == ""                                           # no data -> empty
 
 
+def test_reload_window_normalizes_smart_poll(q_app):
+    """2.1.5 item 9: update_rate=-1.0 (SMART) must reach summarize_* as 2.0 s (SMART samples every
+    SMART_MODE_INTERVAL_MS), not leak through `or 1.0` as -1.0 - which made every Overview summary
+    report coverage 0% in SMART mode."""
+    captured = []
+
+    class _CapWS(_WS):
+        def get_speed_history(self, start, end, iface, resolution='auto', **kwargs):
+            return super().get_speed_history(start, end, iface, resolution=resolution)
+
+        def summarize_network(self, direction, start, end, iface, poll):
+            captured.append(poll)
+            return super().summarize_network(direction, start, end, iface, poll)
+
+        def summarize_hardware(self, stat, start, end, poll):
+            captured.append(poll)
+            return super().summarize_hardware(stat, start, end, poll)
+
+    class _MW2(_MW):
+        widget_state = _CapWS()
+
+    ov = OverviewTab(_MW2(), _cfg(update_rate=-1.0), I18nStrings("en_US"))
+    ov.isVisible = lambda: True          # bypass the visibility guard without show() (no feed thread)
+    ov._reload_window()
+    assert captured and all(p == 2.0 for p in captured)
+
+
 def test_context_right_prefers_true_system_power(q_app):
     from types import SimpleNamespace
     ov = OverviewTab(_MW(), _cfg(), I18nStrings("en_US"))

--- a/src/netspeedtray/tests/unit/test_stats_detail.py
+++ b/src/netspeedtray/tests/unit/test_stats_detail.py
@@ -113,3 +113,46 @@ def test_below_plan_when_threshold_set(q_app):
     sheet = StatsDetailSheet(_WS(), subjects, _window(), _cfg(plan_down_mbps=100), I18nStrings("en_US"))
     text = "\n".join(sheet._copy_text_parts)
     assert "100 Mbps" in text and "below" in text
+
+
+def test_smart_mode_poll_normalized_to_two_seconds(q_app):
+    """2.1.5 item 9: update_rate=-1.0 (SMART) must reach summarize_* as 2.0 s (SMART samples every
+    SMART_MODE_INTERVAL_MS), not leak through `or 1.0` as -1.0 (which zeroed coverage_pct on every
+    stats sheet) and not normalize to a wrong 1.0 s."""
+    captured = []
+
+    class _CapturingWS(_WS):
+        def summarize_network(self, direction, start, end, iface, poll):
+            captured.append(poll)
+            return super().summarize_network(direction, start, end, iface, poll)
+
+    subjects = [{"key": "download", "label": "Download", "unit": "Mbps", "kind": "net_down", "primary": True}]
+    sheet = StatsDetailSheet(_CapturingWS(), subjects, _window(), _cfg(update_rate=-1.0),
+                             I18nStrings("en_US"))
+    assert sheet._poll == 2.0
+    assert captured and all(p == 2.0 for p in captured)
+
+
+def test_interactive_export_normalizes_smart_poll(q_app, monkeypatch, tmp_path):
+    """The Export path (stats_detail.run_interactive_export) is another of the four leak sites: a
+    SMART config must hand export_window_zip poll_interval=2.0, not -1.0."""
+    from PyQt6.QtWidgets import QFileDialog, QMessageBox
+    from netspeedtray.views.monitor import stats_detail as SD
+
+    captured = {}
+
+    def _fake_zip(ws, start, end, label, zip_path, basename, *, machine_id="", app_version="",
+                  poll_interval=1.0):
+        captured["poll"] = poll_interval
+        return zip_path
+
+    monkeypatch.setattr(SD.stats_exporter, "export_window_zip", _fake_zip)
+    monkeypatch.setattr(SD, "get_machine_id", lambda: "cafebabe12345678")
+    monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                        staticmethod(lambda *a, **k: (str(tmp_path / "x.zip"), "")))
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: 0)   # swallow the success dialog
+
+    start, end, label = _window()
+    SD.run_interactive_export(None, _WS(), start, end, label,
+                              _cfg(update_rate=-1.0), I18nStrings("en_US"))
+    assert captured["poll"] == 2.0

--- a/src/netspeedtray/utils/export_cli.py
+++ b/src/netspeedtray/utils/export_cli.py
@@ -86,6 +86,7 @@ def run_export_cli(argv: Optional[List[str]] = None) -> Optional[int]:
     from netspeedtray import constants, __version__
     from netspeedtray.utils.config import ConfigManager
     from netspeedtray.utils.helpers import get_machine_id
+    from netspeedtray.utils.timer_utils import resolve_poll_interval_seconds
     from netspeedtray.utils import stats_exporter
     from netspeedtray.core.widget_state import WidgetState
 
@@ -122,7 +123,9 @@ def run_export_cli(argv: Optional[List[str]] = None) -> Optional[int]:
         ts = now.strftime("%Y%m%d-%H%M%S")
         basename = ns.basename or f"nst_export_{machine}_{token}_{ts}"
         out_dir = os.path.abspath(ns.out)
-        poll = float(config.get("update_rate", 1.0) or 1.0)
+        # NOT `or 1.0`: the SMART sentinel (-1.0) is truthy and samples at 2.0 s, and letting it
+        # through stamped coverage 0.0% on every exported row (2.1.5 item 9).
+        poll = resolve_poll_interval_seconds(config.get("update_rate", 1.0))
 
         paths = stats_exporter.export_window(
             ws, start, now, label, out_dir, basename,

--- a/src/netspeedtray/utils/helpers.py
+++ b/src/netspeedtray/utils/helpers.py
@@ -202,12 +202,23 @@ def get_reference_value_string(force_mega_unit: bool, decimal_places: int, unit_
     return integer_part
 
 
+# Adaptive decimal floor for force-mega display (2.1.5 item 11c). At the shipped defaults
+# (always_mbps, decimal_places=1) any traffic under ~6.25 KB/s rounds to "0.0 Mbps" - Discord
+# idle at 3,000 B/s read as dead air. When the forced-mega value rounds to zero at the
+# configured precision but the TRUE value is at least this fraction of the mega unit
+# (0.001 Mbps = 1 kbps in bits_decimal), extend the decimals just enough to show the first
+# significant digit. Below the floor, plain zero at the configured precision is honest.
+FORCE_MEGA_ZERO_FLOOR: float = 0.001
+# Cap on the borrowed decimals ("0.003" at most): further digits report noise, not traffic.
+FORCE_MEGA_MAX_ADAPTIVE_DECIMALS: int = 3
+
+
 def format_speed(
-    speed: float, 
-    i18n, 
+    speed: float,
+    i18n,
     use_megabytes: bool = False,  # Deprecated
-    *, 
-    force_mega_unit: bool = False, 
+    *,
+    force_mega_unit: bool = False,
     decimal_places: int = 1,
     unit_type: str = "bits_decimal",
     fixed_width: bool = False,
@@ -254,32 +265,77 @@ def format_speed(
     # Select numeric value based on bytes vs bits
     speed_value = current_speed if is_bytes else current_speed * network_consts.BITS_PER_BYTE
 
-    # Determine scale and unit
+    # Determine scale and unit. The unit is chosen from the value as it will be DISPLAYED
+    # (i.e. after rounding), not from the raw value: 999.95..999.999 in a unit used to round
+    # up to "1000.0" and render four integer digits in a slot sized for three (2.1.5 item 11a).
+    # The tier-to-tier ratio is uniform within a family: 1000 decimal, 1024 binary.
+    step_ratio = float(kilo_div)
+    divisors = (1.0, float(kilo_div), float(mega_div), float(giga_div))
+    tier: int
+
     if current_speed < network_consts.MINIMUM_DISPLAY_SPEED:
+        tier = 2 if force_mega_unit else 1
         val = 0.0
-        unit = labels[2] if force_mega_unit else labels[1]
+        unit = labels[tier]
     elif force_mega_unit:
+        tier = 2
         val = speed_value / mega_div
-        unit = labels[2]
+        # Owner decision D4 (no widget widening): once the ROUNDED mega value reaches the
+        # mega->giga ratio, promote to the giga unit ("10000.0 Mbps" -> "10.0 Gbps", which
+        # fits the existing '8888.8' reservation). Applies to the bytes modes too
+        # (1250 MB/s -> GB/s). The reference string is deliberately unchanged.
+        if round(val, decimal_places) >= step_ratio:
+            tier = 3
+            val = speed_value / giga_div
+        unit = labels[tier]
     else:
         if speed_value >= giga_div:
-            val = speed_value / giga_div
-            unit = labels[3]
+            tier = 3
         elif speed_value >= mega_div:
-            val = speed_value / mega_div
-            unit = labels[2]
+            tier = 2
         elif speed_value >= kilo_div:
-            val = speed_value / kilo_div
-            unit = labels[1]
+            tier = 1
         else:
-            val = speed_value
-            unit = labels[0]
+            tier = 0
+        val = speed_value / divisors[tier]
+        # Round-first promotion: a value that ROUNDS to the next divisor at its display
+        # precision (the base unit renders %.0f) shows as "1.0" of the next unit, never as
+        # "1000.0" of this one. A loop, not a single check, because the base tier's %.0f
+        # verdict feeds the kilo tier's decimal_places verdict. Giga is the top unit, so
+        # ~1000 Gbps still (honestly) renders "1000.0".
+        while tier < 3:
+            display_dp = 0 if tier == 0 else decimal_places
+            if round(val, display_dp) < step_ratio:
+                break
+            tier += 1
+            val = speed_value / divisors[tier]
+        unit = labels[tier]
+
+    # Adaptive decimal floor (2.1.5 item 11c): only in force-mega mode, only when the value
+    # rounds to zero at the configured precision yet real traffic is flowing (>= the 1 kbps
+    # floor). Extend to the first significant digit, capped at FORCE_MEGA_MAX_ADAPTIVE_DECIMALS
+    # and at the reference-string width so the widget never grows ("0.02", "0.003"). The
+    # condition is on the VALUE - a config alone never changes precision. Auto mode is
+    # untouched: it never renders zero for nonzero traffic.
+    effective_decimal_places = decimal_places
+    if (
+        force_mega_unit
+        and tier == 2
+        and val >= FORCE_MEGA_ZERO_FLOOR
+        and round(val, decimal_places) == 0
+    ):
+        ref_len = len(get_reference_value_string(force_mega_unit, decimal_places, unit_type=unit_type))
+        max_dp = min(FORCE_MEGA_MAX_ADAPTIVE_DECIMALS, ref_len - 2)  # "0." + decimals must fit the reference
+        for extra_dp in range(decimal_places + 1, max_dp + 1):
+            if round(val, extra_dp) > 0:
+                effective_decimal_places = extra_dp
+                break
 
     # Format numeric part
-    if unit == labels[0]:
+    if tier == 0:
         formatted_val = f"{val:.0f}"
     else:
-        formatted_val = f"{val:.{decimal_places}f}"
+        formatted_val = f"{val:.{effective_decimal_places}f}"
 
     if fixed_width:
         # Use reference string to match logic in layout/renderer

--- a/src/netspeedtray/utils/timer_utils.py
+++ b/src/netspeedtray/utils/timer_utils.py
@@ -15,6 +15,7 @@ in the application that needs to create or manage timers. For managing the speed
 timer specifically, use the `SpeedTimerManager` class in `timer_manager.py`.
 """
 
+import math
 from typing import Optional, Callable
 import logging
 from PyQt6.QtCore import QTimer, QObject
@@ -59,6 +60,36 @@ def calculate_timer_interval(update_rate: float) -> int:
     interval = max(constants.timers.MINIMUM_INTERVAL_MS, int(update_rate * 1000))
     logger.debug("Calculated timer interval: %dms from update_rate %.2fs", interval, update_rate)
     return interval
+
+
+def resolve_poll_interval_seconds(update_rate: object) -> float:
+    """
+    Normalize a configured update rate into the EFFECTIVE sampling interval in seconds.
+
+    The config persists the poll rate in seconds, with non-positive values meaning
+    "smart mode" (0 is the historical sentinel, -1.0 is UpdateMode.SMART). Smart mode
+    actually samples every ``SMART_MODE_INTERVAL_MS`` (2.0 s), NOT 1.0 s - so any
+    seconds-per-sample math (coverage %, bytes-from-rates totals, time-above windows)
+    must come through here rather than the ``or 1.0`` idiom, which lets the *truthy*
+    ``-1.0`` sentinel straight through - and normalizing it to 1.0 would still be
+    wrong by 2x (2.1.5 item 9).
+
+    Unparseable or non-finite input is treated like the historical ``0`` sentinel
+    (smart mode) rather than raising: this is called with raw config values.
+
+    Examples:
+        >>> resolve_poll_interval_seconds(1.0)
+        1.0
+        >>> resolve_poll_interval_seconds(-1.0)   # SMART -> SMART_MODE_INTERVAL_MS
+        2.0
+    """
+    try:
+        rate = float(update_rate)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        rate = 0.0
+    if not math.isfinite(rate):
+        rate = 0.0
+    return calculate_timer_interval(rate) / 1000.0
 
 
 def create_timer(parent: QObject, callback: Callable[[], None], interval: int, single_shot: bool = False) -> QTimer:

--- a/src/netspeedtray/views/monitor/overview/tab.py
+++ b/src/netspeedtray/views/monitor/overview/tab.py
@@ -28,6 +28,7 @@ from netspeedtray import constants
 from netspeedtray.utils import styles as su
 from netspeedtray.constants.styles import styles as tokens
 from netspeedtray.utils.helpers import format_speed, format_data_size, format_duration_short
+from netspeedtray.utils.timer_utils import resolve_poll_interval_seconds
 from netspeedtray.utils.widget_paint import WidgetMetrics   # reuse its Mbps→bytes/sec converter (DRY)
 # NOTE: `summaries` imports numpy at module scope. To honor the Monitor's import firewall (a glance at
 # the default Overview must not eagerly pull the heavy compute deps), it is imported LAZILY inside
@@ -347,7 +348,9 @@ class OverviewTab(QWidget):
             self._render()
             return
         start, end, is_session = self._window()
-        poll = float(self._config.get("update_rate", 1.0) or 1.0)
+        # NOT `or 1.0`: the SMART sentinel (-1.0) is truthy and samples at 2.0 s; leaking it
+        # zeroed coverage_pct on every Overview summary (2.1.5 item 9).
+        poll = resolve_poll_interval_seconds(self._config.get("update_rate", 1.0))
         try:
             if is_session:
                 agg = ws.get_aggregated_speed_history()

--- a/src/netspeedtray/views/monitor/stats_detail.py
+++ b/src/netspeedtray/views/monitor/stats_detail.py
@@ -30,6 +30,7 @@ from PyQt6.QtWidgets import (
 from netspeedtray.utils import styles as su
 from netspeedtray.constants.styles import styles as tokens
 from netspeedtray.utils.helpers import format_speed, get_machine_id, format_duration_short
+from netspeedtray.utils.timer_utils import resolve_poll_interval_seconds
 from netspeedtray.utils import summaries as S
 from netspeedtray.utils import stats_exporter
 
@@ -56,7 +57,8 @@ def run_interactive_export(parent, widget_state, start: datetime, end: datetime,
         return
     if not zip_path.lower().endswith(".zip"):
         zip_path += ".zip"
-    poll = float(config.get("update_rate", 1.0) or 1.0)
+    # NOT `or 1.0`: the SMART sentinel (-1.0) is truthy and samples at 2.0 s (2.1.5 item 9).
+    poll = resolve_poll_interval_seconds(config.get("update_rate", 1.0))
     try:
         zip_path = stats_exporter.export_window_zip(
             widget_state, start, end, window_label, zip_path, basename,
@@ -99,7 +101,9 @@ class StatsDetailSheet(QDialog):
         self._i18n = i18n
         self._app_version = app_version
         self.logger = logging.getLogger("NetSpeedTray.StatsDetailSheet")
-        self._poll = float(config.get("update_rate", 1.0) or 1.0)
+        # NOT `or 1.0`: the SMART sentinel (-1.0) is truthy and samples at 2.0 s; leaking it
+        # zeroed coverage_pct on every stats sheet (2.1.5 item 9).
+        self._poll = resolve_poll_interval_seconds(config.get("update_rate", 1.0))
         self._copy_text_parts: List[str] = []
 
         self.setModal(True)


### PR DESCRIPTION
Four places where the number on screen or in an export was not the number measured. None changes a measurement; all change what is displayed or summed.

### SMART mode zeroed coverage and halved totals

The config stores the poll rate in seconds with `-1.0` meaning SMART. Every seconds-per-sample calculation used the `or 1.0` idiom, which lets the *truthy* `-1.0` straight through - so every stats sheet and CSV export reported `0.0%` coverage, and bytes-from-rates totals came out wrong. Normalizing to `1.0` would still be wrong by 2x: SMART samples every 2.0 s (`calculate_timer_interval(-1.0)` returns 2000 ms).

- `timer_utils.resolve_poll_interval_seconds()` is the one resolver; `stats_detail.py`, `overview/tab.py` and `export_cli.py` all go through it. `widget_state.py` and `views/widget/main.py` follow in the rollback PR, which depends on this one - that is where `test_bandwidth_total.py:62`, which had pinned the 1 s assumption as spec, gets its expectation corrected rather than the code bent to the test.

### Speeds at a unit boundary rendered as `1000.0 Kbps`

`format_speed()` chose the unit from the raw value and rounded afterwards, so `999.96 Kbps` rounded up into a four-digit number that overflows the widget's slot. The unit is now chosen from the value *as displayed*, promoting to `1.0 Mbps`.

### 10 GbE did not fit the widget

In always-Mbps mode `10000.0 Mbps` now promotes to `10.0 Gbps` at the rounded giga boundary - which fits the existing width reservation, so nobody's widget gets wider (owner decision D4: no widening).

### Very light traffic showed as nothing

At default settings ~3,000 B/s read `0.0 Mbps`. It now reads `0.02 Mbps`; a true zero still reads `0.0`. Note `MINIMUM_DISPLAY_SPEED` is a *suppressor* (`helpers.py` sets `val = 0.0` below it), not dead code - reviving it as a floor would have been a measured no-op that regresses auto mode.

### Verified

- `test_format_speed.py` (+151 lines), `test_export_cli.py`, `test_overview_tiles.py`, `test_stats_detail.py`. Every case was demonstrated failing first.
