### PR TITLE
fix(privacy): adapter and display names never reach logs or bundles; privacy.md matches the code

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -1,6 +1,6 @@
 # Privacy Policy for NetSpeedTray
 
-Last Updated: July 3, 2026
+Last Updated: August 24, 2026
 
 This privacy policy outlines how NetSpeedTray handles information. As an open-source project created by a single developer, transparency and user privacy are top priorities.
 
@@ -12,18 +12,18 @@ The application is designed to be completely self-contained on your computer. It
 
 - **Network Monitoring:** The application monitors your network adapters locally to calculate your current upload and download speeds. It measures the *volume* of traffic (bytes per second) - it never inspects the *content* of your traffic. This information is **only displayed to you** on the widget and is **never sent to any server**.
 - **Network Identity (optional):** If you enable the network-identity indicator, NetSpeedTray can show the Wi-Fi **band** (2.4 GHz / 5 GHz) and, optionally, the **network name (SSID)** on the widget. The band is read from your wireless adapter locally and needs no permission. The SSID is different: **Windows only reveals the network name to apps that have Location access**, so enabling the "Network name" option requires you to turn on Windows Location. This is a **Windows privacy gate, not GPS or geolocation** - NetSpeedTray does not use your position, and reads the network name **locally only to display it on the widget**. Like everything else here, the band and SSID are **never stored to the history database and never transmitted**.
-- **Hardware Monitoring (optional):** If you enable the CPU/GPU/RAM monitoring features, the application reads utilization, memory, temperature, and power figures from your own hardware locally. This is displayed to you and, like speed history, may be stored in the local database below. It is never transmitted.
+- **Hardware Monitoring:** The application reads CPU, GPU, and RAM utilization figures from your own hardware locally, and **records this utilization history to the local history database by default** — even if the hardware widgets are turned off — so the Monitor window's hardware graphs have data when you open them. (A setting to turn this recording off is planned for an upcoming release.) Temperature and power figures are read when you enable the corresponding monitoring features, and while the Monitor window is open (its hardware graphs read them live). All of it stays on your computer: displayed to you, stored only in the local database described below, and never transmitted.
 - **App Activity (optional):** The App Activity window shows which running applications are using the network, using process information from your own computer. This data is the most sensitive the app touches (it can include process names and remote addresses), so it is computed and displayed **live only** - it is **never written to disk, never stored in the history database, and never transmitted**. It also never leaves your machine in a Support Bundle (see below).
 - **Configuration File:** Your settings are saved locally on your computer in a `NetSpeedTray_Config.json` file located in your `%appdata%\NetSpeedTray` folder. It contains only your preferences (such as colors, position, and which features are enabled) - no personal data. This file is never transmitted.
-- **History Database:** If you use the graph or hardware-history features, a local SQLite database (`speed_history.db`) is created in the same folder to store your network speed history and, if enabled, your hardware utilization history. This data remains on your computer and is never transmitted.
+- **History Database:** A local SQLite database (`speed_history.db`) is created in the same folder to store your network speed history and your hardware utilization history (recorded by default, as described above). This data remains on your computer and is never transmitted.
 
 ### Support Bundles
 
 NetSpeedTray can generate a "Support Bundle" - a single `.zip` file you can **choose** to attach to a GitHub issue to help diagnose a bug. This file is created locally and is only ever shared if **you** decide to send it.
 
 - **What it contains:** your application logs, your settings file (`config.json`), and basic system info (app version, OS, and monitor layout).
-- **Logs are scrubbed:** before being added to the bundle, log files are passed through a redaction step that replaces file paths, IP addresses (IPv4 and IPv6), MAC addresses, network-interface GUIDs, and your computer's hostname with placeholders.
-- **What is deliberately left out:** App Activity per-process / per-connection data, your hostname, MAC addresses, network-interface friendly names, and full GPU model strings.
+- **Logs are scrubbed:** before being added to the bundle, log files are passed through a redaction step that replaces file paths, IP addresses (IPv4 and IPv6), MAC addresses, network-interface GUIDs, and your computer's hostname with placeholders. Network-adapter friendly names (which you may have renamed to something personal) and display device names are replaced, on a best-effort basis, with a **stable placeholder** (e.g. `NIC-1a2b3c4d`) — a one-way hash, so repeated log lines still correlate for debugging but never contain the name itself.
+- **What is deliberately left out:** App Activity per-process / per-connection data, your hostname, MAC addresses, and full GPU model strings. Network-interface friendly names never appear verbatim: they are redacted from the bundled settings file and replaced with the stable placeholders described above in logs.
 - The bundle includes a `MANIFEST.txt` listing exactly what is and isn't inside, so you can review it before sharing. Nothing is uploaded automatically.
 
 ### Update Checking

--- a/src/netspeedtray/core/controller.py
+++ b/src/netspeedtray/core/controller.py
@@ -13,6 +13,7 @@ from PyQt6.QtCore import pyqtSignal, QObject
 import psutil
 
 from netspeedtray import constants
+from netspeedtray.utils.config import stable_pseudonym
 from netspeedtray.utils.network_utils import get_primary_interface_name
 
 if TYPE_CHECKING:
@@ -388,8 +389,13 @@ class StatsController(QObject):
         except Exception:
             self.primary_interface = None
         if previous != self.primary_interface:
+            # Log a STABLE pseudonym, never the raw friendly name: users rename
+            # adapters to personal/site labels and this INFO line ships in support
+            # bundles (v2.1.5 item 7). Same hash ObfuscatingFormatter uses to scrub
+            # historical lines, so old and new lines still correlate (#263).
             self.logger.info(
-                "Primary network interface changed: %r -> %r", previous, self.primary_interface
+                "Primary network interface changed: %s -> %s",
+                stable_pseudonym(previous), stable_pseudonym(self.primary_interface),
             )
 
 

--- a/src/netspeedtray/core/position_manager.py
+++ b/src/netspeedtray/core/position_manager.py
@@ -22,6 +22,9 @@ from PyQt6.QtGui import QFontMetrics, QScreen
 from PyQt6.QtWidgets import QApplication, QWidget
 
 from netspeedtray import constants
+# Screen names are logged pseudonymized: the support bundle's MANIFEST promises
+# no display names ship (v2.1.5 item 7).
+from netspeedtray.utils.config import stable_pseudonym
 # We import taskbar_utils for low-level detection
 from netspeedtray.utils import taskbar_utils
 from netspeedtray.utils.taskbar_utils import TaskbarInfo, get_taskbar_info, is_small_taskbar
@@ -116,12 +119,13 @@ class ScreenUtils:
 
             if valid_x != x or valid_y != y:
                 logger.debug("Position (%s,%s) validated to (%s,%s) using full geometry for screen '%s'",
-                             x, y, valid_x, valid_y, screen.name())
+                             x, y, valid_x, valid_y, stable_pseudonym(screen.name(), "DISPLAY"))
 
             return ScreenPosition(valid_x, valid_y)
 
         except Exception as e:
-            logger.error("Error validating position (%s,%s) on screen '%s': %s", x, y, screen.name(), e, exc_info=True)
+            logger.error("Error validating position (%s,%s) on screen '%s': %s",
+                         x, y, stable_pseudonym(screen.name(), "DISPLAY"), e, exc_info=True)
             return ScreenPosition(x, y)
 
     @staticmethod
@@ -638,12 +642,12 @@ class PositionManager(QObject):
         if (clamped.x, clamped.y) != (saved_x, saved_y):
             logger.info(
                 "Clamped saved free-move position (%s,%s) onto screen '%s' -> (%s,%s).",
-                saved_x, saved_y, screen.name(), clamped.x, clamped.y,
+                saved_x, saved_y, stable_pseudonym(screen.name(), "DISPLAY"), clamped.x, clamped.y,
             )
         else:
             logger.info(
                 "Restored saved free-move position (%s,%s) on screen '%s'.",
-                saved_x, saved_y, screen.name(),
+                saved_x, saved_y, stable_pseudonym(screen.name(), "DISPLAY"),
             )
         self._apply_geometry(clamped.x, clamped.y)
         return True

--- a/src/netspeedtray/tests/unit/test_obfuscating_formatter.py
+++ b/src/netspeedtray/tests/unit/test_obfuscating_formatter.py
@@ -280,3 +280,13 @@ class TestLoggingSetupIntegrity:
         assert src.count("ObfuscatingFormatter") >= 2, (
             "Expected ObfuscatingFormatter on both file and console handlers"
         )
+
+
+def test_found_new_primary_interface_legacy_shape_is_pseudonymized(formatter):
+    """Review C4: v1.1.9-v1.2.6 logged the primary interface with a Gateway suffix at INFO.
+    Long-lived logs still carry those lines; they must scrub like the current shapes, with
+    the name hashed ALONE so it correlates with modern lines for the same adapter."""
+    out = _format(formatter, "Found new primary interface: 'ACME-HQ Office VPN' (Gateway: 192.168.1.1)")
+    assert "ACME-HQ Office VPN" not in out
+    assert "Found new primary interface: NIC-" in out
+    assert "<REDACTED_IP>" in out, "the gateway operand must still hit the generic IP rule"

--- a/src/netspeedtray/tests/unit/test_support_bundle.py
+++ b/src/netspeedtray/tests/unit/test_support_bundle.py
@@ -8,6 +8,8 @@ Covers:
 - App Activity exclusion (no app-activity data ever included)
 """
 import json
+import logging
+import re
 import zipfile
 from pathlib import Path
 from unittest.mock import patch
@@ -75,6 +77,11 @@ class TestStructure:
         assert "App Activity" in manifest
         assert "Hostname" in manifest
         assert "MAC" in manifest
+        # v2.1.5 item 7 (words half): the promise must match what the code does -
+        # NIC/display names are pseudonymized best-effort, not silently absent.
+        assert "placeholder" in manifest.lower()
+        assert "NIC-" in manifest
+        assert "best-effort" in manifest.lower()
 
 
 class TestConfigSanitization:
@@ -151,6 +158,136 @@ class TestLogScrubbing:
         assert "{12345678-1234-1234-1234-123456789012}" not in log_content
         assert "<REDACTED_GUID>" in log_content
 
+    # --- v2.1.5 item 7: NIC friendly names in logs -------------------------
+    # controller.py's "Primary network interface changed" INFO line shipped the
+    # raw adapter friendly name (94 lines on a real machine's live log). The
+    # scrub must clean those HISTORICAL lines - a source-only fix cannot - by
+    # replacing each name with a STABLE pseudonym so repeated changes still
+    # correlate (#263's edge-triggered logging depends on that).
+
+    def test_primary_interface_change_lines_are_pseudonymized(self, q_app, tmp_path, fake_config, fake_log_dir):
+        from netspeedtray.utils.config import stable_pseudonym
+        # Real message shapes as written by shipped builds (%r operands).
+        (fake_log_dir / "NetSpeedTray_Log.log").write_text(
+            "2026-06-12 10:23:45 - NetSpeedTray.StatsController - INFO - "
+            "controller._update_primary_interface_name:392 - "
+            "Primary network interface changed: None -> 'ACME-HQ Office VPN'\n"
+            "2026-06-12 11:00:01 - NetSpeedTray.StatsController - INFO - "
+            "controller._update_primary_interface_name:392 - "
+            "Primary network interface changed: 'ACME-HQ Office VPN' -> 'Wi-Fi 3'\n"
+            "2026-06-12 12:34:56 - NetSpeedTray.StatsController - INFO - "
+            "controller._update_primary_interface_name:392 - "
+            "Primary network interface changed: 'Wi-Fi 3' -> 'ACME-HQ Office VPN'\n",
+            encoding="utf-8",
+        )
+        dest = tmp_path / "bundle.zip"
+        support_bundle.build_support_bundle(dest, fake_config)
+        log_content = _open_zip_entry(dest, "logs/NetSpeedTray_Log.log")
+
+        # Zero occurrences of the raw names may remain.
+        assert "ACME-HQ Office VPN" not in log_content
+        assert "Wi-Fi 3" not in log_content
+        # The None operand keeps its shape.
+        assert "Primary network interface changed: None ->" in log_content
+        # Stable pseudonyms: the SAME adapter maps to the SAME token every time.
+        vpn = stable_pseudonym("ACME-HQ Office VPN")
+        wifi = stable_pseudonym("Wi-Fi 3")
+        assert re.fullmatch(r"NIC-[0-9a-f]{8}", vpn)
+        found = re.findall(r"NIC-[0-9a-f]{8}", log_content)
+        assert found == [vpn, vpn, wifi, wifi, vpn]
+
+    def test_already_pseudonymized_lines_pass_through_unchanged(self, q_app, tmp_path, fake_config, fake_log_dir):
+        """Lines the NEW build writes (already pseudonymized) must not be re-hashed."""
+        (fake_log_dir / "NetSpeedTray_Log.log").write_text(
+            "2026-08-20 09:00:00 - NetSpeedTray.StatsController - INFO - "
+            "controller._update_primary_interface_name:392 - "
+            "Primary network interface changed: NIC-00aabb11 -> None\n",
+            encoding="utf-8",
+        )
+        dest = tmp_path / "bundle.zip"
+        support_bundle.build_support_bundle(dest, fake_config)
+        log_content = _open_zip_entry(dest, "logs/NetSpeedTray_Log.log")
+        assert "NIC-00aabb11 -> None" in log_content
+
+    def test_display_names_in_logs_are_pseudonymized(self, q_app, tmp_path, fake_config, fake_log_dir):
+        """The MANIFEST promises no display names; `\\\\.\\DISPLAYn` is an
+        OS-generated shape, so a global scrub rule is safe (unlike NIC names)."""
+        (fake_log_dir / "NetSpeedTray_Log.log").write_text(
+            "2026-08-20 09:00:00 - NetSpeedTray.Core.PositionManager - INFO - "
+            "position_manager.restore:646 - "
+            "Restored saved free-move position (10,20) on screen '\\\\.\\DISPLAY2'.\n",
+            encoding="utf-8",
+        )
+        dest = tmp_path / "bundle.zip"
+        support_bundle.build_support_bundle(dest, fake_config)
+        log_content = _open_zip_entry(dest, "logs/NetSpeedTray_Log.log")
+        assert "\\\\.\\DISPLAY" not in log_content
+        assert re.search(r"DISPLAY-[0-9a-f]{8}", log_content)
+
+
+class TestNicPseudonymization:
+    """v2.1.5 item 7 - the pseudonym helper and the source half (controller.py)."""
+
+    def test_stable_pseudonym_is_stable_and_distinct(self):
+        from netspeedtray.utils.config import stable_pseudonym
+        a1 = stable_pseudonym("Wi-Fi 3")
+        a2 = stable_pseudonym("Wi-Fi 3")
+        b = stable_pseudonym("Ethernet")
+        assert a1 == a2, "pseudonym must be stable across calls"
+        assert a1 != b, "different adapters must get different pseudonyms"
+        assert re.fullmatch(r"NIC-[0-9a-f]{8}", a1)
+        assert "Wi-Fi" not in a1
+        # None keeps its printable shape so %s call sites stay readable.
+        assert stable_pseudonym(None) == "None"
+
+    def test_formatter_covers_resolved_debug_shape(self):
+        """network_utils' 'Determined primary interface' debug shape is covered
+        too - belt and suspenders if log levels ever change."""
+        from netspeedtray.utils.config import ObfuscatingFormatter, stable_pseudonym
+        fmt = ObfuscatingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="t", level=logging.DEBUG, pathname="", lineno=0,
+            msg="Determined primary interface: 'ACME-HQ Office VPN' with IP 192.168.1.10",
+            args=None, exc_info=None,
+        )
+        out = fmt.format(record)
+        assert "ACME-HQ Office VPN" not in out
+        assert stable_pseudonym("ACME-HQ Office VPN") in out
+        assert "192.168.1.10" not in out
+
+    def test_controller_logs_pseudonym_not_raw_name(self, q_app, caplog):
+        """Source half: controller.py must log a stable pseudonym, never the raw
+        friendly name - and repeated changes must still correlate."""
+        import netspeedtray.core.controller as controller_mod
+        from netspeedtray.utils.config import stable_pseudonym
+
+        ctrl = controller_mod.StatsController({}, None)
+        with caplog.at_level(logging.INFO, logger="NetSpeedTray.StatsController"):
+            with patch.object(controller_mod, "get_primary_interface_name",
+                              return_value="ACME-HQ Office VPN"):
+                ctrl.last_primary_check_time = 0.0
+                ctrl._update_primary_interface_name()
+            with patch.object(controller_mod, "get_primary_interface_name",
+                              return_value="Wi-Fi 3"):
+                ctrl.last_primary_check_time = 0.0
+                ctrl._update_primary_interface_name()
+            with patch.object(controller_mod, "get_primary_interface_name",
+                              return_value="ACME-HQ Office VPN"):
+                ctrl.last_primary_check_time = 0.0
+                ctrl._update_primary_interface_name()
+
+        changes = [r.getMessage() for r in caplog.records
+                   if "Primary network interface changed" in r.getMessage()]
+        assert len(changes) == 3
+        joined = "\n".join(changes)
+        assert "ACME-HQ Office VPN" not in joined
+        assert "Wi-Fi 3" not in joined
+        vpn = stable_pseudonym("ACME-HQ Office VPN")
+        wifi = stable_pseudonym("Wi-Fi 3")
+        assert changes[0].endswith(f"None -> {vpn}")
+        assert changes[1].endswith(f"{vpn} -> {wifi}")
+        assert changes[2].endswith(f"{wifi} -> {vpn}")
+
 
 class TestSystemInfo:
     def test_no_display_names_leaked(self, q_app, tmp_path, fake_config, fake_log_dir):
@@ -181,3 +318,14 @@ class TestAppActivityExclusion:
         for name in names:
             for token in forbidden:
                 assert token not in name, f"forbidden token '{token}' in bundled path '{name}'"
+
+
+def test_unknown_config_keys_are_redacted_in_bundle():
+    """Review C8: item 4c preserves unknown (newer-build) keys, so the bundle key-allowlist
+    sanitizer can never know them - their VALUES must not ship. The key name stays: that a
+    newer-build setting exists is the useful diagnostic in a rollback bundle."""
+    cfg = {"metrics_bind_host": "acme-nas.local", "config_version": "9.9", "font_size": 10}
+    out = support_bundle._sanitize_config(cfg)
+    assert out["metrics_bind_host"] == "<redacted-unknown-key>"
+    assert out["config_version"] == "9.9", "config_version is schema-known and the key rollback diagnostic"
+    assert out["font_size"] == 10

--- a/src/netspeedtray/utils/support_bundle.py
+++ b/src/netspeedtray/utils/support_bundle.py
@@ -58,7 +58,8 @@ _CONFIG_KEYS_TO_STRIP: tuple = ()
 # Keys whose VALUES can carry a user's own labels and so MUST NOT ship verbatim:
 #   - selected_interfaces / excluded_interfaces hold Windows NIC *friendly names*, which users freely
 #     rename ("Office VPN", a site/company label, a hostname-bearing virtual adapter). The bundle's
-#     MANIFEST explicitly promises "network interface friendly names" are NOT included.
+#     MANIFEST promises those names never ship verbatim: config values are redacted outright here,
+#     and log lines are pseudonymized by ObfuscatingFormatter's message-shape rules (v2.1.5 item 7).
 #   - latency_public_host is a user-chosen ping target (a public hostname/IP) - reveals network choices.
 # We keep the diagnostic SHAPE (how many interfaces, that a host was set) but never the literal name.
 # IMPORTANT: any NEW config field that can hold a name/path/host/ID must be added here.
@@ -84,6 +85,13 @@ def _sanitize_config(config: Dict[str, Any]) -> Dict[str, Any]:
     for key in _CONFIG_VALUE_KEYS_TO_REDACT:
         if sanitized.get(key):
             sanitized[key] = "<redacted>"
+    # A rollback carries keys written by a NEWER build (preserved by config item 4c); the
+    # allowlists above structurally cannot know them, so their VALUES must not ship (review
+    # C8). The key name stays - THAT a newer-build setting exists is the useful diagnostic.
+    known_keys = set(constants.config.defaults.VALIDATION_SCHEMA)
+    for key in list(sanitized):
+        if key not in known_keys:
+            sanitized[key] = "<redacted-unknown-key>"
     return sanitized
 
 
@@ -230,13 +238,20 @@ def build_support_bundle(
             "\n"
             "Contents:\n"
             "  system_info.txt   - App version, OS, monitor layout (no display names)\n"
-            "  config.json       - Your settings (preferences only, no PII)\n"
+            "  config.json       - Your settings (interface names and ping host redacted)\n"
             "  logs/             - Log files, scrubbed for paths/IPs/MACs/GUIDs/hostnames\n"
             "\n"
             "NOT included:\n"
             "  - App Activity per-process / per-connection data\n"
-            "  - Hostname, MAC addresses, network interface friendly names\n"
+            "  - Hostname, MAC addresses\n"
             "  - Full GPU model strings, raw device IDs\n"
+            "\n"
+            "Replaced with placeholders (best-effort scrubbing):\n"
+            "  - Network interface friendly names: redacted from the bundled config,\n"
+            "    and replaced in logs with a stable placeholder (e.g. NIC-1a2b3c4d).\n"
+            "    The placeholder is a one-way hash, so repeated log lines still\n"
+            "    correlate but never contain the name.\n"
+            "  - Display device names in logs (e.g. DISPLAY-1a2b3c4d).\n"
             "\n"
             "It is safe to attach this file to a GitHub issue.\n"
         )

--- a/src/netspeedtray/utils/taskbar_utils.py
+++ b/src/netspeedtray/utils/taskbar_utils.py
@@ -32,6 +32,9 @@ from PyQt6.QtGui import QScreen
 from PyQt6.QtWidgets import QApplication
 
 from netspeedtray import constants
+# Screen names are logged pseudonymized: the support bundle's MANIFEST promises
+# no display names ship (v2.1.5 item 7).
+from netspeedtray.utils.config import stable_pseudonym
 
 logger = logging.getLogger("NetSpeedTray.TaskbarUtils")
 # Caches to improve performance and prevent log spam for invalid handles
@@ -566,7 +569,8 @@ def get_all_taskbar_info() -> List[TaskbarInfo]:
                     best_match_screen = screen
             
             if best_match_screen:
-                logger.debug(f"Found best screen match for taskbar via intersection: {best_match_screen.name()}")
+                logger.debug("Found best screen match for taskbar via intersection: %s",
+                             stable_pseudonym(best_match_screen.name(), "DISPLAY"))
                 return best_match_screen
         except Exception as e:
             logger.error(f"Error during screen intersection check: {e}. Proceeding to fallbacks.")
@@ -576,7 +580,8 @@ def get_all_taskbar_info() -> List[TaskbarInfo]:
             point = QPoint(tb_rect_phys[0], tb_rect_phys[1])
             screen_at_point = QApplication.screenAt(point)
             if screen_at_point:
-                logger.warning(f"Used point-based fallback to find screen: {screen_at_point.name()}")
+                logger.warning("Used point-based fallback to find screen: %s",
+                               stable_pseudonym(screen_at_point.name(), "DISPLAY"))
                 return screen_at_point
         except Exception as e:
             logger.error(f"Error during point-based screen check: {e}. Proceeding to final fallback.")
@@ -783,7 +788,8 @@ def get_free_float_screen(preferred_screen_name: Optional[str]) -> Optional[QScr
             return None  # it has a taskbar of its own -> dock to it normally
         return screen    # present but taskbar-less -> free-float on it
     except Exception as e:  # noqa: BLE001 - fail-safe: never break placement over float detection
-        logger.error("get_free_float_screen failed for '%s': %s", preferred_screen_name, e, exc_info=True)
+        logger.error("get_free_float_screen failed for '%s': %s",
+                     stable_pseudonym(preferred_screen_name, "DISPLAY"), e, exc_info=True)
         return None
 
 


### PR DESCRIPTION
The trust claims in `privacy.md` and the support bundle's MANIFEST have to be true of the code, not of the intent. Three places where they were not.

### The primary-interface line leaked adapter names into bundles

Users rename adapters to personal or site labels ("Office VPN"), and `controller.py` logged the raw name on every primary-interface change - an INFO line that ships in every support bundle. Running the formatter over the maintainer's own 5,201-line log found the real NIC name **94** times.

- `controller.py`: the line now logs `stable_pseudonym(name)` (`NIC-1a2b3c4d`), the same hash `ObfuscatingFormatter` uses to scrub historical lines, so old and new lines still correlate across a bundle (#263).
- `support_bundle.py` / `ObfuscatingFormatter`: the legacy 1.2.x log shape the scrubber missed is covered, and unknown config keys are redacted rather than shipped as-is. After the change the same log contains **0** occurrences.

### Display names shipped too

The MANIFEST promised no display names; `position_manager.py` and `taskbar_utils.py` logged `screen.name()` on several paths. They now log `stable_pseudonym(name, "DISPLAY")`.

### privacy.md described a different app

- Hardware utilization history is recorded to the local database **by default** (the off switch lands in 2.2). It said otherwise.
- Adapter-name scrubbing is described as what it is: best-effort pseudonymization, not "not included".

### Verified

- `test_support_bundle.py` (+148) and `test_obfuscating_formatter.py`: the primary-interface line, the 1.2.x shape, unknown-key redaction, MANIFEST wording pinned to code. Shown failing first.
- Depends on `stable_pseudonym` in `utils/config.py`, which landed with the rollback PR.
