### PR TITLE
chore: 2.1.5 - version bump, changelog entry, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NetSpeedTray
 
-![GitHub release](https://img.shields.io/github/v/release/erez-c137/NetSpeedTray?style=flat-square) ![Downloads](https://img.shields.io/github/downloads/erez-c137/NetSpeedTray/total?style=flat-square) ![License](https://img.shields.io/github/license/erez-c137/NetSpeedTray?style=flat-square) ![Windows](https://img.shields.io/badge/Windows-10%20%7C%2011-0078D6?style=flat-square&logo=windows&logoColor=white) ![Made with Python](https://img.shields.io/badge/Python-3.11+-3776AB?style=flat-square&logo=python&logoColor=white) [![winget](https://img.shields.io/badge/winget-install-blue?style=flat-square&logo=windows&logoColor=white)](https://github.com/microsoft/winget-pkgs) ![Stars](https://img.shields.io/github/stars/erez-c137/NetSpeedTray?style=flat-square&color=yellow)
+![GitHub release](https://img.shields.io/github/v/release/erez-c137/NetSpeedTray?style=flat-square) ![Downloads](https://img.shields.io/github/downloads/erez-c137/NetSpeedTray/total?style=flat-square) ![License](https://img.shields.io/github/license/erez-c137/NetSpeedTray?style=flat-square) ![Windows](https://img.shields.io/badge/Windows-10%20%7C%2011-0078D6?style=flat-square&logo=windows&logoColor=white) ![Made with Python](https://img.shields.io/badge/Python-3.13-3776AB?style=flat-square&logo=python&logoColor=white) [![winget](https://img.shields.io/badge/winget-install-blue?style=flat-square&logo=windows&logoColor=white)](https://github.com/microsoft/winget-pkgs) [![Microsoft Store](https://img.shields.io/badge/Microsoft%20Store-get-0078D6?style=flat-square&logo=windows&logoColor=white)](https://apps.microsoft.com/detail/XP9MHWQZJPLQM8) ![Stars](https://img.shields.io/github/stars/erez-c137/NetSpeedTray?style=flat-square&color=yellow)
 
 ![NetSpeedTray Banner](./screenshots/netspeedtray-hero.jpg)
 
@@ -13,10 +13,11 @@ Open source, signed, no ads, no telemetry. The feature Windows forgot.
 
 </div>
 
-> 🎉 **v2.0 is here - the biggest release yet.** The widget now **docks to the taskbar itself**, so it
-> no longer vanishes behind the Start menu or system flyouts. And everything beyond the readout moved into
-> one calm window - the new **Monitor** - with history charts, honest per-app and per-process detail,
-> exportable statistics, network latency, and data-usage tracking. [Read the release notes →](https://github.com/erez-c137/NetSpeedTray/releases/latest)
+> 🎉 **The 2.x era.** The widget **docks to the taskbar itself**, so it no longer vanishes behind the
+> Start menu or system flyouts. Everything beyond the readout lives in one calm window - the **Monitor** -
+> with history charts, honest per-app and per-process detail, exportable statistics, network latency, and
+> data-usage tracking. And since 2.1.4, the **portable build updates itself** - verified, swapped, and
+> relaunched without you touching a file. [Read the release notes →](https://github.com/erez-c137/NetSpeedTray/releases/latest)
 
 ---
 
@@ -27,6 +28,8 @@ winget install --id erez-c137.NetSpeedTray
 ```
 
 Or grab the latest [**Setup.exe** or **Portable.zip**](https://github.com/erez-c137/NetSpeedTray/releases/latest) directly. Both are digitally signed - no SmartScreen warnings.
+
+Also on the [**Microsoft Store**](https://apps.microsoft.com/detail/XP9MHWQZJPLQM8) - the same signed installer and the same free, open-source app, one click from the Store. It's the *only* NetSpeedTray on the Store; anything with a similar name isn't this project.
 
 **Requirements:** Windows 10 or 11 (64-bit). The widget needs no admin rights. CPU/GPU **temperatures** on some hardware need an optional helper - [see below](#hardware-monitoring---do-i-need-librehardwaremonitor).
 
@@ -124,7 +127,7 @@ So I built NetSpeedTray: live up/down speeds, CPU and GPU utilization, temperatu
 
 🎨 **Make it yours.** Layout modes, fonts, decimals, arrow styles, color thresholds, a mini-graph overlay, light/dark auto-theming, and a live preview in Settings that shows the exact effect before you commit.
 
-🔒 **Trustworthy by design.** Open source under GPLv3. Signed installer, zero ads/tracking/telemetry, logs auto-redacted of paths/IPs/MACs/hostnames, and an in-app updater that *verifies the signature* before running anything. And it stays free: GPLv3 means that even if I lose interest or get hit by a bus, the code can't be bought, closed, or paywalled out from under you - anyone can fork it.
+🔒 **Trustworthy by design.** Open source under GPLv3. Signed installer, zero ads/tracking/telemetry, logs auto-redacted of paths/IPs/MACs/hostnames/adapter names, and an in-app updater that *verifies the signature* before running anything. And it stays free: GPLv3 means that even if I lose interest or get hit by a bus, the code can't be bought, closed, or paywalled out from under you - anyone can fork it.
 
 ---
 
@@ -200,7 +203,7 @@ Only if you ask it to. The default target is your own **gateway**, which never l
 The Wi-Fi **band** (2.4G / 5G) shows on any PC with **no permission**. The **network name (SSID)** is different: since Windows 11, Windows only hands the SSID to apps that have **Location** access - a Windows privacy gate, the same one your browser hits for Wi-Fi features. It is **not** GPS and **not** tracking: NetSpeedTray never uses your position, reads the name **locally** only to show it on the widget, and never stores or transmits it (see the [Privacy Policy](privacy.md)). Prefer not to? Leave "Network name" off and use the band - it needs nothing. The first time the name is blocked, NetSpeedTray shows a one-time explainer with a shortcut straight to the Windows Location setting.
 
 **Where does it store data and settings?**
-`%APPDATA%\NetSpeedTray\` - `config.json` for settings, `speed_history.db` (SQLite) for network/hardware history, and rotated logs. Everything stays local. Settings has an **Export Support Bundle** button that auto-redacts paths, IPs, hostnames, and MACs for clean bug reports.
+`%APPDATA%\NetSpeedTray\` - `NetSpeedTray_Config.json` for settings, `speed_history.db` (SQLite) for network/hardware history, and rotated logs. Everything stays local. Settings has an **Export Support Bundle** button that auto-redacts paths, IPs, hostnames, MACs, and adapter names for clean bug reports. The database's schema, example queries, and how to restore a backup are all documented in [DATABASE.md](DATABASE.md).
 
 **Does it work on Windows 7 or 8?**
 Officially Windows 10 and 11 (64-bit). The taskbar APIs changed enough after Win8 that older versions aren't tested. It might work; it's not supported.
@@ -246,7 +249,7 @@ You probably grabbed an unsigned dev build. The official releases ([Setup.exe / 
 - **Units** - Bits (Mbps), Bytes (MB/s), Binary (MiB/s), or Decimal, with toggleable suffixes
 
 ### Positioning & Integration
-- **Taskbar-docked** - stays above the taskbar through the Start menu, flyovers, and the tray overflow
+- **Taskbar-docked** - stays above the taskbar through the Start menu, flyouts, and the tray overflow
 - **Drag to reposition** - drag the widget to move it along the taskbar; your spot is remembered. **Free Move (No Snapping)** lets you place it anywhere, including off the taskbar
 - **Preferred monitor** - pin to a specific display (auto free-floats on a taskbar-less screen)
 - **Survives** sleep/resume, monitor add/remove/primary-swap, and Explorer restarts
@@ -260,9 +263,9 @@ You probably grabbed an unsigned dev build. The official releases ([Setup.exe / 
 - **Digitally signed** by the [SignPath Foundation](https://signpath.org/) - no SmartScreen warnings
 - **100% open source** (GPLv3) - no ads, no tracking, no telemetry · [Privacy Policy](privacy.md)
 - **Your history is a plain SQLite file you can query yourself** - schema, units and example queries in [DATABASE.md](DATABASE.md)
-- **PII obfuscation** - logs auto-redact paths, IPs (incl. IPv6), MACs, hostnames, and interface GUIDs
+- **PII obfuscation** - logs auto-redact paths, IPs (incl. IPv6), MACs, hostnames, and interface GUIDs - and network-adapter names are replaced with **stable pseudonyms**, so repeated log lines still correlate for debugging without carrying the labels you gave your adapters
 - **Latency boundary** - off by default; gateway-only unless you explicitly opt in to a public host you name
-- **Verified updates** - the in-app updater authenticates the installer (Windows `WinVerifyTrust` + a publisher pin) before running, with a GitHub fallback
+- **Verified updates** - the in-app updater authenticates every download (Windows `WinVerifyTrust` + a publisher pin) before running it, with a GitHub fallback. Since 2.1.4 the **portable build updates itself in place**, and the updater never offers a prerelease - trying a beta is always a deliberate download
 - **Support Bundle** - one-click sanitized zip of logs + config + system info for bug reports
 
 ### Localization

--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,142 @@ ALSO
 
 ---
 
+## [2.1.5] - September 8, 2026
+
+The release that makes rolling back safe - the escape hatch the 2.2 beta cycle depends on, plus
+honest numbers on the widget and in every export.
+
+> **Upgrading:** the first launch compacts the history database (a typical install drops from
+> ~53 MB to ~7 MB - nothing is deleted, the file was mostly slack). And very light traffic now
+> shows as `0.02 Mbps` instead of `0.0 Mbps` - a display change, not a measurement change.
+
+### Added
+
+- **Opening a database written by a newer NetSpeedTray now shows an on-screen notice, not just a
+  log line.** History stays visible while recording pauses, and the message names the exact
+  backup file to go back to. ([#273])
+
+  *Under the hood: the guard shipped in 2.1.4 but never left the log - four
+  `_schema_incompatible` sites, none emitting a signal. A rolled-back install looked perfectly
+  healthy while recording nothing, forever.*
+
+- **DATABASE.md documents how to restore a pre-migration backup** - including deleting the
+  `-wal`/`-shm` sidecar files first, which is not optional.
+
+  *Under the hood: renaming the `.bak` into place with stale sidecars present lets SQLite replay
+  the newer schema's write-ahead log onto the restored file - `quick_check` says ok, and the old
+  tables are gone.*
+
+- **Your settings are backed up before any migration touches them.** The first time a config
+  written by a different version loads, a pristine copy is kept as `config.json.bak.v<version>`.
+
+- **NetSpeedTray is on the [Microsoft Store](https://apps.microsoft.com/detail/XP9MHWQZJPLQM8).**
+  Same signed installer, same free app, one click from the Store - and the only official listing
+  there. Anything with a similar name is not this project.
+
+- **The updater never offers a prerelease.** When 2.2.0 ships as a beta, trying it will always be
+  a deliberate download - nobody gets moved onto one automatically. ([#264])
+
+### Changed
+
+- **The startup cleanup only deletes update folders it created itself, and logs every removal.**
+  A rollback copy like `NetSpeedTray-2.1.5-backup` kept beside the install now survives every
+  launch. ([#264])
+
+- **The read-only refusal message points at your data instead of away from it** - it names the
+  newest backup this version can actually open, and no longer suggests discarding your history
+  as the first option.
+
+### Fixed
+
+- **A config from a different version no longer loses your settings.** An unparseable
+  `config_version` used to reset everything to defaults - and then save the reset. Newer
+  versions are never stamped down, and settings this version doesn't know survive untouched.
+
+- **Coverage and totals are no longer wrong in SMART mode.** Every stats sheet and CSV export
+  reported 0.0% coverage, and bandwidth totals came out halved. ([#273])
+
+  *Under the hood: SMART's `-1.0` sentinel is truthy, so the `or 1.0` idiom let it straight
+  through - and SMART samples every 2.0 s, so normalizing to 1.0 would still be wrong by 2x. One
+  shared resolver now feeds the sampler and all the math. A unit test had pinned the wrong 1 s
+  assumption as spec; the expectation was corrected rather than the code bent to the test.*
+
+- **Speeds at a unit boundary no longer render as `1000.0 Kbps`.** The unit is chosen from the
+  value as displayed, so it promotes to `1.0 Mbps` instead of overflowing the widget's number
+  slot.
+
+- **10 GbE speeds fit the widget.** In always-Mbps mode, `10000.0 Mbps` now promotes to
+  `10.0 Gbps`, without widening the widget for anyone.
+
+- **Light traffic is no longer shown as nothing.** At the default settings, ~3,000 B/s reads
+  `0.02 Mbps` instead of `0.0 Mbps`; a true zero still reads `0.0`.
+
+- **A CPU temperature that never moves is no longer shown as if it were real.** Some boards
+  answer every poll with the same round placeholder (290 K, 300 K), which the widget showed as
+  17 °C or 27 °C forever. Those zones are now ignored; a real sensor still reads normally.
+  ([#275], [#237])
+
+  *Under the hood: ACPI thermal zones report tenths of a kelvin, and a Celsius-derived value
+  never lands on a whole ten-kelvin multiple. A zone that reports one is a placeholder until the
+  first time it changes, after which it is trusted for good. The 0-150 °C range check that let
+  the placeholders through is unchanged.*
+
+- **Hovering the Monitor graph shows a readout on every tab.** It only ever worked on the combined
+  Hardware view; the Network tab and the other Hardware layouts showed nothing. The readout also
+  uses your unit setting.
+
+  *Under the hood: two bugs masking each other. Only one plot call passed `label=`, so the
+  tooltip skipped every other line as a helper; and the network axes carry Mbps while the
+  formatter expected bytes/sec, so had it fired it would have read 40 Mbps as 320 bps. A series
+  the renderer splits at gaps now collapses to one row; the dashed zero bridges stay unlabeled
+  so a synthesized zero is never reported as a measurement.*
+
+- **The database file actually shrinks now.** Maintenance compaction was gated on a condition
+  that could not be true for an install's first year (or ever, on "Keep everything") while
+  fragmentation grew from day one. It also no longer leaves a write-ahead log the size of the
+  whole database behind afterwards.
+
+### Security
+
+- **Network adapter names no longer appear in logs or support bundles.** Adapters you have
+  renamed ("Office VPN") are replaced with stable pseudonyms (`NIC-1a2b3c4d`) that still
+  correlate across lines - including lines written by older versions, when a bundle is built.
+  ([#263])
+
+- **privacy.md now says exactly what the app does.** Hardware utilization history is recorded to
+  the local database by default (the off switch lands in 2.2), and adapter-name scrubbing is
+  described honestly as best-effort pseudonymization rather than "not included".
+
+### Localization
+
+- **Italian.** NetSpeedTray now speaks 15 languages - `it_IT` contributed by
+  [@parmacvn-beep](https://github.com/parmacvn-beep). ([#279])
+- **Two new strings** for the database notice are drafted in every language, matched to each
+  file's existing wording; native review continues through [#202].
+
+### Developer notes
+
+- The release pipeline can now ship a beta safely: a prerelease tag publishes as a prerelease
+  (not Latest), skips WinGet entirely, and the build chain accepts `-beta.N` version strings end
+  to end. The false branch is rehearsed by this very release's tag. ([#257])
+- The exe's `FileVersion` string in Explorer's file Properties now reads `2.1.5` (previously
+  `2.1.4.0`-style); the numeric version resource is unchanged.
+- Each release is also submitted to the Microsoft Store listing by CI once the Partner Center
+  credentials are configured; until then the job skips with a warning and the submission is
+  done by hand. Prereleases never reach the Store, by the same guard as WinGet.
+- 1,361 tests, up 136 from 2.1.4. Every fix above landed with a test demonstrated failing first.
+
+[#202]: https://github.com/erez-c137/NetSpeedTray/issues/202
+[#237]: https://github.com/erez-c137/NetSpeedTray/issues/237
+[#257]: https://github.com/erez-c137/NetSpeedTray/issues/257
+[#263]: https://github.com/erez-c137/NetSpeedTray/issues/263
+[#264]: https://github.com/erez-c137/NetSpeedTray/pull/264
+[#273]: https://github.com/erez-c137/NetSpeedTray/pull/273
+[#275]: https://github.com/erez-c137/NetSpeedTray/issues/275
+[#279]: https://github.com/erez-c137/NetSpeedTray/pull/279
+
+---
+
 ## [2.1.4] - August 23, 2026
 
 The portable build updates itself - plus a log that had been drowning out the bugs it was meant to record, and the groundwork that makes the next release safe to try.

--- a/src/netspeedtray/__init__.py
+++ b/src/netspeedtray/__init__.py
@@ -4,4 +4,4 @@ NetSpeedTray package initialization.
 A system tray application for monitoring network speed on Windows.
 """
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"


### PR DESCRIPTION
The last PR of the 2.1.5 cycle. After it merges, releasing is `git tag v2.1.5 && git push origin v2.1.5`.

### What is in it

- `src/netspeedtray/__init__.py`: `__version__ = "2.1.5"`. `build.bat` and `create_version_info.py` read it; nothing else carries the number.
- `changelog.md`: the `[2.1.5]` entry, written from the reviewed draft in `Docs/releases/v2.1.5/` and dated **September 8, 2026**. Every `[#N]` reference in the entry resolves inside it; none unused. If the tag lands on a different day, the date line is the only thing to touch.
- `README.md`: the 2.x-era blockquote (portable self-update since 2.1.4), adapter-name pseudonyms at the three trust claims, the `NetSpeedTray_Config.json` filename fix, Python 3.13 badge, `DATABASE.md` link in the FAQ, the "flyouts" typo, the Microsoft Store badge and install line (listing `XP9MHWQZJPLQM8`), and 15 languages with Italian credited.

### What the tag will do, and what it will not

`release.yml` (#280) builds, signs via SignPath, publishes the GitHub release as **Latest** (not a prerelease - no `-` in the tag), submits to WinGet, and runs the Store job, which **skips with a warning** until the five `MSSTORE_*` secrets exist. CI still does not apply release notes: after publish, `gh release edit v2.1.5 --notes-file Docs/releases/v2.1.5/release-notes.md`.

### Still owed by hand before tagging

From the readiness checklist in `Docs/releases/v2.1.5/action-plan.md`:

- the throwaway `v0.0.1-test` tag proving the prerelease branch (prerelease, not Latest, no WinGet PR, Store job skipped), deleted afterwards;
- a scratch `build.bat` at `2.2.0-beta.1`, `FileVersionInfo` checked on the binary;
- the read-only flyout seen on screen against a `db_version: 8` file; a backup folder surviving three launches; the graph hover in the live Monitor window;
- the GUI smoke test on the signed build.
