### PR TITLE
ci(store): reusable Store submit workflow, callable from release.yml and by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,80 +140,11 @@ jobs:
 
   submit-to-msstore:
     needs: build-and-sign
-    # Same guard as WinGet: a prerelease must never reach the Store listing. The listing is a
-    # Win32 EXE submission (Store ID XP9MHWQZJPLQM8), so the Store downloads and caches the
-    # Setup.exe from the GitHub release asset URL below, then runs its own certification pass.
-    # Nothing here is MSIX - the taskbar dock and the in-app updater behave exactly as on GitHub.
+    # Same guard as WinGet: a prerelease must never reach the Store listing. The implementation
+    # lives in store-submit.yml (one payload, also runnable by hand for a repair) and carries its
+    # own continue-on-error, so a Partner Center hiccup never fails the release run.
     if: "!contains(github.ref_name, '-')"
-    runs-on: ubuntu-latest
-    # Partner Center is a best-effort channel: a Store hiccup must not fail the release.
-    continue-on-error: true
-    steps:
-      - name: Check Store credentials
-        id: creds
-        env:
-          CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
-        run: |
-          if [ -z "$CLIENT_ID" ]; then
-            echo "::warning::MSSTORE_* secrets are not set - Store submission skipped. Submit ${GITHUB_REF_NAME} by hand in Partner Center."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ok=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Configure Store credentials
-        if: steps.creds.outputs.ok == 'true'
-        uses: microsoft/store-submission@v1
-        with:
-          command: configure
-          type: win32
-          seller-id: ${{ secrets.MSSTORE_SELLER_ID }}
-          product-id: ${{ secrets.MSSTORE_PRODUCT_ID }}
-          tenant-id: ${{ secrets.MSSTORE_TENANT_ID }}
-          client-id: ${{ secrets.MSSTORE_CLIENT_ID }}
-          client-secret: ${{ secrets.MSSTORE_CLIENT_SECRET }}
-
-      - name: Point the listing at this release's installer
-        if: steps.creds.outputs.ok == 'true'
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          V="${VERSION#v}"
-          URL="https://github.com/erez-c137/NetSpeedTray/releases/download/${VERSION}/NetSpeedTray-${V}-x64-Setup.exe"
-          # This PUT replaces the listing's package module, so every field below mirrors what the
-          # by-hand 2.1.4 submission holds - read back verbatim by the Store preflight workflow on
-          # 2026-09-04 - except packageUrl, which moves from the one-off upload to the GitHub
-          # release asset. Change a field here only after re-reading the module with the preflight.
-          python3 - "$URL" > product-update.json <<'PY'
-          import json, sys
-          scenarios = ["installationCancelledByUser", "applicationAlreadyExists",
-                       "installationAlreadyInProgress", "diskSpaceIsFull", "rebootRequired",
-                       "networkFailure", "packageRejectedDuringInstallation",
-                       "installationSuccessful", "miscellaneous"]
-          print(json.dumps({"packages": [{
-              "packageUrl": sys.argv[1],
-              "languages": ["zh", "zh-tw", "nl", "en", "fr", "de", "he", "ja", "ko", "pl", "ru", "sl", "tr", "es", "it"],
-              "architectures": ["X64"],
-              "isSilentInstall": False,
-              "installerParameters": "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-",
-              "genericDocUrl": "https://github.com/erez-c137/NetSpeedTray",
-              "errorDetails": [{"errorScenario": s, "errorScenarioDetails": []} for s in scenarios],
-              "packageType": "exe",
-          }]}, separators=(",", ":")))
-          PY
-          echo "PRODUCT_UPDATE=$(cat product-update.json)" >> "$GITHUB_ENV"
-          echo "Store package URL: $URL"
-          python3 -c "import json;p=json.load(open('product-update.json'))['packages'][0];p.pop('errorDetails');print(json.dumps(p,indent=2))"
-
-      - name: Update draft submission
-        if: steps.creds.outputs.ok == 'true'
-        uses: microsoft/store-submission@v1
-        with:
-          command: update
-          product-update: ${{ env.PRODUCT_UPDATE }}
-
-      - name: Publish submission
-        if: steps.creds.outputs.ok == 'true'
-        uses: microsoft/store-submission@v1
-        with:
-          command: publish
+    uses: ./.github/workflows/store-submit.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -70,16 +70,22 @@ jobs:
           client-secret: ${{ secrets.MSSTORE_CLIENT_SECRET }}
 
       - name: Build the package payload
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          python3 - "$ASSET_URL" > product-update.json <<'PY'
+          python3 - "$ASSET_URL "${VERSION#v}" > product-update.json <<'PY'
           import json, sys
+          version = tuple(int(x) for x in sys.argv[2].split("."))
+          languages = ["zh", "zh-tw", "nl", "en", "fr", "de", "he", "ja", "ko", "pl", "ru", "sl", "tr", "es"]
+          if version >= (2, 1, 5):
+              languages.append("it")          # Italian shipped in 2.1.5 (#279)
           scenarios = ["installationCancelledByUser", "applicationAlreadyExists",
                        "installationAlreadyInProgress", "diskSpaceIsFull", "rebootRequired",
                        "networkFailure", "packageRejectedDuringInstallation",
                        "installationSuccessful", "miscellaneous"]
           print(json.dumps({"packages": [{
               "packageUrl": sys.argv[1],
-              "languages": ["zh", "zh-tw", "nl", "en", "fr", "de", "he", "ja", "ko", "pl", "ru", "sl", "tr", "es", "it"],
+              "languages": languages,
               "architectures": ["X64"],
               "isSilentInstall": False,
               "installerParameters": "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-",

--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -1,0 +1,103 @@
+name: Store submit
+
+# Submits ONE released version's Setup.exe to the Microsoft Store listing (Win32 EXE listing
+# XP9MHWQZJPLQM8) and starts certification. Two entry points, one implementation:
+#   - workflow_call:     release.yml calls it after a non-prerelease tag is published.
+#   - workflow_dispatch: run it by hand for a version that is already a GitHub release, e.g. to
+#                        repair the listing (2026-09-04: the by-hand submission had pointed the
+#                        Store at a tmpfiles.org link, so the Store cached a 3 KB HTML page as
+#                        the installer and every install failed).
+# The package payload mirrors what Partner Center holds field for field - read it back with the
+# Store preflight workflow before changing anything here. Only packageUrl differs: it is always the
+# GitHub release asset, never a one-off upload.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version without the v, e.g. 2.1.5 (its GitHub release must exist)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the v, e.g. 2.1.4 (its GitHub release must exist)"
+        required: true
+        type: string
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    # Partner Center is a best-effort channel: a Store hiccup must never fail a release run.
+    continue-on-error: true
+    steps:
+      - name: Refuse prereleases and check the asset exists
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${VERSION#v}"                      # release.yml passes the raw tag (v2.1.5)
+          case "$VERSION" in
+            *-*) echo "::error::'$VERSION' is a prerelease - the Store listing never gets one"; exit 1 ;;
+          esac
+          URL="https://github.com/erez-c137/NetSpeedTray/releases/download/v${VERSION}/NetSpeedTray-${VERSION}-x64-Setup.exe"
+          # The Store downloads this URL itself. Prove it resolves to the real installer first -
+          # the 2.1.4 by-hand submission pointed at a link that served a 3 KB HTML page instead.
+          read -r code bytes < <(curl -sSL -o /dev/null -w '%{http_code} %{size_download}' "$URL")
+          echo "asset: $URL -> HTTP $code, $bytes bytes"
+          if [ "$code" != "200" ] || [ "$bytes" -lt 10000000 ]; then
+            echo "::error::release asset missing or too small ($bytes bytes) - not submitting"; exit 1
+          fi
+          echo "ASSET_URL=$URL" >> "$GITHUB_ENV"
+
+      - name: Check Store credentials
+        env:
+          CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+        run: |
+          if [ -z "$CLIENT_ID" ]; then
+            echo "::error::MSSTORE_* secrets are not set - submit ${{ inputs.version }} by hand in Partner Center"; exit 1
+          fi
+
+      - name: Configure Store credentials
+        uses: microsoft/store-submission@v1
+        with:
+          command: configure
+          type: win32
+          seller-id: ${{ secrets.MSSTORE_SELLER_ID }}
+          product-id: ${{ secrets.MSSTORE_PRODUCT_ID }}
+          tenant-id: ${{ secrets.MSSTORE_TENANT_ID }}
+          client-id: ${{ secrets.MSSTORE_CLIENT_ID }}
+          client-secret: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+
+      - name: Build the package payload
+        run: |
+          python3 - "$ASSET_URL" > product-update.json <<'PY'
+          import json, sys
+          scenarios = ["installationCancelledByUser", "applicationAlreadyExists",
+                       "installationAlreadyInProgress", "diskSpaceIsFull", "rebootRequired",
+                       "networkFailure", "packageRejectedDuringInstallation",
+                       "installationSuccessful", "miscellaneous"]
+          print(json.dumps({"packages": [{
+              "packageUrl": sys.argv[1],
+              "languages": ["zh", "zh-tw", "nl", "en", "fr", "de", "he", "ja", "ko", "pl", "ru", "sl", "tr", "es", "it"],
+              "architectures": ["X64"],
+              "isSilentInstall": False,
+              "installerParameters": "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-",
+              "genericDocUrl": "https://github.com/erez-c137/NetSpeedTray",
+              "errorDetails": [{"errorScenario": s, "errorScenarioDetails": []} for s in scenarios],
+              "packageType": "exe",
+          }]}, separators=(",", ":")))
+          PY
+          echo "PRODUCT_UPDATE=$(cat product-update.json)" >> "$GITHUB_ENV"
+          python3 -c "import json;p=json.load(open('product-update.json'))['packages'][0];p.pop('errorDetails');print(json.dumps(p,indent=2))"
+
+      - name: Update the draft's package module
+        uses: microsoft/store-submission@v1
+        with:
+          command: update
+          product-update: ${{ env.PRODUCT_UPDATE }}
+
+      - name: Publish (starts certification)
+        uses: microsoft/store-submission@v1
+        with:
+          command: publish


### PR DESCRIPTION
**Why now.** Partner Center shows install attempts and zero successes. The Store's cached installer for the listing is **3,233 bytes** - the tmpfiles.org HTML landing page the by-hand 2.1.4 submission linked to (SHA256 `1fb1586b...`, matching the Store manifest; the real Setup.exe is 44,289,200 bytes, SHA256 `0edde446...`). That link is now a 404. Every Store install has failed since the listing went live.

**What this does.** `store-submit.yml` is the single implementation, with two entry points:
- `workflow_call` from `release.yml`'s `submit-to-msstore` job (same prerelease guard, `secrets: inherit`);
- `workflow_dispatch` with a `version` input, to submit an existing release by hand - first use: repair the listing with the real 2.1.4 asset today.

It strips a leading `v`, refuses prereleases, **downloads the GitHub asset once and refuses to submit unless it is HTTP 200 and >10 MB**, then configure -> update -> publish with the payload read back from Partner Center by the preflight (#286, #287). `continue-on-error` lives on its own job, so a Store hiccup never fails a release run.

**Verified:** the asset URL redirects once to a signed `release-assets.githubusercontent.com` URL and returns 200 / 44,289,200 bytes. Whether the Store's fetcher follows that redirect is the one remaining unknown; the dispatch run for 2.1.4 answers it before the 2.1.5 tag.