### PR TITLE
ci(store): fix the asset gate and show red on manual runs

### DIFF
--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -28,8 +28,9 @@ on:
 jobs:
   submit:
     runs-on: ubuntu-latest
-    # Partner Center is a best-effort channel: a Store hiccup must never fail a release run.
-    continue-on-error: true
+    # Partner Center is a best-effort channel: a Store hiccup must never fail a RELEASE run (the
+    # caller's event is the tag push). A by-hand dispatch must show red when it fails.
+    continue-on-error: ${{ github.event_name == 'push' }}
     steps:
       - name: Refuse prereleases and check the asset exists
         env:
@@ -43,8 +44,11 @@ jobs:
           URL="https://github.com/erez-c137/NetSpeedTray/releases/download/v${VERSION}/NetSpeedTray-${VERSION}-x64-Setup.exe"
           # The Store downloads this URL itself. Prove it resolves to the real installer first -
           # the 2.1.4 by-hand submission pointed at a link that served a 3 KB HTML page instead.
-          read -r code bytes < <(curl -sSL -o /dev/null -w '%{http_code} %{size_download}' "$URL")
-          echo "asset: $URL -> HTTP $code, $bytes bytes"
+          # Not `read < <(curl ...)`: curl's -w output has no trailing newline, so `read` returns 1
+          # at EOF and the shell's exit-on-error kills the step before it prints anything.
+          out=$(curl -sSL -o /dev/null -w '%{http_code} %{size_download}' "$URL" || true)
+          code="${out%% *}"; bytes="${out##* }"; bytes="${bytes:-0}"
+          echo "asset: $URL -> HTTP ${code:-none}, $bytes bytes"
           if [ "$code" != "200" ] || [ "$bytes" -lt 10000000 ]; then
             echo "::error::release asset missing or too small ($bytes bytes) - not submitting"; exit 1
           fi


### PR DESCRIPTION
First dispatch (run 33865425737) died in the asset gate before printing anything: `read -r code bytes < <(curl -w ...)` returns 1 at EOF because curl's `-w` output has no trailing newline, and the step's `bash -e` stopped it there. Replaced with a captured variable and a guarded parse; dry-run locally against the 2.1.4 asset (HTTP 200, 44,289,200 bytes, gate PASS). Also `continue-on-error` is now `github.event_name == 'push'`: a release run stays green on a Store hiccup, but a by-hand dispatch shows red instead of masking a failure as success - which is exactly what just happened.