### PR TITLE
ci(store): restore the missing quote in the payload step

### DIFF
--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          python3 - "$ASSET_URL "${VERSION#v}" > product-update.json <<'PY'
+          python3 - "$ASSET_URL" "${VERSION#v}" > product-update.json <<'PY'
           import json, sys
           version = tuple(int(x) for x in sys.argv[2].split("."))
           languages = ["zh", "zh-tw", "nl", "en", "fr", "de", "he", "ja", "ko", "pl", "ru", "sl", "tr", "es"]


### PR DESCRIPTION
Run 33865695020 reached the payload step and died with `syntax error near unexpected token '('`: the heredoc line read `"$ASSET_URL "${VERSION#v}"` - the closing quote after the URL was lost in the previous edit, and bash parsed the rest of the step through a broken quote. Fixed, and every `run:` block of the three workflows now passes `bash -n`, which is what the last two PRs should have done before pushing.