### PR TITLE
ci(store): installer parameters within the API's 40-character cap

### DIFF
--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -92,7 +92,10 @@ jobs:
               "languages": languages,
               "architectures": ["X64"],
               "isSilentInstall": False,
-              "installerParameters": "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-",
+              # The submission API caps this at 40 characters (the Partner Center UI accepted the
+              # 45-character "... /SP-"; the API rejects it). /SP- only suppresses Inno's startup
+              # prompt, which never shows under /VERYSILENT - same install. Exactly 40 characters.
+              "installerParameters": "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART",
               "genericDocUrl": "https://github.com/erez-c137/NetSpeedTray",
               "errorDetails": [{"errorScenario": s, "errorScenarioDetails": []} for s in scenarios],
               "packageType": "exe",


### PR DESCRIPTION
Runs 33865993425 and 33866067134 reached the Store API, which answered: `Packages, maximum length allowed for InstallerParameters is 40.` The by-hand submission's string is 45 characters - the Partner Center UI accepted it, the API does not. `/SP-` only suppresses Inno's startup prompt, which never appears under `/VERYSILENT`, so `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`, exactly 40, is the same install. Every `run:` block in both Store workflows passes `bash -n`.