### PR TITLE
build(installer): silent installs relaunch the app and never hang on the running-app prompt

### DIFF
--- a/build/setup.iss
+++ b/build/setup.iss
@@ -100,6 +100,11 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: 
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
+; A silent install (Microsoft Store, winget install, winget upgrade) shows no Finish page, so the
+; entry above never fires and the app is simply not running until the next sign-in - "nothing
+; visible happened" (#260) on a new channel. This entry covers the silent path only, and
+; runasoriginaluser keeps the tray app unelevated even though Setup itself ran as admin.
+Filename: "{app}\{#MyAppExeName}"; Flags: nowait runasoriginaluser; Check: LaunchAfterSilentInstall
 
 [UninstallDelete]
 Type: files; Name: "{autodesktop}\{#MyAppName}.lnk"
@@ -121,6 +126,13 @@ const
   WM_CLOSE = $0010;  
 
 // --- Helper Functions ---
+function LaunchAfterSilentInstall(): Boolean;
+begin
+  Result := WizardSilent();
+  if Result then
+    Log('Silent install: starting {#MyAppName} as the original user (no Finish page to offer it).');
+end;
+
 function BoolToStr(Value: Boolean): string;
 begin
   if Value then
@@ -243,11 +255,14 @@ function InitializeSetup(): Boolean;
 begin
   if IsAppRunning() then
   begin
-    if MsgBox('{#MyAppName} is currently running and needs to be closed to continue installation.'#13#10#13#10'Click OK to automatically close it, or Cancel to exit the installer.', mbConfirmation, MB_OKCANCEL) = IDOK then
+    // SuppressibleMsgBox, not MsgBox: a plain MsgBox is NOT suppressed by /SUPPRESSMSGBOXES, so a
+    // silent install (Microsoft Store, winget upgrade) over a running app hung on this dialog.
+    // Silent default = OK = close the app and carry on, which is what an upgrade must do.
+    if SuppressibleMsgBox('{#MyAppName} is currently running and needs to be closed to continue installation.'#13#10#13#10'Click OK to automatically close it, or Cancel to exit the installer.', mbConfirmation, MB_OKCANCEL, IDOK) = IDOK then
     begin
       if not CloseNetSpeedTray() then
       begin
-        MsgBox('Failed to close {#MyAppName}.'#13#10'Please close it manually and try again.', mbError, MB_OK);
+        SuppressibleMsgBox('Failed to close {#MyAppName}.'#13#10'Please close it manually and try again.', mbError, MB_OK, IDOK);
         Result := False;
         Exit;
       end;
@@ -265,11 +280,11 @@ function InitializeUninstall(): Boolean;
 begin
   if IsAppRunning() then
   begin
-    if MsgBox('{#MyAppName} is currently running and needs to be closed to continue uninstallation.'#13#10#13#10'Click OK to automatically close it, or Cancel to exit the uninstaller.', mbConfirmation, MB_OKCANCEL) = IDOK then
+    if SuppressibleMsgBox('{#MyAppName} is currently running and needs to be closed to continue uninstallation.'#13#10#13#10'Click OK to automatically close it, or Cancel to exit the uninstaller.', mbConfirmation, MB_OKCANCEL, IDOK) = IDOK then
     begin
       if not CloseNetSpeedTray() then
       begin
-        MsgBox('Failed to close {#MyAppName}.'#13#10'Please close it manually and try again.', mbError, MB_OK);
+        SuppressibleMsgBox('Failed to close {#MyAppName}.'#13#10'Please close it manually and try again.', mbError, MB_OK, IDOK);
         Result := False;
         Exit;
       end;

--- a/build/version_info.txt
+++ b/build/version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 1, 4, 0),
-    prodvers=(2, 1, 4, 0),
+    filevers=(2, 1, 5, 0),
+    prodvers=(2, 1, 5, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -17,12 +17,12 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Erez C137'),
             StringStruct('FileDescription', 'NetSpeedTray'),
-            StringStruct('FileVersion', '2.1.4'),
+            StringStruct('FileVersion', '2.1.5'),
             StringStruct('InternalName', 'NetSpeedTray'),
             StringStruct('LegalCopyright', 'Copyright (c) Erez C137'),
             StringStruct('OriginalFilename', 'NetSpeedTray.exe'),
             StringStruct('ProductName', 'NetSpeedTray'),
-            StringStruct('ProductVersion', '2.1.4'),
+            StringStruct('ProductVersion', '2.1.5'),
           ]
         )
       ]

--- a/changelog.md
+++ b/changelog.md
@@ -113,6 +113,10 @@ honest numbers on the widget and in every export.
 
 ### Changed
 
+- **After a silent install, NetSpeedTray starts right away.** Installs from the Microsoft Store
+  and `winget` show no Finish page, so until now the app was simply not running until your next
+  sign-in - and a `winget upgrade` left it closed. The installer now starts it, unelevated.
+
 - **The startup cleanup only deletes update folders it created itself, and logs every removal.**
   A rollback copy like `NetSpeedTray-2.1.5-backup` kept beside the install now survives every
   launch. ([#264])


### PR DESCRIPTION
Found by running the 2.1.5 installer with the Store's switches (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`) over a running 2.1.4 on the maintainer's machine.

### 1. Silent installs over a running app hung

`InitializeSetup` / `InitializeUninstall` asked "NetSpeedTray is running... OK to close it?" with `MsgBox`, which `/SUPPRESSMSGBOXES` does **not** suppress (only `SuppressibleMsgBox` honours it). The installer log showed the box and then nothing: a Store update or a `winget upgrade` on any machine where the app is running - i.e. every upgrade - would sit on an invisible dialog. All four boxes are now `SuppressibleMsgBox(..., IDOK)`: under a silent install the answer is OK, the app is closed, the install proceeds. The interactive path is unchanged. (The uninstaller's "delete user data?" question was already guarded by `not UnInstallSilent()` and stays a plain MsgBox - it must never default.)

### 2. Silent installs left the app not running

The only `[Run]` entry was `postinstall skipifsilent`, so after a Store or winget install nothing appeared until the next sign-in - "nothing visible happened" (#260) on a new channel. A second entry, `Flags: nowait runasoriginaluser; Check: LaunchAfterSilentInstall` (a one-line `[Code]` helper around `WizardSilent` that also logs), starts the app after a silent install only, as the original user.

### Verified live, installer log excerpts

```
Defaulting to OK for suppressed message box (OK/Cancel):
Could not find NetSpeedTray window, falling back to taskkill on EXE/tree...
taskkill (attempt 1) executed with exit code: 0
Installation process succeeded.
Silent install: starting NetSpeedTray as the original user (no Finish page to offer it).
```

The relaunched process: new pid, `elevated=False`, integrity `medium`, path `C:\Program Files\NetSpeedTray\NetSpeedTray.exe`. Bonus from the same run: 2.1.5's first launch compacted the maintainer's live database from 53,035,008 to 3,686,400 bytes (readiness item E), and the primary-interface log line shows a pseudonym (item F).

### Also in this PR

`changelog.md`: one "Changed" bullet for 2.1.5. `build/version_info.txt`: regenerated for 2.1.5 by the local build.

### Not in this PR (follow-up)

The graceful-close path looks for a window titled `NetSpeedTrayHidden` and never finds it, so every upgrade closes the app with `taskkill /F`. The app's atomic config writes and WAL database make that safe, but it should be a real close. Recorded for 2.1.6.