### PR TITLE
ci(release): wait up to 30 min for SignPath approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
           signing-policy-slug: "release-signing"
           github-artifact-id: ${{ steps.upload_installer.outputs.artifact-id }}
           output-artifact-directory: "signed-installer"
+          # SignPath holds rapid successive requests for manual approval; the default 600 s wait
+          # failed a whole release run once (v2.1.2). 30 min gives the owner time to approve.
+          wait-for-completion-timeout-in-seconds: 1800
 
       - name: Submit Portable ZIP to SignPath
         uses: signpath/github-action-submit-signing-request@v2
@@ -81,6 +84,7 @@ jobs:
           signing-policy-slug: "release-signing"
           github-artifact-id: ${{ steps.upload_portable.outputs.artifact-id }}
           output-artifact-directory: "signed-portable"
+          wait-for-completion-timeout-in-seconds: 1800
 
       # --- Calculate Checksums of SIGNED files ---
       - name: Generate Checksums


### PR DESCRIPTION
SignPath holds rapid successive signing requests for manual approval; with the action's default 600 s wait the whole v2.1.2 release run failed while a request sat at WaitingForApproval. Both signing steps now wait up to 1800 s, so a delayed approval no longer aborts the build. No other change.