### PR TITLE
fix(monitor): the hover reads the peak under the cursor, not the spike's neighbour

### DIFF
--- a/src/netspeedtray/tests/unit/test_graph_hover.py
+++ b/src/netspeedtray/tests/unit/test_graph_hover.py
@@ -102,3 +102,26 @@ def test_rows_at_returns_nothing_far_from_any_sample():
     ax.set_xlim(mdates.date2num(T0), mdates.date2num(T0 + timedelta(minutes=10)))
     x = mdates.date2num(T0 + timedelta(minutes=5))
     assert GraphHoverTooltip(_host("network"))._rows_at(ax, x) == ([], None)
+
+
+def test_rows_at_reports_the_peak_under_the_cursor_not_its_neighbour():
+    """A one-second spike is narrower than a pixel at the one-hour window, so the sample nearest the
+    cursor's x is the spike's NEIGHBOUR half the time - the owner hovered a 12 Mbps spike and read
+    0.8 (2026-09-04). The readout must be the peak within the pixel column under the cursor."""
+    ys = [1.0] * 10
+    ys[4] = 12.0
+    ax = _axes_with([("Upload", T0, ys, {})])
+    ax.set_xlim(mdates.date2num(T0 - timedelta(minutes=30)), mdates.date2num(T0 + timedelta(minutes=30)))
+    x = mdates.date2num(T0 + timedelta(seconds=4.6))          # nearest sample is +5 s (1.0), spike is +4 s
+    rows, at = GraphHoverTooltip(_host("network"))._rows_at(ax, x)
+    assert [(r[0], r[1]) for r in rows] == [("Upload", 12.0)]
+    assert at == pytest.approx(mdates.date2num(T0 + timedelta(seconds=4)))
+
+
+def test_rows_at_on_a_flat_line_still_reads_the_nearest_sample():
+    ys = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    ax = _axes_with([("Upload", T0, ys, {})])
+    ax.set_xlim(mdates.date2num(T0), mdates.date2num(T0 + timedelta(seconds=9)))   # ~65 px per second
+    x = mdates.date2num(T0 + timedelta(seconds=6.2))
+    rows, _ = GraphHoverTooltip(_host("network"))._rows_at(ax, x)
+    assert [(r[0], r[1]) for r in rows] == [("Upload", 7.0)]

--- a/src/netspeedtray/views/monitor/graph_hover.py
+++ b/src/netspeedtray/views/monitor/graph_hover.py
@@ -28,6 +28,7 @@ from netspeedtray import constants
 
 # Don't pop a tooltip when the cursor is miles from any point (in axis-fraction of the x-range).
 _MAX_SNAP_FRAC = 0.04
+_PIXEL_SLACK = 1.5      # the cursor's pixel column plus half a pixel each side - what the eye reads
 
 
 class GraphHoverTooltip(QObject):
@@ -101,18 +102,27 @@ class GraphHoverTooltip(QObject):
             self._hide()
 
     def _rows_at(self, ax, x: float) -> Tuple[List[Tuple[str, float, str]], Optional[float]]:
-        """The value of every labelled series at the sample nearest `x`, plus that sample's x.
+        """The value of every labelled series under the cursor, plus the x of the sample reported.
+
+        "Under the cursor" means the highest sample within the pixel column the cursor is on
+        (plus a pixel of slack), not the sample nearest `x`. At the one-hour window a pixel is
+        about two seconds and a spike is one sample wide, so nearest-x picks the spike's neighbour
+        half the time: the owner hovered a 12 Mbps spike and read 0.8. The line is drawn through
+        the peak, so the peak is the honest readout. Where nothing falls inside the column (sparse
+        data) the nearest sample within the snap distance is used, as before.
 
         Lines without a legend label (matplotlib's `_childN`) are helpers - crosshairs and the
         renderer's dashed zero bridges across gaps - and are skipped, so the hover never reports a
         synthesized zero as a measurement. The renderer draws one series as several segments when
-        the data has gaps; those share a label and collapse to ONE row, the segment nearest the
-        cursor. X is read in axis units (`orig=False`), which is what `event.xdata` is in - the
-        original data are datetimes and cannot be compared to it.
+        the data has gaps; those share a label and collapse to ONE row. X is read in axis units
+        (`orig=False`), which is what `event.xdata` is in - the original data are datetimes.
         """
         xmin, xmax = ax.get_xlim()
         span = (xmax - xmin) or 1.0
-        best: Dict[str, Tuple[float, float, str, float]] = {}   # label -> (dx, y, color, x_at)
+        width_px = float(getattr(ax.bbox, "width", 0.0) or 0.0)
+        column = span / width_px * _PIXEL_SLACK if width_px > 0 else 0.0   # data units per pixel column
+        # label -> (rank, y, color, x_at, dx); rank sorts in-column peaks before nearest fallbacks
+        best: Dict[str, Tuple[Tuple[int, float], float, str, float, float]] = {}
         for line in ax.get_lines():
             lbl = line.get_label()
             if not lbl or str(lbl).startswith("_"):
@@ -121,18 +131,24 @@ class GraphHoverTooltip(QObject):
             yd = np.asarray(line.get_ydata(orig=False), dtype=float)
             if xd.size == 0 or yd.size != xd.size:
                 continue
-            idx = int(np.argmin(np.abs(xd - x)))
-            dx = abs(xd[idx] - x)
-            if dx > span * _MAX_SNAP_FRAC:          # cursor too far from this line's samples
-                continue
+            dist = np.abs(xd - x)
+            in_column = np.flatnonzero(dist <= column) if column > 0 else np.empty(0, dtype=int)
+            if in_column.size:
+                idx = int(in_column[np.argmax(yd[in_column])])       # the peak the line draws here
+                rank = (0, -float(yd[idx]))
+            else:
+                idx = int(np.argmin(dist))
+                if dist[idx] > span * _MAX_SNAP_FRAC:               # cursor too far from this line
+                    continue
+                rank = (1, float(dist[idx]))
             cur = best.get(str(lbl))
-            if cur is None or dx < cur[0]:
-                best[str(lbl)] = (dx, float(yd[idx]), line.get_color(), float(xd[idx]))
+            if cur is None or rank < cur[0]:
+                best[str(lbl)] = (rank, float(yd[idx]), line.get_color(), float(xd[idx]), float(dist[idx]))
         if not best:
             return [], None
-        rows = [(lbl, y, color) for lbl, (_dx, y, color, _xa) in best.items()]
-        nearest_x = min(best.values(), key=lambda t: t[0])[3]
-        return rows, nearest_x
+        rows = [(lbl, y, color) for lbl, (_r, y, color, _xa, _dx) in best.items()]
+        at = min(best.values(), key=lambda t: t[0])[3]                   # the reported peak's time
+        return rows, at
 
     def _format(self, x_num: float, rows: List[Tuple[str, float, str]]) -> str:
         when = mdates.num2date(x_num).strftime("%H:%M:%S")


### PR DESCRIPTION
Found by the owner in the 10-second hover check (2026-09-04): hovering a ~12 Mbps upload spike on the 1-hour window read **0.8 Mbps**, and it was hard to ever land on the matching value.

**Cause.** `_rows_at` reported the sample nearest the cursor's x. At the 1-hour window one pixel is ~2 s and a spike is one 1 s sample wide, so the nearest sample is the spike's neighbour about half the time.

**Fix.** Report the highest sample within the pixel column under the cursor (plus half a pixel of slack, `_PIXEL_SLACK = 1.5`), which is the value the line is drawing there; the timestamp is that sample's. Where nothing falls inside the column (sparse data) the previous nearest-within-snap rule still applies. Pixel width comes from `ax.bbox`, available on a bare Figure, so the tests need no canvas.

**Tests.** `test_rows_at_reports_the_peak_under_the_cursor_not_its_neighbour` reproduces the screenshot (1 s samples, 1-hour xlim, cursor 0.6 s off the spike) and fails on the old code; a flat-line test pins the unchanged case. Suite green.