### PR TITLE
fix(update): closing the progress dialog no longer cancels the update (#296)

### DIFF
--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -439,7 +439,12 @@ class SecureUpdater(QObject):
             self._progress.setValue(pct)
 
     def _on_cancel(self) -> None:
+        # Only a live dialog can carry a user's cancel. Once _close_progress() has detached it, any
+        # late `canceled` is the dialog being closed by us, not by the user (see _close_progress).
+        if self._progress is None:
+            return
         self._user_cancelled = True
+        logger.info("Update cancelled by the user.")
         if self._worker is not None:
             self._worker.cancel()
 
@@ -447,6 +452,7 @@ class SecureUpdater(QObject):
         self._teardown_thread()
         self._close_progress()
         if self._user_cancelled:
+            logger.info("Update cancelled before the installer was launched; download discarded.")
             self._cleanup_file()
             self._finish()
             return
@@ -561,9 +567,19 @@ class SecureUpdater(QObject):
         self._worker = None
 
     def _close_progress(self) -> None:
-        if self._progress is not None:
-            self._progress.close()  # WA_DeleteOnClose -> destroyed
-            self._progress = None
+        # QProgressDialog emits `canceled()` from its CLOSE EVENT, not only from the Cancel button.
+        # Closing the dialog with the signal still wired ran _on_cancel, and the very next line of
+        # _on_verified / _on_staged then treated the finished download as cancelled: it deleted the
+        # verified installer and returned without a word (#296, and #260 before it). Detach the
+        # dialog first, and silence it, so closing it can never look like a cancel.
+        dlg, self._progress = self._progress, None
+        if dlg is not None:
+            try:
+                dlg.canceled.disconnect(self._on_cancel)
+            except (TypeError, RuntimeError):
+                pass
+            dlg.blockSignals(True)
+            dlg.close()  # WA_DeleteOnClose -> destroyed
 
     def _cleanup_file(self) -> None:
         # Remove the whole private download directory (and the installer in it).

--- a/src/netspeedtray/tests/unit/test_update_installer_dialog.py
+++ b/src/netspeedtray/tests/unit/test_update_installer_dialog.py
@@ -1,0 +1,92 @@
+"""
+The in-app updater's progress dialog must not cancel the update by being closed.
+
+Found on release day of 2.1.5 (#296, and the same symptom in #260 for 2.1.3 -> 2.1.4): the download
+ran to 100%, the progress window closed, and then nothing - no installer, no browser, no log line.
+The cause is one line of ordering plus one Qt fact. `_on_verified` calls `_close_progress()` and
+THEN checks `self._user_cancelled`; `_close_progress()` calls `QProgressDialog.close()`; and Qt's
+QProgressDialog emits `canceled()` from its close event, not only from the Cancel button. So closing
+the dialog ran `_on_cancel`, set the flag, and the next line silently deleted the verified installer
+and finished. Every failure path logs; this one was the single silent path, which is why two bug
+reports and one release went by without a trace in any log.
+
+These tests drive `SecureUpdater` with a REAL QProgressDialog wired exactly as `start()` wires it,
+because a mocked dialog cannot emit the signal that caused the bug.
+"""
+import os
+
+import pytest
+from PyQt6.QtWidgets import QProgressDialog, QWidget
+
+from netspeedtray.constants.i18n import I18nStrings
+from netspeedtray.core import update_installer as ui
+
+
+@pytest.fixture
+def updater(q_app, tmp_path):
+    parent = QWidget()
+    u = ui.SecureUpdater(parent, "https://example.invalid/Setup.exe", "https://example.invalid/release",
+                         I18nStrings("en_US"), latest_version="9.9.9")
+    # The private download folder + the "verified" installer inside it, as after a real download.
+    u._tmpdir = str(tmp_path / "dl")
+    os.makedirs(u._tmpdir)
+    u._dest = os.path.join(u._tmpdir, "NetSpeedTray-Setup.exe")
+    with open(u._dest, "wb") as f:
+        f.write(b"MZ" + b"\0" * 64)
+    # The progress dialog exactly as start() creates and wires it.
+    u._progress = QProgressDialog("Downloading", "Cancel", 0, 100, parent)
+    u._progress.setAutoClose(False)
+    u._progress.setAutoReset(False)
+    u._progress.canceled.connect(u._on_cancel)
+    u._progress.show()
+    q_app.processEvents()
+    u._active = True
+    yield u
+    parent.deleteLater()
+
+
+def test_closing_the_progress_dialog_is_not_a_user_cancel(updater, q_app):
+    updater._on_progress(100)
+    updater._close_progress()
+    q_app.processEvents()
+    assert updater._user_cancelled is False
+
+
+def test_a_verified_installer_is_launched_not_discarded(updater, monkeypatch, q_app):
+    launched = []
+    monkeypatch.setattr(ui, "launch_installer", lambda path: launched.append(path))
+    quit_requested = []
+    updater.launching.connect(lambda: quit_requested.append(True))
+
+    updater._on_progress(100)
+    updater._on_verified(updater._dest, True, "ok")
+    q_app.processEvents()
+
+    assert launched == [updater._dest], "the verified installer must be launched"
+    assert quit_requested, "the app must be told to quit for the installer"
+    assert os.path.isfile(updater._dest), "the download must not be deleted on the success path"
+
+
+def test_a_real_cancel_click_still_cancels(updater, monkeypatch, q_app):
+    launched = []
+    monkeypatch.setattr(ui, "launch_installer", lambda path: launched.append(path))
+    updater._progress.canceled.emit()     # what the Cancel button does (cancel() is the slot; the button emits)
+    q_app.processEvents()
+    assert updater._user_cancelled is True
+    updater._on_verified(updater._dest, True, "ok")
+    q_app.processEvents()
+    assert launched == []
+    assert not os.path.exists(updater._tmpdir), "a cancelled download is cleaned up"
+
+
+def test_portable_staged_path_is_not_cancelled_by_the_dialog_closing(updater, monkeypatch, q_app):
+    handed_off = []
+    monkeypatch.setattr(ui.SecureUpdater, "_try_hands_off", lambda self, ready, app_dir: handed_off.append(ready) or True)
+    monkeypatch.setattr(ui, "is_portable_install", lambda: True, raising=False)
+    monkeypatch.setattr(ui.sys, "executable", os.path.join(updater._tmpdir, "NetSpeedTray.exe"), raising=False)
+    updater._portable = True
+    updater._on_progress(100)
+    updater._on_staged(os.path.join(updater._tmpdir, "NetSpeedTray-9.9.9"))
+    q_app.processEvents()
+    assert updater._user_cancelled is False
+    assert handed_off, "the staged portable update must proceed to the hands-off swap"


### PR DESCRIPTION
**Symptom** (#296 today on 2.1.4 -> 2.1.5; identical in #260 for 2.1.3 -> 2.1.4): the download bar reaches 100%, the window closes, nothing happens, nothing is logged.

**Cause.** `_on_verified` (and `_on_staged` for the portable path) call `_close_progress()` and *then* check `self._user_cancelled`. `_close_progress()` calls `QProgressDialog.close()`, and Qt's QProgressDialog emits `canceled()` from its **close event**, not only from the Cancel button - verified empirically with PyQt6 6.10 (`close()` while visible: fires; after autoReset hid it: fires; `reset()+hide()`: does not). So closing our own dialog ran `_on_cancel`, set the flag, and the next line deleted the verified installer and returned. Every failure path logs; this was the one silent path, which is why relu616's bundle shows `Update starting` and then nothing, twice.

**Fix.** `_close_progress()` detaches the dialog (`disconnect` + `blockSignals`) before closing it; `_on_cancel` ignores a `canceled` that arrives after the dialog has been detached; the cancel path logs.

**Tests.** `test_update_installer_dialog.py` drives `SecureUpdater` with a real QProgressDialog wired exactly as `start()` wires it (a mocked dialog cannot emit the signal that caused this). Three of four tests fail on the old code; the fourth pins that a real Cancel click still cancels and cleans up. The existing 16 updater tests never constructed the dialog, which is how this shipped in two releases.

**Consequence to communicate.** The bug lives in the *running* version, so 2.1.4 and 2.1.5 users cannot update in-app to anything; one manual install (release page, winget, or the Store) is needed once, after which in-app updates work. This wants a 2.1.6 soon, mainly so fresh installs stop shipping the broken updater.