### PR TITLE
fix(update): start the verified installer elevated and silent; a declined UAC prompt keeps the app

### DIFF
--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -89,10 +89,62 @@ def sweep_stale_update_dirs() -> None:
         pass
 
 
-def launch_installer(path: str) -> None:
-    """Launch the (already-verified) installer. The app must then quit so Inno's
-    AppMutex check passes and it can replace the running files."""
-    subprocess.Popen([path], close_fds=True)
+# The switches the Microsoft Store and winget run the installer with - and, since 2.1.5, what makes
+# the installer relaunch the app as the original user when it is done (setup.iss, LaunchAfterSilentInstall).
+INSTALLER_SILENT_ARGS = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+_ERROR_CANCELLED = 1223
+
+
+class UpdateElevationDeclined(RuntimeError):
+    """The user said No at the UAC prompt. Not a failure of ours - and not a reason to vanish."""
+
+
+def _shell_execute_runas(path: str, params: str, hwnd: int = 0) -> None:
+    """ShellExecuteEx(runas): start `path` elevated. Blocks until the UAC prompt is answered, then
+    returns once the elevated process exists. Raises UpdateElevationDeclined on ERROR_CANCELLED,
+    OSError on anything else. Isolated so tests can replace it without touching UAC."""
+    import ctypes
+    from ctypes import wintypes as w
+
+    class SHELLEXECUTEINFOW(ctypes.Structure):
+        _fields_ = [("cbSize", w.DWORD), ("fMask", w.ULONG), ("hwnd", w.HWND), ("lpVerb", w.LPCWSTR),
+                    ("lpFile", w.LPCWSTR), ("lpParameters", w.LPCWSTR), ("lpDirectory", w.LPCWSTR),
+                    ("nShow", ctypes.c_int), ("hInstApp", w.HINSTANCE), ("lpIDList", ctypes.c_void_p),
+                    ("lpClass", w.LPCWSTR), ("hkeyClass", w.HKEY), ("dwHotKey", w.DWORD),
+                    ("hIcon", w.HANDLE), ("hProcess", w.HANDLE)]
+
+    SEE_MASK_NOCLOSEPROCESS, SEE_MASK_NOASYNC, SEE_MASK_FLAG_NO_UI = 0x40, 0x100, 0x400
+    sei = SHELLEXECUTEINFOW()
+    sei.cbSize = ctypes.sizeof(sei)
+    sei.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI
+    sei.hwnd = hwnd or None
+    sei.lpVerb = "runas"
+    sei.lpFile = path
+    sei.lpParameters = params
+    sei.lpDirectory = os.path.dirname(path) or None
+    sei.nShow = 1  # SW_SHOWNORMAL
+    shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+    if not shell32.ShellExecuteExW(ctypes.byref(sei)):
+        err = ctypes.get_last_error()
+        if err == _ERROR_CANCELLED:
+            raise UpdateElevationDeclined("the UAC prompt was declined")
+        raise OSError(err, f"ShellExecuteEx(runas) failed with Win32 error {err}")
+    if sei.hProcess:
+        ctypes.windll.kernel32.CloseHandle(sei.hProcess)
+
+
+def launch_installer(path: str, hwnd: int = 0) -> None:
+    """Start the (already-verified) installer ELEVATED and SILENT, then return so the app can quit.
+
+    Why not just `Popen([path])`: that ran the installer's non-elevated stub, which requested
+    elevation on its own AFTER the app had quit - the UAC prompt belonged to a process with no
+    window, so on some machines it never came to the front, and a declined prompt left the user
+    with no app and no message (#296, #260). Now the elevation request is ours, made while we are
+    the foreground app, and the installer runs with the Store/winget switches, which also relaunch
+    the app when it is done (since 2.1.5). A declined prompt raises UpdateElevationDeclined so the
+    caller can say so; the app keeps running.
+    """
+    _shell_execute_runas(path, INSTALLER_SILENT_ARGS, hwnd)
 
 
 def _safe_extract(zip_path: str, dest_dir: str) -> None:
@@ -462,9 +514,20 @@ class SecureUpdater(QObject):
             self._fallback(f"signature check failed: {reason}")
             return
         try:
-            launch_installer(path)
+            hwnd = 0
+            try:
+                if self._parent is not None:
+                    hwnd = int(self._parent.winId())
+            except Exception:  # noqa: BLE001
+                hwnd = 0
+            launch_installer(path, hwnd)
+            logger.info("Verified installer started elevated and silent; it will relaunch the app when done.")
             self.launching.emit()
             self._finish()
+        except UpdateElevationDeclined:
+            logger.info("Update cancelled at the UAC prompt; staying on the current version.")
+            self._cleanup_file()
+            self._fallback("the elevation prompt was declined")
         except Exception as e:  # noqa: BLE001
             logger.error("Could not launch installer: %s", e, exc_info=True)
             self._cleanup_file()

--- a/src/netspeedtray/tests/unit/test_update_installer_dialog.py
+++ b/src/netspeedtray/tests/unit/test_update_installer_dialog.py
@@ -54,7 +54,7 @@ def test_closing_the_progress_dialog_is_not_a_user_cancel(updater, q_app):
 
 def test_a_verified_installer_is_launched_not_discarded(updater, monkeypatch, q_app):
     launched = []
-    monkeypatch.setattr(ui, "launch_installer", lambda path: launched.append(path))
+    monkeypatch.setattr(ui, "launch_installer", lambda path, hwnd=0: launched.append(path))
     quit_requested = []
     updater.launching.connect(lambda: quit_requested.append(True))
 
@@ -69,7 +69,7 @@ def test_a_verified_installer_is_launched_not_discarded(updater, monkeypatch, q_
 
 def test_a_real_cancel_click_still_cancels(updater, monkeypatch, q_app):
     launched = []
-    monkeypatch.setattr(ui, "launch_installer", lambda path: launched.append(path))
+    monkeypatch.setattr(ui, "launch_installer", lambda path, hwnd=0: launched.append(path))
     updater._progress.canceled.emit()     # what the Cancel button does (cancel() is the slot; the button emits)
     q_app.processEvents()
     assert updater._user_cancelled is True
@@ -90,3 +90,34 @@ def test_portable_staged_path_is_not_cancelled_by_the_dialog_closing(updater, mo
     q_app.processEvents()
     assert updater._user_cancelled is False
     assert handed_off, "the staged portable update must proceed to the hands-off swap"
+
+
+# ----------------------------------------------------------------------------- the elevated launch
+
+def test_launch_runs_the_installer_elevated_and_silent(monkeypatch):
+    """The installer is started through ShellExecuteEx(runas) with the Store/winget switches, so the
+    UAC prompt is the app's own and the install is hands-off, ending in the installer relaunching us."""
+    calls = []
+    monkeypatch.setattr(ui, "_shell_execute_runas", lambda path, params, hwnd=0: calls.append((path, params, hwnd)))
+    ui.launch_installer(r"C:\dl\Setup.exe", hwnd=42)
+    assert calls == [(r"C:\dl\Setup.exe", "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART", 42)]
+
+
+def test_a_declined_uac_prompt_keeps_the_app_and_says_so(updater, monkeypatch, q_app):
+    """Declining UAC used to leave the user with no app and no message. Now: no quit, the download
+    is dropped, and the existing fallback (message + release page) tells them what happened."""
+    def declined(path, params, hwnd=0):
+        raise ui.UpdateElevationDeclined("the UAC prompt was declined")
+    monkeypatch.setattr(ui, "_shell_execute_runas", declined)
+    fallbacks = []
+    monkeypatch.setattr(updater, "_fallback", lambda reason: fallbacks.append(reason))
+    quit_requested = []
+    updater.launching.connect(lambda: quit_requested.append(True))
+
+    updater._on_progress(100)
+    updater._on_verified(updater._dest, True, "ok")
+    q_app.processEvents()
+
+    assert quit_requested == [], "the app must keep running when the prompt is declined"
+    assert fallbacks and "declined" in fallbacks[0]
+    assert not os.path.exists(updater._tmpdir), "the download is dropped; nothing is left half-done"


### PR DESCRIPTION
Second half of the #296 / #260 repair, on top of #298.

`launch_installer` used `Popen([path])`: the installer's asInvoker stub then requested elevation by itself, seconds after the app had quit for it. That prompt belonged to a process with no window, so it could sit unnoticed, and a declined prompt left the user with no app and no message - the other way an update could end in *nothing*.

Now `launch_installer` calls `ShellExecuteEx(runas)` itself, while the app is the foreground process, with the Store/winget switches (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART`). Since 2.1.5 the installer relaunches the app as the original user after a silent install, so the update is hands-off: click, UAC, the app comes back updated. `ERROR_CANCELLED` raises `UpdateElevationDeclined`; `_on_verified` logs it, drops the download and uses the existing fallback (message + release page) with the app still running.

Tests: `test_update_installer_dialog.py` gains the elevated-launch contract and the declined-prompt path (no quit, download dropped, fallback shown). Full suite 1,369. Live end-to-end run through the real Download button against the real v2.1.5 release follows on the maintainer's machine before 2.1.6 is tagged.