### PR TITLE
fix(update): make the in-app update independent of the app - orphan the installer, log what it did

### DIFF
--- a/build/setup.iss
+++ b/build/setup.iss
@@ -186,11 +186,14 @@ begin
     
     if IsAppRunning() or (FindWindow('', 'NetSpeedTrayHidden') <> 0) then
     begin
-      Log('Graceful close incomplete (parent/child lingering), using taskkill on EXE/tree...');
+      // No /T: it kills the whole process TREE, and when the in-app updater starts this installer
+      // the installer is a descendant of the app - so /T made it kill itself mid-install. /IM alone
+      // already ends every process with that name, which is all this ever needed.
+      Log('Graceful close incomplete (parent/child lingering), using taskkill on the EXE...');
       KillAttempts := 0;
       while (KillAttempts < 3) and IsAppRunning() do
       begin
-        if Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM "{#MyAppExeName}" /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+        if Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM "{#MyAppExeName}"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
         begin
           Log('taskkill (attempt ' + IntToStr(KillAttempts + 1) + ') executed with exit code: ' + IntToStr(ResultCode));
           Sleep(2000); 
@@ -221,11 +224,11 @@ begin
   end
   else
   begin
-    Log('Could not find NetSpeedTray window, falling back to taskkill on EXE/tree...');
+    Log('Could not find NetSpeedTray window, falling back to taskkill on the EXE...');
     KillAttempts := 0;
     while (KillAttempts < 3) and IsAppRunning() do
     begin
-      if Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM "{#MyAppExeName}" /T', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+      if Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM "{#MyAppExeName}"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
       begin
         Log('taskkill (attempt ' + IntToStr(KillAttempts + 1) + ') executed with exit code: ' + IntToStr(ResultCode));
         Sleep(2000);

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -6,7 +6,7 @@ the old behavior - so the worst case is never worse than before):
 
     download installer_url -> %TEMP%  (HTTPS, with a progress dialog)
       -> signature_verifier.verify_file()  (WinVerifyTrust + SignPath pin, fail-closed)
-        -> launch the installer + quit the app   (Inno's AppMutex lets it replace us)
+        -> run the installer elevated + silent, and let IT close and replace us
 
 Both the download AND the (potentially network-blocking) signature verification run on
 the worker thread, so the UI never freezes. The download host doesn't have to be
@@ -33,7 +33,7 @@ import urllib.request
 import zipfile
 from typing import Callable, Optional
 
-from PyQt6.QtCore import QObject, Qt, QThread, pyqtSignal
+from PyQt6.QtCore import QObject, Qt, QThread, QTimer, pyqtSignal
 from PyQt6.QtWidgets import QMessageBox, QProgressDialog, QWidget
 
 from netspeedtray import constants
@@ -143,15 +143,18 @@ def _installer_log_path() -> str:
 
 
 def launch_installer(path: str, hwnd: int = 0) -> None:
-    """Start the (already-verified) installer ELEVATED and SILENT, then return so the app can quit.
+    """Start the (already-verified) installer ELEVATED and SILENT. The caller must then STAY ALIVE.
 
     Why not just `Popen([path])`: that ran the installer's non-elevated stub, which requested
-    elevation on its own AFTER the app had quit - the UAC prompt belonged to a process with no
-    window, so on some machines it never came to the front, and a declined prompt left the user
-    with no app and no message (#296, #260). Now the elevation request is ours, made while we are
-    the foreground app, and the installer runs with the Store/winget switches, which also relaunch
-    the app when it is done (since 2.1.5). A declined prompt raises UpdateElevationDeclined so the
-    caller can say so; the app keeps running.
+    elevation on its own after the app had quit - a prompt owned by a process with no window, and a
+    declined prompt left the user with no app and no message (#296, #260). The elevation request is
+    ours now, made while we are the foreground app, with the Store/winget switches - which also make
+    the installer relaunch the app when it is done (since 2.1.5). A declined prompt raises
+    UpdateElevationDeclined, and the app carries on.
+
+    The caller must not exit here. Windows ties the elevated process to the requester: quitting
+    straight after this call killed the installer before it wrote a line of its own log (measured
+    2026-09-06). The installer closes the app itself and then brings the new version back.
     """
     params = INSTALLER_SILENT_ARGS
     try:
@@ -408,9 +411,13 @@ class SecureUpdater(QObject):
     Orchestrates download -> verify -> launch with a progress dialog and a browser
     fallback. Parented to the widget; self-destructs (deleteLater) when it finishes.
 
-    Emits ``launching`` right before the verified installer starts, so the caller quits.
+    Emits ``launching`` when the app must quit for the update - the PORTABLE hand-off only. The
+    installer path deliberately does NOT quit; see ``_on_verified``.
     """
     launching = pyqtSignal()
+
+    # How long to wait to be closed by the installer before admitting the update did not happen.
+    _REPLACEMENT_TIMEOUT_MS = 180_000
 
     def __init__(self, parent_widget: QWidget, installer_url: str, release_url: str, i18n,
                  *, portable: bool = False, portable_url: str = "", latest_version: str = "") -> None:
@@ -535,9 +542,14 @@ class SecureUpdater(QObject):
             except Exception:  # noqa: BLE001
                 hwnd = 0
             launch_installer(path, hwnd)
-            logger.info("Verified installer started elevated and silent; it will relaunch the app when done.")
-            self.launching.emit()
-            self._finish()
+            # Do NOT quit here. Windows ties the elevated installer to the process that requested
+            # it: quitting immediately after ShellExecuteEx killed the installer outright before it
+            # wrote a single line of its own log (measured 2026-09-06 - the app vanished and nothing
+            # was installed). Staying alive costs nothing, because the installer closes us itself
+            # (CloseApplications=force plus the explicit taskkill in setup.iss) and then relaunches
+            # the new version. If we are somehow still here later, _not_replaced() says so.
+            logger.info("Verified installer started elevated and silent; waiting for it to replace this version.")
+            QTimer.singleShot(self._REPLACEMENT_TIMEOUT_MS, self._not_replaced)
         except UpdateElevationDeclined:
             logger.info("Update cancelled at the UAC prompt; staying on the current version.")
             self._cleanup_file()
@@ -546,6 +558,15 @@ class SecureUpdater(QObject):
             logger.error("Could not launch installer: %s", e, exc_info=True)
             self._cleanup_file()
             self._fallback(f"could not start the installer: {e}")
+
+    def _not_replaced(self) -> None:
+        """Still running three minutes after the installer started: it did not replace us. Say so
+        instead of leaving the user to wonder - the silence is what made this class of bug live for
+        three releases (#296, #260)."""
+        logger.warning("Still running %s after starting the installer; the update did not complete.",
+                       constants.app.VERSION)
+        self._cleanup_file()
+        self._fallback("the installer did not replace this version")
 
     def _on_staged(self, ready: str) -> None:
         """

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -133,6 +133,15 @@ def _shell_execute_runas(path: str, params: str, hwnd: int = 0) -> None:
         ctypes.windll.kernel32.CloseHandle(sei.hProcess)
 
 
+def _installer_log_path() -> str:
+    """Where the elevated installer writes ITS log: next to the app's own log, so a support bundle
+    carries what the installer did. An update that ends in nothing must never be silent again."""
+    from netspeedtray.utils.helpers import get_app_data_path
+    logs = os.path.join(str(get_app_data_path()), "logs")
+    os.makedirs(logs, exist_ok=True)
+    return os.path.join(logs, "update-install.log")
+
+
 def launch_installer(path: str, hwnd: int = 0) -> None:
     """Start the (already-verified) installer ELEVATED and SILENT, then return so the app can quit.
 
@@ -144,7 +153,12 @@ def launch_installer(path: str, hwnd: int = 0) -> None:
     the app when it is done (since 2.1.5). A declined prompt raises UpdateElevationDeclined so the
     caller can say so; the app keeps running.
     """
-    _shell_execute_runas(path, INSTALLER_SILENT_ARGS, hwnd)
+    params = INSTALLER_SILENT_ARGS
+    try:
+        params += f' /LOG="{_installer_log_path()}"'
+    except Exception as e:  # noqa: BLE001 - the log is a nice-to-have, the install is not
+        logger.debug("No installer log path: %s", e)
+    _shell_execute_runas(path, params, hwnd)
 
 
 def _safe_extract(zip_path: str, dest_dir: str) -> None:

--- a/src/netspeedtray/core/update_installer.py
+++ b/src/netspeedtray/core/update_installer.py
@@ -99,7 +99,7 @@ class UpdateElevationDeclined(RuntimeError):
     """The user said No at the UAC prompt. Not a failure of ours - and not a reason to vanish."""
 
 
-def _shell_execute_runas(path: str, params: str, hwnd: int = 0) -> None:
+def _shell_execute_runas(path: str, params: str, hwnd: int = 0, show: int = 1) -> None:
     """ShellExecuteEx(runas): start `path` elevated. Blocks until the UAC prompt is answered, then
     returns once the elevated process exists. Raises UpdateElevationDeclined on ERROR_CANCELLED,
     OSError on anything else. Isolated so tests can replace it without touching UAC."""
@@ -122,7 +122,7 @@ def _shell_execute_runas(path: str, params: str, hwnd: int = 0) -> None:
     sei.lpFile = path
     sei.lpParameters = params
     sei.lpDirectory = os.path.dirname(path) or None
-    sei.nShow = 1  # SW_SHOWNORMAL
+    sei.nShow = show
     shell32 = ctypes.WinDLL("shell32", use_last_error=True)
     if not shell32.ShellExecuteExW(ctypes.byref(sei)):
         err = ctypes.get_last_error()
@@ -152,16 +152,25 @@ def launch_installer(path: str, hwnd: int = 0) -> None:
     the installer relaunch the app when it is done (since 2.1.5). A declined prompt raises
     UpdateElevationDeclined, and the app carries on.
 
-    The caller must not exit here. Windows ties the elevated process to the requester: quitting
-    straight after this call killed the installer before it wrote a line of its own log (measured
-    2026-09-06). The installer closes the app itself and then brings the new version back.
+    The installer must NOT end up as this process's child, which is what `ShellExecuteEx` on the
+    installer itself produces. Two separate things then kill it (both measured live, 2026-09-06):
+    Windows tears down the elevated process when the requester exits, and the installer's own
+    ``taskkill /F /IM NetSpeedTray.exe /T`` walks the tree it is standing in and kills itself
+    mid-install - its log stops in the middle of the line that says so.
+
+    So we elevate a shell that `start`s the installer and exits immediately. The installer is
+    orphaned before anything can happen to it, and the update no longer depends on this process at
+    all: it survives us quitting, being killed, or crashing.
     """
     params = INSTALLER_SILENT_ARGS
     try:
         params += f' /LOG="{_installer_log_path()}"'
     except Exception as e:  # noqa: BLE001 - the log is a nice-to-have, the install is not
         logger.debug("No installer log path: %s", e)
-    _shell_execute_runas(path, params, hwnd)
+    comspec = os.environ.get("COMSPEC") or os.path.join(os.environ.get("SystemRoot", r"C:\Windows"),
+                                                        "System32", "cmd.exe")
+    # `start ""` needs the empty title first, or it eats the quoted path as one.
+    _shell_execute_runas(comspec, f'/c start "" "{path}" {params}', hwnd, show=0)
 
 
 def _safe_extract(zip_path: str, dest_dir: str) -> None:

--- a/src/netspeedtray/tests/unit/test_update_installer_dialog.py
+++ b/src/netspeedtray/tests/unit/test_update_installer_dialog.py
@@ -99,8 +99,9 @@ def test_launch_runs_the_installer_elevated_and_silent(monkeypatch):
     UAC prompt is the app's own and the install is hands-off, ending in the installer relaunching us."""
     calls = []
     monkeypatch.setattr(ui, "_shell_execute_runas", lambda path, params, hwnd=0: calls.append((path, params, hwnd)))
+    monkeypatch.setattr(ui, "_installer_log_path", lambda: "C:/logs/update-install.log")
     ui.launch_installer(r"C:\dl\Setup.exe", hwnd=42)
-    assert calls == [(r"C:\dl\Setup.exe", "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART", 42)]
+    assert calls == [(r"C:\dl\Setup.exe", '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG="C:/logs/update-install.log"', 42)]
 
 
 def test_a_declined_uac_prompt_keeps_the_app_and_says_so(updater, monkeypatch, q_app):

--- a/src/netspeedtray/tests/unit/test_update_installer_dialog.py
+++ b/src/netspeedtray/tests/unit/test_update_installer_dialog.py
@@ -117,14 +117,24 @@ def test_portable_staged_path_is_not_cancelled_by_the_dialog_closing(updater, mo
 
 # ----------------------------------------------------------------------------- the elevated launch
 
-def test_launch_runs_the_installer_elevated_and_silent(monkeypatch):
-    """The installer is started through ShellExecuteEx(runas) with the Store/winget switches, so the
-    UAC prompt is the app's own and the install is hands-off, ending in the installer relaunching us."""
+def test_launch_orphans_the_installer_so_nothing_here_can_kill_it(monkeypatch):
+    """The installer must not be our child. We elevate a shell that `start`s it and exits, so the
+    installer survives this process quitting AND its own `taskkill /IM NetSpeedTray.exe` - which,
+    while it was a descendant of ours, killed it mid-install (measured live 2026-09-06)."""
     calls = []
-    monkeypatch.setattr(ui, "_shell_execute_runas", lambda path, params, hwnd=0: calls.append((path, params, hwnd)))
+    monkeypatch.setattr(ui, "_shell_execute_runas",
+                        lambda path, params, hwnd=0, show=1: calls.append((path, params, hwnd, show)))
     monkeypatch.setattr(ui, "_installer_log_path", lambda: "C:/logs/update-install.log")
+    monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+
     ui.launch_installer(r"C:\dl\Setup.exe", hwnd=42)
-    assert calls == [(r"C:\dl\Setup.exe", '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG="C:/logs/update-install.log"', 42)]
+
+    (elevated, params, hwnd, show), = calls
+    assert elevated.lower().endswith("cmd.exe"), "the elevated process is the shell, not the installer"
+    assert params.startswith('/c start "" "C:\\dl\\Setup.exe" '), params
+    assert "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" in params, "the Store/winget switches"
+    assert '/LOG="C:/logs/update-install.log"' in params, "the installer must leave a log"
+    assert (hwnd, show) == (42, 0), "owned by our window, and no console flash"
 
 
 def test_a_declined_uac_prompt_keeps_the_app_and_says_so(updater, monkeypatch, q_app):

--- a/src/netspeedtray/tests/unit/test_update_installer_dialog.py
+++ b/src/netspeedtray/tests/unit/test_update_installer_dialog.py
@@ -55,6 +55,19 @@ def test_closing_the_progress_dialog_is_not_a_user_cancel(updater, q_app):
 def test_a_verified_installer_is_launched_not_discarded(updater, monkeypatch, q_app):
     launched = []
     monkeypatch.setattr(ui, "launch_installer", lambda path, hwnd=0: launched.append(path))
+
+    updater._on_progress(100)
+    updater._on_verified(updater._dest, True, "ok")
+    q_app.processEvents()
+
+    assert launched == [updater._dest], "the verified installer must be launched"
+    assert os.path.isfile(updater._dest), "the download must not be deleted on the success path"
+
+
+def test_the_app_does_not_quit_when_the_installer_starts(updater, monkeypatch, q_app):
+    """Windows kills the elevated installer when the process that asked for it exits. Quitting here
+    is what made the update end in nothing (measured live 2026-09-06); the installer closes us."""
+    monkeypatch.setattr(ui, "launch_installer", lambda path, hwnd=0: None)
     quit_requested = []
     updater.launching.connect(lambda: quit_requested.append(True))
 
@@ -62,9 +75,19 @@ def test_a_verified_installer_is_launched_not_discarded(updater, monkeypatch, q_
     updater._on_verified(updater._dest, True, "ok")
     q_app.processEvents()
 
-    assert launched == [updater._dest], "the verified installer must be launched"
-    assert quit_requested, "the app must be told to quit for the installer"
-    assert os.path.isfile(updater._dest), "the download must not be deleted on the success path"
+    assert quit_requested == [], "the app must stay alive so the installer survives"
+
+
+def test_still_running_much_later_is_reported_not_ignored(updater, monkeypatch, q_app):
+    """If the installer never replaces us, say so - silence is what hid this for three releases."""
+    monkeypatch.setattr(ui, "launch_installer", lambda path, hwnd=0: None)
+    fallbacks = []
+    monkeypatch.setattr(updater, "_fallback", lambda reason: fallbacks.append(reason))
+    updater._on_progress(100)
+    updater._on_verified(updater._dest, True, "ok")
+    updater._not_replaced()          # the watchdog, fired directly instead of waiting 3 minutes
+    q_app.processEvents()
+    assert fallbacks and "did not replace" in fallbacks[0]
 
 
 def test_a_real_cancel_click_still_cancels(updater, monkeypatch, q_app):


### PR DESCRIPTION
Third and last part of the #296 / #260 repair, on top of #298 and #299. With those two merged the installer finally *launched* - and still nothing was installed. Two more mechanisms, both measured on real hardware today, not reasoned about:

**The elevated installer died with its requester.** The app quit for it as designed; the installer vanished without writing a line of its own log. A caller that stays alive gets a clean install every time.

**Then the installer killed its own tree.** Keeping the app alive got further: the installer ran, opened its log, and executed `taskkill /F /IM NetSpeedTray.exe /T` from `InitializeSetup`. Because the app had requested the elevation, the installer was a **descendant of the app**, so `/T` killed it mid-install. Its log ends inside the line announcing the taskkill, with nothing after it.

**The fix.** The app elevates a shell that `start`s the installer and exits, so the installer is orphaned before anything can touch it. The update no longer depends on this process at all: it survives the app quitting, being killed, or crashing. Alongside that: the app no longer quits (the installer closes it, exactly as a Store or winget upgrade does), the installer writes `%APPDATA%\NetSpeedTray\logs\update-install.log` so a support bundle carries what it did, a 3-minute watchdog reports if the installer never replaced us, and `setup.iss` drops `/T` - which it never needed, since `/IM` already ends every process with that name.

**Live proof, through the real UI.** A client built from this branch and labeled 2.1.4, installed, left to find the **real published v2.1.5**, and driven by pressing the dialog's Download button:

```
01:33:16  Update available: v2.1.5 (current: 2.1.4)
01:33:21  Verified installer started elevated and silent; waiting for it to replace this version
01:33:21  [installer] Log opened / taskkill / All NetSpeedTray processes closed
01:33:28  [installer] Installation process succeeded -> starting NetSpeedTray as the original user
          installed version now 2.1.5, running
```

Twelve seconds, hands-off. Note the target was the **published 2.1.5 installer, which still has `/T`** - so the app-side fix alone is sufficient, and the `setup.iss` change is defense in depth for the future. 1,371 tests.